### PR TITLE
sidecar/tauri: JDBC接続テストボタンと /jdbc/test エンドポイントを追加

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/JdbcResourceFileController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/JdbcResourceFileController.java
@@ -1,9 +1,14 @@
 package yo.dbunitcli.sidecar.controller;
 
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
 import jakarta.inject.Inject;
+import yo.dbunitcli.application.option.JdbcOption;
 import yo.dbunitcli.sidecar.domain.project.ResourceFile;
 import yo.dbunitcli.sidecar.domain.project.Workspace;
+import yo.dbunitcli.sidecar.dto.JdbcTestRequestDto;
 import yo.dbunitcli.sidecar.dto.ResourceSaveRequest;
 
 @Controller("jdbc")
@@ -17,5 +22,31 @@ public class JdbcResourceFileController extends AbstractResourceFileController<R
     @Override
     protected ResourceFile getResourceFile() {
         return this.workspace.resources().jdbc();
+    }
+
+    @Post(uri = "test", produces = MediaType.APPLICATION_JSON)
+    public String test(@Body final JdbcTestRequestDto body) {
+        try {
+            final JdbcOption option = new JdbcOption("jdbc",
+                    body.getProperties(),
+                    body.getUrl(),
+                    body.getUser(),
+                    body.getPass());
+            option.getDatabaseConnectionLoader().loadConnection().getConnection().close();
+            return "{\"success\":true,\"message\":\"接続成功\"}";
+        } catch (final Throwable e) {
+            final Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return "{\"success\":false,\"message\":" + toJsonString(cause.getMessage()) + "}";
+        }
+    }
+
+    private static String toJsonString(final String s) {
+        if (s == null) {
+            return "\"\"";
+        }
+        return "\"" + s.replace("\\", "\\\\")
+                       .replace("\"", "\\\"")
+                       .replace("\n", "\\n")
+                       .replace("\r", "\\r") + "\"";
     }
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/JdbcTestRequestDto.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/JdbcTestRequestDto.java
@@ -1,0 +1,43 @@
+package yo.dbunitcli.sidecar.dto;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class JdbcTestRequestDto {
+    private String url;
+    private String user;
+    private String pass;
+    private String properties;
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(final String user) {
+        this.user = user;
+    }
+
+    public String getPass() {
+        return this.pass;
+    }
+
+    public void setPass(final String pass) {
+        this.pass = pass;
+    }
+
+    public String getProperties() {
+        return this.properties;
+    }
+
+    public void setProperties(final String properties) {
+        this.properties = properties;
+    }
+}

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -4,6 +4,7 @@ import {
 	type Dispatch,
 	Fragment,
 	type SetStateAction,
+	useCallback,
 	useEffect,
 	useRef,
 	useState,
@@ -21,6 +22,7 @@ import {
 	InputLabel,
 	SelectBox,
 } from "../../components/element/Input";
+import { useEnviroment } from "../../context/EnviromentProvider";
 import {
 	useResourcesSettings,
 	useWorkspaceContext,
@@ -35,6 +37,7 @@ import {
 	type QueryDatasourceType,
 } from "../../model/QueryDatasource";
 import type { WorkspaceContext } from "../../model/WorkspaceResources";
+import { fetchData, handleFetchError } from "../../utils/fetchUtils";
 import DatasetSettingEditButton, {
 	RemoveDatasetSettingButton,
 } from "../settings/DatasetSettingEditButton";
@@ -46,11 +49,14 @@ import XlsxSchemaEditButton, {
 	RemoveXlsxSchemaButton,
 } from "../settings/XlsxSchemaEditButton";
 
+const JDBC_FIELD_NAMES = ["jdbcUrl", "jdbcUser", "jdbcPass", "jdbcProperties"] as const;
+
 type Prop = {
 	prefix: string;
 	element: CommandParam;
 	hidden?: boolean;
 	srcType?: string;
+	onValueChange?: (name: string, value: string) => void;
 };
 type FileProp = Prop & {
 	path: string;
@@ -73,9 +79,32 @@ export default function CommandFormElements(
 	const srcType = srcTypeElement ? srcTypeElement.value : "";
 	const toggleOptional = () => setShowOptional(!showOptional);
 
+	const isJdbcSection = prop.elements.some((e) =>
+		JDBC_FIELD_NAMES.includes(e.name as (typeof JDBC_FIELD_NAMES)[number]),
+	);
+	const [jdbcValues, setJdbcValues] = useState<Record<string, string>>(() => {
+		const initial: Record<string, string> = {};
+		for (const el of prop.elements) {
+			if (
+				JDBC_FIELD_NAMES.includes(
+					el.name as (typeof JDBC_FIELD_NAMES)[number],
+				)
+			) {
+				initial[el.name] = el.value;
+			}
+		}
+		return initial;
+	});
+	const handleJdbcValueChange = useCallback((name: string, value: string) => {
+		setJdbcValues((prev) => ({ ...prev, [name]: value }));
+	}, []);
+
 	return (
 		<>
 			{prop.elements.map((element) => {
+				const isJdbcField = JDBC_FIELD_NAMES.includes(
+					element.name as (typeof JDBC_FIELD_NAMES)[number],
+				);
 				if (element.attribute.type === "FLG") {
 					return (
 						<Fragment key={prop.name + prop.prefix + element.name}>
@@ -133,10 +162,17 @@ export default function CommandFormElements(
 							element={element}
 							hidden={prop.optional?.(element.name) && !showOptional}
 							srcType={element.name === "src" ? srcType : undefined}
+							onValueChange={isJdbcField ? handleJdbcValueChange : undefined}
 						/>
 					</Fragment>
 				);
 			})}
+			{isJdbcSection && (
+				<JdbcConnectionTestButton
+					prefix={prop.prefix}
+					jdbcValues={jdbcValues}
+				/>
+			)}
 		</>
 	);
 }
@@ -144,6 +180,9 @@ function Text(prop: Prop) {
 	const [path, setPath] = useState(prop.element.value);
 	const [showJdbcUrlBuilder, setShowJdbcUrlBuilder] = useState(false);
 	const { element, srcType } = prop;
+	useEffect(() => {
+		prop.onValueChange?.(element.name, path);
+	}, [path]);
 	function resources(): string[] {
 		const settings = useResourcesSettings();
 		let resources: string[] = [];
@@ -240,6 +279,81 @@ function Text(prop: Prop) {
 					)}
 				</div>
 			</div>
+		</div>
+	);
+}
+
+function JdbcConnectionTestButton({
+	prefix,
+	jdbcValues,
+}: {
+	prefix: string;
+	jdbcValues: Record<string, string>;
+}) {
+	const { apiUrl } = useEnviroment();
+	const [result, setResult] = useState<{
+		success: boolean;
+		message: string;
+	} | null>(null);
+	const [testing, setTesting] = useState(false);
+
+	const hasUrlUserPass =
+		!!jdbcValues.jdbcUrl &&
+		!!jdbcValues.jdbcUser &&
+		!!jdbcValues.jdbcPass;
+	const hasProperties = !!jdbcValues.jdbcProperties;
+	const isEnabled = !testing && (hasUrlUserPass || hasProperties);
+
+	const handleTest = async () => {
+		setTesting(true);
+		setResult(null);
+		const params = {
+			endpoint: `${apiUrl}jdbc/test`,
+			options: {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					url: jdbcValues.jdbcUrl ?? "",
+					user: jdbcValues.jdbcUser ?? "",
+					pass: jdbcValues.jdbcPass ?? "",
+					properties: jdbcValues.jdbcProperties ?? "",
+				}),
+			},
+		};
+		try {
+			const response = await fetchData(params);
+			const json = await response.json() as { success: boolean; message: string };
+			setResult(json);
+		} catch (e) {
+			handleFetchError((e as Error).message, params);
+		} finally {
+			setTesting(false);
+		}
+	};
+
+	return (
+		<div className="mt-2 flex items-center gap-3">
+			<button
+				type="button"
+				disabled={!isEnabled}
+				onClick={handleTest}
+				className={`px-3 py-2 text-sm font-semibold rounded-lg border transition duration-100 ring-indigo-300 focus-visible:ring-3
+					${isEnabled
+						? "bg-indigo-500 hover:bg-indigo-600 text-white border-gray-300"
+						: "bg-gray-200 text-gray-400 border-gray-200 cursor-not-allowed"
+					}`}
+				id={`${prefix}_jdbcConnectionTest`}
+			>
+				{testing ? "接続中..." : "接続テスト"}
+			</button>
+			{result && (
+				<span
+					className={`text-sm font-medium ${result.success ? "text-green-600" : "text-red-600"}`}
+				>
+					{result.success ? "✓ " : "✗ "}
+					{result.message}
+				</span>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
- sidecar: POST /jdbc/test エンドポイントを JdbcResourceFileController に追加
  - url・user・pass または properties ファイル名を受け取り接続テストを実行
  - 成功/失敗を JSON レスポンスで返す
- tauri: JDBC フィールドセクションに接続テストボタンを追加
  - jdbcUrl・jdbcUser・jdbcPass がすべて入力済み、または jdbcProperties が入力済みの場合に有効化
  - テスト結果をボタン右横にインライン表示

https://claude.ai/code/session_012rG7NvjrBAwK9BYuwjSnMw