### PR TITLE
Add controller test update rules to test conventions

### DIFF
--- a/sidecar/.claude/rules/test-conventions.md
+++ b/sidecar/.claude/rules/test-conventions.md
@@ -18,3 +18,21 @@
 - 期待値 JSON を `src/test/resources/yo/dbunitcli/sidecar/controller/` に格納
 - `normalizeJson`（空白・改行除去）で正規化してから `assertEquals` で全フィールドを比較
 - ファイル作成を伴うテストは `Files.exists()` で副作用も検証
+
+## コード変更時のcontrollerテスト更新ルール
+
+### 基底クラスを変更したとき
+`AbstractCommandController` または `AbstractResourceFileController` を変更したら、
+それを継承する全コントローラーのテストが影響を受ける前提で確認する。
+
+### レスポンス構造を変更したとき
+コントローラーのレスポンスJSON構造が変わったら（フィールド追加・削除・型変更を含む）、
+`src/test/resources/yo/dbunitcli/sidecar/controller/` 配下の対応する期待値JSONファイルを更新する。
+
+### DTOのフィールドを変更したとき
+リクエスト/レスポンス用DTOのフィールドを変更したら、そのDTOを使うコントローラーテストを確認する。
+リクエストボディの形式が変わるとデシリアライズが失敗するため、テスト内のリクエストJSONも合わせて更新する。
+
+### `@Controller` のパスを変更したとき
+コントローラークラスの `@Controller` アノテーションのパスを変更したら、
+テスト内のHTTPリクエストURLを合わせて更新する。


### PR DESCRIPTION
## Summary
Added comprehensive guidelines for updating controller tests when making code changes to the codebase. This documents the relationship between code modifications and their corresponding test updates.

## Key Changes
- **Base class modifications**: Documented that changes to `AbstractCommandController` or `AbstractResourceFileController` require verification of all inheriting controller tests
- **Response structure changes**: Specified that JSON response structure modifications (field additions, deletions, type changes) require updating expected value JSON files in `src/test/resources/yo/dbunitcli/sidecar/controller/`
- **DTO field changes**: Clarified that request/response DTO modifications require checking related controller tests and updating request JSON in tests when deserialization format changes
- **Controller path changes**: Added rule that `@Controller` annotation path modifications must be reflected in test HTTP request URLs

## Implementation Details
These rules establish clear conventions for maintaining test consistency when making changes to:
- Base controller classes
- API response structures
- Data transfer objects
- Controller routing paths

This helps prevent test failures and ensures tests remain synchronized with code changes.

https://claude.ai/code/session_01RuEHdgvcsNJWDPN9N4D5H3