### PR TITLE
Add Save Shell functionality to parameter execution

### DIFF
--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -6,6 +6,7 @@ import {
 	type Running,
 	useExecParameter,
 	useSaveParameter,
+	useSaveShell,
 } from "../../hooks/useSelectParameter";
 import ResultDialog from "./ResultDialog";
 
@@ -23,6 +24,7 @@ export default function Footer(prop: {
 	const parameter = useSelectParameter();
 	const saveParameter = useSaveParameter();
 	const execParameter = useExecParameter();
+	const saveShell = useSaveShell();
 	const openDirectory = async (path: string) => {
 		await core.invoke("open_directory", { path });
 	};
@@ -35,6 +37,9 @@ export default function Footer(prop: {
 		throw new Promise(() =>
 			saveParameter(prop.formData(false).values, setRunning),
 		);
+	}
+	if (running.command === "saveShell") {
+		throw new Promise(() => saveShell(setRunning));
 	}
 	return (
 		<>
@@ -59,9 +64,9 @@ export default function Footer(prop: {
 			</ResultDialog>
 			{parameter.command && (
 				<div
-					className="fixed bottom-0 right-1 
+					className="fixed bottom-0 right-1
                                 w-full z-50
-								bg-gray-100 
+								bg-gray-100
                                 flex items-center justify-end p-4 gap-2"
 				>
 					<BlueButton
@@ -82,6 +87,16 @@ export default function Footer(prop: {
 						handleClick={() => {
 							setRunning({
 								command: "save",
+								resultMessage: "",
+								resultDir: "",
+							});
+						}}
+					/>
+					<BlueButton
+						title="Save Shell"
+						handleClick={() => {
+							setRunning({
+								command: "saveShell",
 								resultMessage: "",
 								resultDir: "",
 							});

--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -120,6 +120,34 @@ export const useExecParameter = () => {
 	};
 };
 
+export const useSaveShell = () => {
+	const parameter = useSelectParameter();
+	const environment = useEnviroment();
+	return async (handleResult: (result: Running) => void) => {
+		const fetchParams = {
+			endpoint: `${environment.apiUrl + parameter.command}/shell`,
+			options: {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ name: parameter.name }),
+			},
+		};
+		await fetchData(fetchParams)
+			.then((response) => response.text())
+			.then((resultDir: string) =>
+				handleResult({
+					command: "",
+					resultMessage: "Save Shell Success",
+					resultDir,
+				}),
+			)
+			.catch((ex) => {
+				handleFetchError((ex as Error).message, fetchParams);
+				handleResult({ command: "", resultMessage: ex.message, resultDir: "" });
+			});
+	};
+};
+
 export const useParameterizeFrom = () => {
 	const setParameter = useSetSelectParameterState();
 	const setParameterList = useSetParameterList();


### PR DESCRIPTION
## Summary
This PR adds a new "Save Shell" feature that allows users to save shell commands with their parameters. A new hook `useSaveShell` has been implemented to handle the shell save operation, and the Footer component has been updated to expose this functionality through a new button.

## Key Changes
- **New Hook**: Added `useSaveShell()` hook in `useSelectParameter.ts` that:
  - Makes a POST request to the `/shell` endpoint with the parameter name
  - Handles the response and error cases
  - Returns a callback that updates the running state with the result
  
- **Footer Component Updates**:
  - Imported and integrated the new `useSaveShell` hook
  - Added conditional logic to execute the save shell operation when `running.command === "saveShell"`
  - Added a new "Save Shell" button in the footer toolbar that triggers the save operation
  - Fixed minor whitespace/formatting issues in className strings

## Implementation Details
- The `useSaveShell` hook follows the same pattern as existing hooks like `useSaveParameter` and `useExecParameter`
- The save operation sends a POST request to `{apiUrl}/{command}/shell` with the parameter name in the request body
- Success and error responses are handled through the `handleResult` callback, which updates the UI state
- The button is only displayed when a command parameter is selected (within the existing conditional render)

https://claude.ai/code/session_011GhLVg9MHgJ9EBiLTDfFxs