### PR TITLE
Extract JDBC URL builder logic into reusable model module

### DIFF
--- a/tauri/src/app/settings/JdbcUrlBuilderDialog.tsx
+++ b/tauri/src/app/settings/JdbcUrlBuilderDialog.tsx
@@ -6,84 +6,13 @@ import {
 	PreviewField,
 	SelectBox,
 } from "../../components/element/Input";
-
-type RdbType = "oracle" | "postgres" | "h2";
-
-type JdbcUrlBuilderState = {
-	rdbType: RdbType;
-	host: string;
-	port: string;
-	serviceName: string;
-};
-
-const DEFAULT_PORTS: Record<RdbType, string> = {
-	oracle: "1521",
-	postgres: "5432",
-	h2: "9092",
-};
-
-const SERVICE_NAME_LABEL: Record<RdbType, string> = {
-	oracle: "Service Name",
-	postgres: "Database Name",
-	h2: "Database Name",
-};
-
-function buildJdbcUrl(state: JdbcUrlBuilderState): string {
-	const { rdbType, host, port, serviceName } = state;
-	if (!host && !serviceName) return "";
-	switch (rdbType) {
-		case "oracle":
-			return `jdbc:oracle:thin:@${host}:${port}:${serviceName}`;
-		case "postgres":
-			return `jdbc:postgresql://${host}:${port}/${serviceName}`;
-		case "h2":
-			return `jdbc:h2:tcp://${host}:${port}/${serviceName}`;
-	}
-}
-
-function parseJdbcUrl(url: string): Partial<JdbcUrlBuilderState> {
-	if (!url) return {};
-	if (url.startsWith("jdbc:oracle:thin:@")) {
-		const rest = url.slice("jdbc:oracle:thin:@".length);
-		const parts = rest.split(":");
-		if (parts.length >= 3) {
-			return {
-				rdbType: "oracle",
-				host: parts[0],
-				port: parts[1],
-				serviceName: parts.slice(2).join(":"),
-			};
-		}
-	}
-	if (url.startsWith("jdbc:postgresql://")) {
-		const rest = url.slice("jdbc:postgresql://".length);
-		const slashIdx = rest.indexOf("/");
-		const hostPort = slashIdx >= 0 ? rest.slice(0, slashIdx) : rest;
-		const db = slashIdx >= 0 ? rest.slice(slashIdx + 1) : "";
-		const colonIdx = hostPort.lastIndexOf(":");
-		return {
-			rdbType: "postgres",
-			host: colonIdx >= 0 ? hostPort.slice(0, colonIdx) : hostPort,
-			port:
-				colonIdx >= 0 ? hostPort.slice(colonIdx + 1) : DEFAULT_PORTS.postgres,
-			serviceName: db,
-		};
-	}
-	if (url.startsWith("jdbc:h2:tcp://")) {
-		const rest = url.slice("jdbc:h2:tcp://".length);
-		const slashIdx = rest.indexOf("/");
-		const hostPort = slashIdx >= 0 ? rest.slice(0, slashIdx) : rest;
-		const db = slashIdx >= 0 ? rest.slice(slashIdx + 1) : "";
-		const colonIdx = hostPort.lastIndexOf(":");
-		return {
-			rdbType: "h2",
-			host: colonIdx >= 0 ? hostPort.slice(0, colonIdx) : hostPort,
-			port: colonIdx >= 0 ? hostPort.slice(colonIdx + 1) : DEFAULT_PORTS.h2,
-			serviceName: db,
-		};
-	}
-	return {};
-}
+import {
+	DEFAULT_PORTS,
+	SERVICE_NAME_LABEL,
+	buildJdbcUrl,
+	parseJdbcUrl,
+} from "../../model/JdbcUrlBuilder";
+import type { JdbcUrlBuilderState, RdbType } from "../../model/JdbcUrlBuilder";
 
 type JdbcUrlBuilderDialogProps = {
 	currentUrl: string;

--- a/tauri/src/model/JdbcUrlBuilder.ts
+++ b/tauri/src/model/JdbcUrlBuilder.ts
@@ -1,0 +1,77 @@
+export type RdbType = "oracle" | "postgres" | "h2";
+
+export type JdbcUrlBuilderState = {
+	rdbType: RdbType;
+	host: string;
+	port: string;
+	serviceName: string;
+};
+
+export const DEFAULT_PORTS: Record<RdbType, string> = {
+	oracle: "1521",
+	postgres: "5432",
+	h2: "9092",
+};
+
+export const SERVICE_NAME_LABEL: Record<RdbType, string> = {
+	oracle: "Service Name",
+	postgres: "Database Name",
+	h2: "Database Name",
+};
+
+export function buildJdbcUrl(state: JdbcUrlBuilderState): string {
+	const { rdbType, host, port, serviceName } = state;
+	if (!host && !serviceName) return "";
+	switch (rdbType) {
+		case "oracle":
+			return `jdbc:oracle:thin:@${host}:${port}:${serviceName}`;
+		case "postgres":
+			return `jdbc:postgresql://${host}:${port}/${serviceName}`;
+		case "h2":
+			return `jdbc:h2:tcp://${host}:${port}/${serviceName}`;
+	}
+}
+
+export function parseJdbcUrl(url: string): Partial<JdbcUrlBuilderState> {
+	if (!url) return {};
+	if (url.startsWith("jdbc:oracle:thin:@")) {
+		const rest = url.slice("jdbc:oracle:thin:@".length);
+		const parts = rest.split(":");
+		if (parts.length >= 3) {
+			return {
+				rdbType: "oracle",
+				host: parts[0],
+				port: parts[1],
+				serviceName: parts.slice(2).join(":"),
+			};
+		}
+	}
+	if (url.startsWith("jdbc:postgresql://")) {
+		const rest = url.slice("jdbc:postgresql://".length);
+		const slashIdx = rest.indexOf("/");
+		const hostPort = slashIdx >= 0 ? rest.slice(0, slashIdx) : rest;
+		const db = slashIdx >= 0 ? rest.slice(slashIdx + 1) : "";
+		const colonIdx = hostPort.lastIndexOf(":");
+		return {
+			rdbType: "postgres",
+			host: colonIdx >= 0 ? hostPort.slice(0, colonIdx) : hostPort,
+			port:
+				colonIdx >= 0 ? hostPort.slice(colonIdx + 1) : DEFAULT_PORTS.postgres,
+			serviceName: db,
+		};
+	}
+	if (url.startsWith("jdbc:h2:tcp://")) {
+		const rest = url.slice("jdbc:h2:tcp://".length);
+		const slashIdx = rest.indexOf("/");
+		const hostPort = slashIdx >= 0 ? rest.slice(0, slashIdx) : rest;
+		const db = slashIdx >= 0 ? rest.slice(slashIdx + 1) : "";
+		const colonIdx = hostPort.lastIndexOf(":");
+		return {
+			rdbType: "h2",
+			host: colonIdx >= 0 ? hostPort.slice(0, colonIdx) : hostPort,
+			port: colonIdx >= 0 ? hostPort.slice(colonIdx + 1) : DEFAULT_PORTS.h2,
+			serviceName: db,
+		};
+	}
+	return {};
+}

--- a/tauri/src/tests/model/JdbcUrlBuilder.test.ts
+++ b/tauri/src/tests/model/JdbcUrlBuilder.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_PORTS,
+	SERVICE_NAME_LABEL,
+	buildJdbcUrl,
+	parseJdbcUrl,
+} from "../../model/JdbcUrlBuilder";
+import type { JdbcUrlBuilderState } from "../../model/JdbcUrlBuilder";
+
+describe("DEFAULT_PORTS", () => {
+	it("各DBのデフォルトポートが正しいこと", () => {
+		expect(DEFAULT_PORTS.oracle).toBe("1521");
+		expect(DEFAULT_PORTS.postgres).toBe("5432");
+		expect(DEFAULT_PORTS.h2).toBe("9092");
+	});
+});
+
+describe("SERVICE_NAME_LABEL", () => {
+	it("Oracleのラベルがサービス名であること", () => {
+		expect(SERVICE_NAME_LABEL.oracle).toBe("Service Name");
+	});
+	it("PostgreSQLとH2のラベルがデータベース名であること", () => {
+		expect(SERVICE_NAME_LABEL.postgres).toBe("Database Name");
+		expect(SERVICE_NAME_LABEL.h2).toBe("Database Name");
+	});
+});
+
+describe("buildJdbcUrl", () => {
+	it("hostもserviceNameも空の場合は空文字を返すこと", () => {
+		const state: JdbcUrlBuilderState = {
+			rdbType: "postgres",
+			host: "",
+			port: "5432",
+			serviceName: "",
+		};
+		expect(buildJdbcUrl(state)).toBe("");
+	});
+
+	it("Oracle の JDBC URL を生成できること", () => {
+		const state: JdbcUrlBuilderState = {
+			rdbType: "oracle",
+			host: "localhost",
+			port: "1521",
+			serviceName: "ORCL",
+		};
+		expect(buildJdbcUrl(state)).toBe("jdbc:oracle:thin:@localhost:1521:ORCL");
+	});
+
+	it("PostgreSQL の JDBC URL を生成できること", () => {
+		const state: JdbcUrlBuilderState = {
+			rdbType: "postgres",
+			host: "localhost",
+			port: "5432",
+			serviceName: "mydb",
+		};
+		expect(buildJdbcUrl(state)).toBe("jdbc:postgresql://localhost:5432/mydb");
+	});
+
+	it("H2 の JDBC URL を生成できること", () => {
+		const state: JdbcUrlBuilderState = {
+			rdbType: "h2",
+			host: "localhost",
+			port: "9092",
+			serviceName: "testdb",
+		};
+		expect(buildJdbcUrl(state)).toBe("jdbc:h2:tcp://localhost:9092/testdb");
+	});
+});
+
+describe("parseJdbcUrl", () => {
+	it("空文字の場合は空オブジェクトを返すこと", () => {
+		expect(parseJdbcUrl("")).toEqual({});
+	});
+
+	it("不明なURLの場合は空オブジェクトを返すこと", () => {
+		expect(parseJdbcUrl("jdbc:mysql://localhost/db")).toEqual({});
+	});
+
+	it("Oracle の JDBC URL をパースできること", () => {
+		const result = parseJdbcUrl("jdbc:oracle:thin:@localhost:1521:ORCL");
+		expect(result.rdbType).toBe("oracle");
+		expect(result.host).toBe("localhost");
+		expect(result.port).toBe("1521");
+		expect(result.serviceName).toBe("ORCL");
+	});
+
+	it("PostgreSQL の JDBC URL をパースできること", () => {
+		const result = parseJdbcUrl("jdbc:postgresql://localhost:5432/mydb");
+		expect(result.rdbType).toBe("postgres");
+		expect(result.host).toBe("localhost");
+		expect(result.port).toBe("5432");
+		expect(result.serviceName).toBe("mydb");
+	});
+
+	it("H2 の JDBC URL をパースできること", () => {
+		const result = parseJdbcUrl("jdbc:h2:tcp://localhost:9092/testdb");
+		expect(result.rdbType).toBe("h2");
+		expect(result.host).toBe("localhost");
+		expect(result.port).toBe("9092");
+		expect(result.serviceName).toBe("testdb");
+	});
+
+	it("buildJdbcUrl でビルドした URL を parseJdbcUrl で元に戻せること", () => {
+		const state: JdbcUrlBuilderState = {
+			rdbType: "postgres",
+			host: "db.example.com",
+			port: "5432",
+			serviceName: "production",
+		};
+		const url = buildJdbcUrl(state);
+		const parsed = parseJdbcUrl(url);
+		expect(parsed.rdbType).toBe(state.rdbType);
+		expect(parsed.host).toBe(state.host);
+		expect(parsed.port).toBe(state.port);
+		expect(parsed.serviceName).toBe(state.serviceName);
+	});
+});


