### PR TITLE
Sync parameterize list when creating parameters from source

### DIFF
--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -1,5 +1,6 @@
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSelectParameter, useSetSelectParameterState } from "../context/SelectParameterProvider";
+import { useSetParameterList } from "../context/WorkspaceResourcesProvider";
 import {
 	type Parameter,
 	type ParameterizeParams,
@@ -121,6 +122,7 @@ export const useExecParameter = () => {
 
 export const useParameterizeFrom = () => {
 	const setParameter = useSetSelectParameterState();
+	const setParameterList = useSetParameterList();
 	const environment = useEnviroment();
 	return async (sourceCommand: string, name: string) => {
 		const fetchParams = {
@@ -135,6 +137,10 @@ export const useParameterizeFrom = () => {
 			.then((response) => response.json())
 			.then((parameter: ParameterizeParams) => {
 				setParameter(new SelectParameter(parameter, "parameterize", name));
+				setParameterList((current) => {
+					if (current.parameterize.includes(name)) return current;
+					return current.replace("parameterize", [...current.parameterize, name]);
+				});
 			})
 			.catch((ex) => handleFetchError((ex as Error).message, fetchParams));
 	};

--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -138,7 +138,9 @@ export const useParameterizeFrom = () => {
 			.then((parameter: ParameterizeParams) => {
 				setParameter(new SelectParameter(parameter, "parameterize", name));
 				setParameterList((current) => {
-					if (current.parameterize.includes(name)) return current;
+					if (current.parameterize.includes(name)) {
+						return current;
+					}
 					return current.replace("parameterize", [...current.parameterize, name]);
 				});
 			})


### PR DESCRIPTION
## Summary
Updated the `useParameterizeFrom` hook to synchronize the parameter list in workspace resources when a new parameter is created from a source command.

## Key Changes
- Added import of `useSetParameterList` from `WorkspaceResourcesProvider`
- Enhanced the parameter creation flow to update the workspace's parameterize list after successfully creating a parameter
- Implemented deduplication logic to prevent duplicate parameter names in the list

## Implementation Details
When a parameter is parameterized from a source command, the hook now:
1. Creates the parameter as before using `setParameter`
2. Updates the workspace's parameterize list via `setParameterList` 
3. Checks if the parameter name already exists in the list to avoid duplicates
4. Uses the `replace` method to add the new parameter name to the parameterize array while maintaining immutability

https://claude.ai/code/session_01Udn86SoiEBKbK2AwVZU5h2