### PR TITLE
Add shell script generation for command execution

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -134,6 +134,16 @@ public abstract class AbstractCommandController<DTO extends CommandDto, OPTION e
         }
     }
 
+    @Post(uri = "shell", produces = MediaType.TEXT_PLAIN)
+    public String shell(@Body final CommandRequestDto body) {
+        try {
+            return this.workspace.saveShell(this.getCommandType(), body.getName());
+        } catch (final Throwable th) {
+            LOGGER.error("cause:", th);
+            throw new ApplicationException(th);
+        }
+    }
+
     @Post(uri = "parameterize", produces = MediaType.APPLICATION_JSON)
     public String parameterize(@Body final CommandRequestDto input) {
         String parameterizeName = this.workspace.parameterize(this.getCommandType(), input.getName());

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -106,23 +106,30 @@ public class Workspace {
     }
 
     public String saveShell(final Type commandType, final String name) throws IOException {
+        final Path launchDir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
         final Path backendDir = this.installDir().resolve("backend");
-        final String workspacePath = FileResources.baseDir().toPath().toAbsolutePath().normalize().toString();
-        final String datasetBasePath = FileResources.datasetDir().toPath().toAbsolutePath().normalize().toString();
-        final String resultBasePath = FileResources.resultDir().toPath().toAbsolutePath().normalize().toString();
         final String content = "@echo off\r\n"
-                + backendDir.resolve("dbunit-cli-sidecar.exe") + " ^\r\n"
-                + "  -Djava.home=" + backendDir + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_WORKSPACE + "=" + workspacePath + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_DATASET_BASE + "=" + datasetBasePath + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_RESULT_BASE + "=" + resultBasePath + " ^\r\n"
+                + "cd /d %~dp0\r\n"
+                + toRelative(launchDir, backendDir.resolve("dbunit-cli-sidecar.exe")) + " ^\r\n"
+                + "  -Djava.home=" + toRelative(launchDir, backendDir) + " ^\r\n"
+                + "  -D" + FileResources.PROPERTY_WORKSPACE + "=" + toRelative(launchDir, FileResources.baseDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
+                + "  -D" + FileResources.PROPERTY_DATASET_BASE + "=" + toRelative(launchDir, FileResources.datasetDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
+                + "  -D" + FileResources.PROPERTY_RESULT_BASE + "=" + toRelative(launchDir, FileResources.resultDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
                 + "  -cli ^\r\n"
                 + "  -cmd=" + commandType.name() + " ^\r\n"
                 + "  -template=option/" + commandType.name() + "/" + name + ".txt ^\r\n"
                 + "  -srcType=none\r\n";
-        final File scriptFile = new File(System.getProperty("user.dir"), commandType.name() + "_" + name + ".bat");
+        final File scriptFile = new File(launchDir.toFile(), commandType.name() + "_" + name + ".bat");
         Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
         return scriptFile.getAbsolutePath();
+    }
+
+    private static String toRelative(final Path base, final Path target) {
+        try {
+            return base.relativize(target).toString();
+        } catch (final IllegalArgumentException e) {
+            return target.toString();
+        }
     }
 
     private Path installDir() {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -120,9 +120,22 @@ public class Workspace {
                 + "  -cmd=" + commandType.name() + " ^\r\n"
                 + "  -template=option/" + commandType.name() + "/" + name + ".txt ^\r\n"
                 + "  -srcType=none\r\n";
-        final File scriptFile = new File(System.getProperty("user.dir"), commandType.name() + "_" + name + ".bat");
+        final File scriptFile = new File(this.installDir().toFile(), commandType.name() + "_" + name + ".bat");
         Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
         return scriptFile.getAbsolutePath();
+    }
+
+    private Path installDir() {
+        // sidecarはbackend/dbunit-cli-sidecar.exeとして配置されるため
+        // 自身のexeパスから2階層上(backend/の親)がインストールディレクトリ
+        return ProcessHandle.current().info().command()
+                .map(cmd -> {
+                    final Path exe = Path.of(cmd).toAbsolutePath().normalize();
+                    final Path backendDir = exe.getParent();
+                    final Path dir = backendDir != null ? backendDir.getParent() : null;
+                    return dir != null ? dir : Path.of(System.getProperty("user.dir"));
+                })
+                .orElseGet(() -> Path.of(System.getProperty("user.dir")));
     }
 
     public String parameterize(final Type type, final String name) {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -106,13 +106,13 @@ public class Workspace {
     }
 
     public String saveShell(final Type commandType, final String name) throws IOException {
+        final Path backendDir = this.installDir().resolve("backend");
         final String workspacePath = FileResources.baseDir().toPath().toAbsolutePath().normalize().toString();
         final String datasetBasePath = FileResources.datasetDir().toPath().toAbsolutePath().normalize().toString();
         final String resultBasePath = FileResources.resultDir().toPath().toAbsolutePath().normalize().toString();
         final String content = "@echo off\r\n"
-                + "cd /d %~dp0\r\n"
-                + "backend\\dbunit-cli-sidecar.exe ^\r\n"
-                + "  -Djava.home=backend ^\r\n"
+                + backendDir.resolve("dbunit-cli-sidecar.exe") + " ^\r\n"
+                + "  -Djava.home=" + backendDir + " ^\r\n"
                 + "  -D" + FileResources.PROPERTY_WORKSPACE + "=" + workspacePath + " ^\r\n"
                 + "  -D" + FileResources.PROPERTY_DATASET_BASE + "=" + datasetBasePath + " ^\r\n"
                 + "  -D" + FileResources.PROPERTY_RESULT_BASE + "=" + resultBasePath + " ^\r\n"
@@ -120,7 +120,7 @@ public class Workspace {
                 + "  -cmd=" + commandType.name() + " ^\r\n"
                 + "  -template=option/" + commandType.name() + "/" + name + ".txt ^\r\n"
                 + "  -srcType=none\r\n";
-        final File scriptFile = new File(this.installDir().toFile(), commandType.name() + "_" + name + ".bat");
+        final File scriptFile = new File(System.getProperty("user.dir"), commandType.name() + "_" + name + ".bat");
         Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
         return scriptFile.getAbsolutePath();
     }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -15,6 +15,8 @@ import yo.dbunitcli.sidecar.dto.WorkspaceDto;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -101,6 +103,26 @@ public class Workspace {
 
     public Stream<Path> parameterFiles(final Type type) {
         return this.options().paths(type);
+    }
+
+    public String saveShell(final Type commandType, final String name) throws IOException {
+        final String workspacePath = FileResources.baseDir().toPath().toAbsolutePath().normalize().toString();
+        final String datasetBasePath = FileResources.datasetDir().toPath().toAbsolutePath().normalize().toString();
+        final String resultBasePath = FileResources.resultDir().toPath().toAbsolutePath().normalize().toString();
+        final String content = "@echo off\r\n"
+                + "cd /d %~dp0\r\n"
+                + "backend\\dbunit-cli-sidecar.exe ^\r\n"
+                + "  -Djava.home=backend ^\r\n"
+                + "  -D" + FileResources.PROPERTY_WORKSPACE + "=" + workspacePath + " ^\r\n"
+                + "  -D" + FileResources.PROPERTY_DATASET_BASE + "=" + datasetBasePath + " ^\r\n"
+                + "  -D" + FileResources.PROPERTY_RESULT_BASE + "=" + resultBasePath + " ^\r\n"
+                + "  -cli ^\r\n"
+                + "  -cmd=" + commandType.name() + " ^\r\n"
+                + "  -template=option/" + commandType.name() + "/" + name + ".txt ^\r\n"
+                + "  -srcType=none\r\n";
+        final File scriptFile = new File(System.getProperty("user.dir"), commandType.name() + "_" + name + ".bat");
+        Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
+        return scriptFile.getAbsolutePath();
     }
 
     public String parameterize(final Type type, final String name) {


### PR DESCRIPTION
## Summary
This PR adds functionality to generate Windows batch shell scripts that wrap command execution with proper environment configuration. This allows users to execute dbunit-cli commands through generated shell scripts with all necessary Java properties and paths pre-configured.

## Key Changes
- **New `saveShell()` method in Workspace**: Generates a Windows batch file (.bat) that executes the dbunit-cli-sidecar with appropriate Java system properties and command-line arguments. The script:
  - Sets up relative paths from the launch directory to the backend executable
  - Configures workspace, dataset, and result base directories
  - Passes the command type and template name as parameters
  
- **New `installDir()` method in Workspace**: Determines the installation directory by traversing up from the current process's executable path (sidecar is located at `backend/dbunit-cli-sidecar.exe`, so the parent of the parent directory is the install root)

- **New `toRelative()` helper method**: Converts absolute paths to relative paths when possible, falling back to absolute paths if the paths are on different drives or cannot be relativized

- **New `/shell` POST endpoint in AbstractCommandController**: Exposes the shell script generation functionality via HTTP, accepting a `CommandRequestDto` and returning the absolute path to the generated script file

- **Added imports**: `StandardCharsets` and `Files` for file I/O operations

## Notable Implementation Details
- The generated batch script uses Windows-specific syntax (`@echo off`, `cd /d`, `^` for line continuation)
- Relative path calculation is defensive, falling back to absolute paths if relativization fails (e.g., different drives on Windows)
- The script file is created in the current working directory with a naming convention: `{commandType}_{name}.bat`
- File content is written with UTF-8 encoding

https://claude.ai/code/session_01NWeHqQM7NxmjL1dRS4px8P