### PR TITLE
Filter undefined values when applying JDBC form updates

### DIFF
--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -52,7 +52,14 @@ export default function JdbcFormSection({
 
 	const handleApplyValues = useCallback(
 		(newValues: Partial<Record<string, string>>) => {
-			setJdbcValues((prev) => ({ ...prev, ...newValues }));
+			setJdbcValues((prev) => {
+				const defined = Object.fromEntries(
+					Object.entries(newValues).filter(
+						(entry): entry is [string, string] => entry[1] !== undefined,
+					),
+				);
+				return { ...prev, ...defined };
+			});
 		},
 		[],
 	);


### PR DESCRIPTION
## Summary
Updated the `handleApplyValues` callback in `JdbcFormSection` to filter out undefined values before merging them into the JDBC configuration state.

## Key Changes
- Modified the state update logic to exclude any entries with `undefined` values from `newValues` before spreading them into the previous state
- Added type-safe filtering using a type guard to ensure only `[string, string]` tuples are included in the merged object

## Implementation Details
The change prevents undefined values from overwriting existing JDBC configuration values. Previously, if `newValues` contained any undefined entries, they would be spread into the state object. Now, only defined string values are extracted and merged, ensuring that undefined values don't inadvertently clear or reset existing configuration settings.

https://claude.ai/code/session_01AaYf3x6tKbwQyDZEregsJ4