### PR TITLE
Refactor shell script generation to use StringTemplate

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -13,6 +13,10 @@ import yo.dbunitcli.sidecar.dto.ContextDto;
 import yo.dbunitcli.sidecar.dto.ParametersDto;
 import yo.dbunitcli.sidecar.dto.WorkspaceDto;
 
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
+import org.stringtemplate.v4.STGroupFile;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -108,17 +112,19 @@ public class Workspace {
     public String saveShell(final Type commandType, final String name) throws IOException {
         final Path launchDir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
         final Path backendDir = this.installDir().resolve("backend");
-        final String content = "@echo off\r\n"
-                + "cd /d %~dp0\r\n"
-                + toRelative(launchDir, backendDir.resolve("dbunit-cli-sidecar.exe")) + " ^\r\n"
-                + "  -Djava.home=" + toRelative(launchDir, backendDir) + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_WORKSPACE + "=" + toRelative(launchDir, FileResources.baseDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_DATASET_BASE + "=" + toRelative(launchDir, FileResources.datasetDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
-                + "  -D" + FileResources.PROPERTY_RESULT_BASE + "=" + toRelative(launchDir, FileResources.resultDir().toPath().toAbsolutePath().normalize()) + " ^\r\n"
-                + "  -cli ^\r\n"
-                + "  -cmd=" + commandType.name() + " ^\r\n"
-                + "  -template=option/" + commandType.name() + "/" + name + ".txt ^\r\n"
-                + "  -srcType=none\r\n";
+        final STGroup group = new STGroupFile("shell/saveShell.stg", '$', '$');
+        final ST template = group.getInstanceOf("saveShell");
+        template.add("sidecarExe", toRelative(launchDir, backendDir.resolve("dbunit-cli-sidecar.exe")));
+        template.add("backendDir", toRelative(launchDir, backendDir));
+        template.add("workspaceProperty", FileResources.PROPERTY_WORKSPACE);
+        template.add("workspace", toRelative(launchDir, FileResources.baseDir().toPath().toAbsolutePath().normalize()));
+        template.add("datasetBaseProperty", FileResources.PROPERTY_DATASET_BASE);
+        template.add("datasetBase", toRelative(launchDir, FileResources.datasetDir().toPath().toAbsolutePath().normalize()));
+        template.add("resultBaseProperty", FileResources.PROPERTY_RESULT_BASE);
+        template.add("resultBase", toRelative(launchDir, FileResources.resultDir().toPath().toAbsolutePath().normalize()));
+        template.add("commandType", commandType.name());
+        template.add("name", name);
+        final String content = template.render().replace("\r\n", "\n").replace("\n", "\r\n");
         final File scriptFile = new File(launchDir.toFile(), commandType.name() + "_" + name + ".bat");
         Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
         return scriptFile.getAbsolutePath();

--- a/sidecar/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli-sidecar/resource-config.json
+++ b/sidecar/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli-sidecar/resource-config.json
@@ -80,6 +80,9 @@
         "pattern": "\\Qapplication.properties\\E"
       },
       {
+        "pattern": "\\Qshell/saveShell.stg\\E"
+      },
+      {
         "pattern": "\\Qlogback.scmo\\E"
       },
       {

--- a/sidecar/src/main/resources/shell/saveShell.stg
+++ b/sidecar/src/main/resources/shell/saveShell.stg
@@ -1,0 +1,13 @@
+saveShell(sidecarExe, backendDir, workspaceProperty, workspace, datasetBaseProperty, datasetBase, resultBaseProperty, resultBase, commandType, name) ::= <<
+@echo off
+cd /d %~dp0
+$sidecarExe$ ^
+  -Djava.home=$backendDir$ ^
+  -D$workspaceProperty$=$workspace$ ^
+  -D$datasetBaseProperty$=$datasetBase$ ^
+  -D$resultBaseProperty$=$resultBase$ ^
+  -cli ^
+  -cmd=$commandType$ ^
+  -template=option/$commandType$/$name$.txt ^
+  -srcType=none
+>>


### PR DESCRIPTION
## Summary
Refactored the shell script generation logic in the `Workspace` class to use StringTemplate (ST4) templating instead of string concatenation. This improves maintainability and separates the template structure from the Java code.

## Key Changes
- Replaced hardcoded string concatenation in `saveShell()` method with StringTemplate-based rendering
- Created new `shell/saveShell.stg` template file containing the batch script structure
- Added StringTemplate v4 imports to `Workspace.java`
- Updated native-image resource configuration to include the new `.stg` template file for GraalVM compilation

## Implementation Details
- The template uses `$...$` delimiters for variable substitution
- All path and property values are passed as template variables rather than being concatenated in Java
- Template rendering output is normalized to use Windows line endings (`\r\n`)
- The template file is registered in `resource-config.json` to ensure it's included in native image builds

https://claude.ai/code/session_01Pt48yDToN8PTxCJKBPeo3n