### PR TITLE
Add ability to delete JDBC properties

### DIFF
--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -14,12 +14,14 @@ import {
 } from "../../components/element/Input";
 import { useResourcesSettings } from "../../context/WorkspaceResourcesProvider";
 import {
+	useDeleteJdbcProperties,
 	useJdbcConnectionTest,
 	useJdbcSaveProperties,
 } from "../../hooks/useJdbc";
 import type { CommandParam } from "../../model/CommandParam";
 import JdbcSavePropertiesDialog from "../settings/JdbcSavePropertiesDialog";
 import JdbcUrlBuilderDialog from "../settings/JdbcUrlBuilderDialog";
+import { RemoveResource } from "../settings/ResourceEditButton";
 import { FileChooser } from "./Chooser";
 
 export const JDBC_FIELD_NAMES = [
@@ -117,6 +119,9 @@ function JdbcTextField({
 							path={path}
 							setPath={setPath}
 						/>
+					)}
+					{isJdbcProperties && path && (
+						<RemoveJdbcPropertiesButton path={path} setPath={setPath} />
 					)}
 					{isJdbcUrl && (
 						<JdbcUrlBuilderButton
@@ -248,5 +253,22 @@ function JdbcSavePropertiesButton({
 				/>
 			)}
 		</>
+	);
+}
+
+function RemoveJdbcPropertiesButton({
+	path,
+	setPath,
+}: {
+	path: string;
+	setPath: (value: string) => void;
+}) {
+	const deleteJdbcProperties = useDeleteJdbcProperties();
+	return (
+		<RemoveResource
+			path={path}
+			setPath={setPath}
+			deleteResource={deleteJdbcProperties}
+		/>
 	);
 }

--- a/tauri/src/hooks/useJdbc.ts
+++ b/tauri/src/hooks/useJdbc.ts
@@ -6,6 +6,39 @@ import { fetchData, handleFetchError } from "../utils/fetchUtils";
 
 type OperationResult = "success" | "failed";
 
+export const useDeleteJdbcProperties = () => {
+	const { apiUrl } = useEnviroment();
+	const setResourcesSettings = useSetResourcesSettings();
+	return async (name: string): Promise<OperationResult> => {
+		return deleteJdbcProperties(apiUrl, name, setResourcesSettings);
+	};
+};
+
+async function deleteJdbcProperties(
+	apiUrl: string,
+	name: string,
+	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
+): Promise<OperationResult> {
+	const fetchParams = {
+		endpoint: `${apiUrl}jdbc/delete`,
+		options: {
+			method: "POST",
+			headers: { "Content-Type": "text/plain" },
+			body: name,
+		},
+	};
+	return await fetchData(fetchParams)
+		.then((response) => response.json())
+		.then((files: string[]) => {
+			setResourcesSettings((current) => current.with({ jdbcFiles: files }));
+			return "success" as OperationResult;
+		})
+		.catch((ex) => {
+			handleFetchError((ex as Error).message, fetchParams);
+			return "failed" as OperationResult;
+		});
+}
+
 function toJdbcRequestBody(jdbcValues: Record<string, string>) {
 	return {
 		url: jdbcValues.jdbcUrl ?? "",


### PR DESCRIPTION
## Summary
This PR adds functionality to delete JDBC properties from the resources settings. It introduces a new hook and UI component that allow users to remove saved JDBC configurations.

## Key Changes
- **New hook `useDeleteJdbcProperties`**: Created a custom hook that wraps the `deleteJdbcProperties` function, providing a clean interface for components to delete JDBC properties via the API
- **Delete API integration**: Implemented `deleteJdbcProperties` function that:
  - Sends a POST request to the `jdbc/delete` endpoint with the JDBC property name
  - Updates the resources settings with the returned list of remaining JDBC files
  - Handles errors gracefully and returns operation status
- **UI component `RemoveJdbcPropertiesButton`**: Added a new button component in the JDBC form section that:
  - Appears when a JDBC property is selected
  - Uses the `RemoveResource` component for consistent UI/UX with other resource deletion
  - Triggers the delete operation and updates the form state

## Implementation Details
- The delete operation sends the JDBC property name as plain text in the request body
- Upon successful deletion, the component updates the resources settings with the new list of JDBC files
- The button is conditionally rendered only when both `isJdbcProperties` and `path` are truthy, ensuring it only appears in the appropriate context

https://claude.ai/code/session_01Jf6p9MoXmRH6Arg3BFqYrp