### PR DESCRIPTION
## Summary
Refactored JDBC URL builder functionality by extracting it from the dialog component into a dedicated model module, improving code organization and testability.

## Key Changes
- Created new `src/model/JdbcUrlBuilder.ts` module containing:
  - `RdbType` type definition for supported databases (Oracle, PostgreSQL, H2)
  - `JdbcUrlBuilderState` type for builder state management
  - `DEFAULT_PORTS` constant mapping database types to their default ports
  - `SERVICE_NAME_LABEL` constant for UI label text per database type
  - `buildJdbcUrl()` function to generate JDBC URLs from state
  - `parseJdbcUrl()` function to parse JDBC URLs back into state objects

- Updated `JdbcUrlBuilderDialog.tsx` to import and use the extracted functions and types instead of defining them locally

- Added comprehensive test suite `src/tests/model/JdbcUrlBuilder.test.ts` with 13 test cases covering:
  - Default port values for each database type
  - Service name label correctness
  - JDBC URL generation for Oracle, PostgreSQL, and H2
  - JDBC URL parsing for all supported databases
  - Round-trip conversion (build → parse → verify)
  - Edge cases (empty inputs, unknown URL formats)

## Implementation Details
- All logic remains functionally identical; this is a pure refactoring
- Types are properly exported for use in consuming components
- The extracted module is database-agnostic and can be reused across the application
- Test coverage ensures the parsing and building functions work correctly for all supported database types

https://claude.ai/code/session_01YAizQ7BCbKkKdLYaNa7yZs