### PR TITLE
Extract DbOperation enum from DBConverter class

### DIFF
--- a/core/src/main/java/yo/dbunitcli/application/command/GenerateDto.java
+++ b/core/src/main/java/yo/dbunitcli/application/command/GenerateDto.java
@@ -5,7 +5,7 @@ import yo.dbunitcli.application.CommandDto;
 import yo.dbunitcli.application.ParameterUnit;
 import yo.dbunitcli.application.dto.DataSetLoadDto;
 import yo.dbunitcli.application.dto.TemplateRenderDto;
-import yo.dbunitcli.dataset.converter.DBConverter;
+import yo.dbunitcli.dataset.DbOperation;
 
 public class GenerateDto extends CommandDto {
     @CommandLine.Option(names = "-generateType")
@@ -23,7 +23,7 @@ public class GenerateDto extends CommandDto {
     @CommandLine.Option(names = "-sqlFilePrefix", description = "generate sqlFile fileName prefix")
     private String sqlFilePrefix;
     @CommandLine.Option(names = "-op")
-    private DBConverter.Operation operation;
+    private DbOperation operation;
     @CommandLine.Option(names = "-outputEncoding", description = "output file encoding")
     private String outputEncoding;
     @CommandLine.Option(names = "-template", description = "template file")
@@ -92,11 +92,11 @@ public class GenerateDto extends CommandDto {
         this.sqlFilePrefix = sqlFilePrefix;
     }
 
-    public DBConverter.Operation getOperation() {
+    public DbOperation getOperation() {
         return this.operation;
     }
 
-    public void setOperation(final DBConverter.Operation operation) {
+    public void setOperation(final DbOperation operation) {
         this.operation = operation;
     }
 

--- a/core/src/main/java/yo/dbunitcli/application/command/GenerateOption.java
+++ b/core/src/main/java/yo/dbunitcli/application/command/GenerateOption.java
@@ -9,7 +9,7 @@ import yo.dbunitcli.application.option.DataSetLoadOption;
 import yo.dbunitcli.application.option.TemplateRenderOption;
 import yo.dbunitcli.common.Parameter;
 import yo.dbunitcli.dataset.ComparableDataSetParam;
-import yo.dbunitcli.dataset.converter.DBConverter;
+import yo.dbunitcli.dataset.DbOperation;
 import yo.dbunitcli.dataset.producer.ComparableDataSetLoader;
 import yo.dbunitcli.resource.FileResources;
 import yo.dbunitcli.resource.poi.jxls.JxlsTemplateGenerator;
@@ -27,7 +27,7 @@ public record GenerateOption(
         , String resultPath
         , GenerateType generateType
         , ParameterUnit unit
-        , DBConverter.Operation operation
+        , DbOperation operation
         , String sqlFilePrefix
         , String sqlFileSuffix
         , boolean commit
@@ -139,7 +139,7 @@ public record GenerateOption(
         switch (this.generateType) {
             case sql -> {
                 result.put("-commit", Boolean.toString(this.commit))
-                        .put("-op", this.operation, DBConverter.Operation.class)
+                        .put("-op", this.operation, DbOperation.class)
                         .put("-sqlFilePrefix", this.sqlFilePrefix)
                         .put("-sqlFileSuffix", this.sqlFileSuffix);
                 srcComponent.remove("-src.useJdbcMetaData");

--- a/core/src/main/java/yo/dbunitcli/application/dto/DataSetConverterDto.java
+++ b/core/src/main/java/yo/dbunitcli/application/dto/DataSetConverterDto.java
@@ -2,8 +2,8 @@ package yo.dbunitcli.application.dto;
 
 import picocli.CommandLine;
 import yo.dbunitcli.application.CompositeDto;
+import yo.dbunitcli.dataset.DbOperation;
 import yo.dbunitcli.dataset.ResultType;
-import yo.dbunitcli.dataset.converter.DBConverter;
 
 import java.util.stream.Stream;
 
@@ -17,7 +17,7 @@ public class DataSetConverterDto implements CompositeDto {
     @CommandLine.Option(names = "-resultPath", description = "result file relative path from -result=dir.")
     private String resultPath;
     @CommandLine.Option(names = "-op", description = "import operation UPDATE | INSERT | DELETE | REFRESH | CLEAN_INSERT")
-    private DBConverter.Operation operation;
+    private DbOperation operation;
     @CommandLine.Option(names = "-exportHeader", description = "if true then export file has no header row ")
     private String exportHeader;
     @CommandLine.Option(names = "-outputEncoding", description = "output csv file encoding")
@@ -64,11 +64,11 @@ public class DataSetConverterDto implements CompositeDto {
         this.resultPath = resultPath;
     }
 
-    public DBConverter.Operation getOperation() {
+    public DbOperation getOperation() {
         return this.operation;
     }
 
-    public void setOperation(final DBConverter.Operation operation) {
+    public void setOperation(final DbOperation operation) {
         this.operation = operation;
     }
 

--- a/core/src/main/java/yo/dbunitcli/application/option/DataSetConverterOption.java
+++ b/core/src/main/java/yo/dbunitcli/application/option/DataSetConverterOption.java
@@ -5,8 +5,8 @@ import yo.dbunitcli.application.Option;
 import yo.dbunitcli.application.dto.DataSetConverterDto;
 import yo.dbunitcli.dataset.DataSetConverterParam;
 import yo.dbunitcli.dataset.DataSourceType;
+import yo.dbunitcli.dataset.DbOperation;
 import yo.dbunitcli.dataset.ResultType;
-import yo.dbunitcli.dataset.converter.DBConverter;
 import yo.dbunitcli.resource.FileResources;
 
 import java.io.File;
@@ -15,7 +15,7 @@ public record DataSetConverterOption(
         String prefix
         , ResultType resultType
         , JdbcOption jdbcOption
-        , DBConverter.Operation operation
+        , DbOperation operation
         , String resultDir
         , String resultPath
         , boolean exportEmptyTable
@@ -56,8 +56,8 @@ public record DataSetConverterOption(
         }
         final DataSourceType type = DataSourceType.valueOf(this.resultType.name());
         if (type == DataSourceType.table) {
-            result.put("-op", this.operation == null ? DBConverter.Operation.CLEAN_INSERT : this.operation
-                            , DBConverter.Operation.class)
+            result.put("-op", this.operation == null ? DbOperation.CLEAN_INSERT : this.operation
+                            , DbOperation.class)
                     .addComponent("jdbc", this.jdbcOption.toParameters());
         } else {
             result.putDir("-result", this.resultDir, BaseDir.RESULT)

--- a/core/src/main/java/yo/dbunitcli/dataset/DataSetConverterParam.java
+++ b/core/src/main/java/yo/dbunitcli/dataset/DataSetConverterParam.java
@@ -1,6 +1,5 @@
 package yo.dbunitcli.dataset;
 
-import yo.dbunitcli.dataset.converter.DBConverter;
 import yo.dbunitcli.resource.jdbc.DatabaseConnectionLoader;
 
 import java.io.File;
@@ -8,7 +7,7 @@ import java.io.File;
 public record DataSetConverterParam(
         DatabaseConnectionLoader databaseConnectionLoader
         , ResultType resultType
-        , DBConverter.Operation operation
+        , DbOperation operation
         , File resultDir
         , String fileName
         , String outputEncoding
@@ -36,7 +35,7 @@ public record DataSetConverterParam(
     public static class Builder {
         private DatabaseConnectionLoader databaseConnectionLoader;
         private ResultType resultType;
-        private DBConverter.Operation operation;
+        private DbOperation operation;
         private File resultDir;
         private String outputEncoding;
         private String excelTable;
@@ -66,11 +65,11 @@ public record DataSetConverterParam(
             return this;
         }
 
-        public DBConverter.Operation getOperation() {
+        public DbOperation getOperation() {
             return this.operation;
         }
 
-        public Builder setOperation(final DBConverter.Operation operation) {
+        public Builder setOperation(final DbOperation operation) {
             this.operation = operation;
             return this;
         }

--- a/core/src/main/java/yo/dbunitcli/dataset/DbOperation.java
+++ b/core/src/main/java/yo/dbunitcli/dataset/DbOperation.java
@@ -1,0 +1,5 @@
+package yo.dbunitcli.dataset;
+
+public enum DbOperation {
+    INSERT, UPDATE, DELETE, REFRESH, CLEAN_INSERT
+}

--- a/core/src/main/java/yo/dbunitcli/dataset/converter/DBConverter.java
+++ b/core/src/main/java/yo/dbunitcli/dataset/converter/DBConverter.java
@@ -5,13 +5,14 @@ import org.dbunit.dataset.DataSetException;
 import org.dbunit.dataset.ITableMetaData;
 import yo.dbunitcli.dataset.AddSettingTableMetaData;
 import yo.dbunitcli.dataset.DataSetConverterParam;
+import yo.dbunitcli.dataset.DbOperation;
 import yo.dbunitcli.dataset.IDataSetConverter;
 import yo.dbunitcli.dataset.converter.db.*;
 
 public class DBConverter implements IDataSetConverter {
 
     private final IDatabaseConnection connection;
-    private final Operation operation;
+    private final DbOperation operation;
     private final boolean exportEmptyTable;
     private final DBOperator operator;
 
@@ -21,11 +22,21 @@ public class DBConverter implements IDataSetConverter {
                 , param.exportEmptyTable());
     }
 
-    public DBConverter(final IDatabaseConnection connection, final Operation operation, final boolean exportEmptyTable) {
+    public DBConverter(final IDatabaseConnection connection, final DbOperation operation, final boolean exportEmptyTable) {
         this.connection = connection;
         this.operation = operation;
         this.exportEmptyTable = exportEmptyTable;
-        this.operator = operation.operator(connection);
+        this.operator = this.createOperator(operation, connection);
+    }
+
+    private DBOperator createOperator(final DbOperation operation, final IDatabaseConnection connection) {
+        return switch (operation) {
+            case INSERT -> new InsertOperator(connection);
+            case UPDATE -> new UpdateOperator(connection);
+            case DELETE -> new DeleteOperator(connection);
+            case REFRESH -> new RefreshOperator(connection);
+            default -> new CleanInsertOperator(connection);
+        };
     }
 
     @Override
@@ -78,21 +89,4 @@ public class DBConverter implements IDataSetConverter {
         this.operator.row(objects);
     }
 
-    public enum Operation {
-        INSERT,
-        UPDATE,
-        DELETE,
-        REFRESH,
-        CLEAN_INSERT;
-
-        DBOperator operator(final IDatabaseConnection connection) {
-            return switch (this) {
-                case INSERT -> new InsertOperator(connection);
-                case UPDATE -> new UpdateOperator(connection);
-                case DELETE -> new DeleteOperator(connection);
-                case REFRESH -> new RefreshOperator(connection);
-                default -> new CleanInsertOperator(connection);
-            };
-        }
-    }
 }

--- a/core/src/test/java/yo/dbunitcli/application/command/GenerateOptionTest.java
+++ b/core/src/test/java/yo/dbunitcli/application/command/GenerateOptionTest.java
@@ -7,7 +7,7 @@ import yo.dbunitcli.application.ParameterUnit;
 import yo.dbunitcli.application.Option;
 import yo.dbunitcli.common.Parameter;
 import yo.dbunitcli.dataset.DataSourceType;
-import yo.dbunitcli.dataset.converter.DBConverter;
+import yo.dbunitcli.dataset.DbOperation;
 
 import java.util.Arrays;
 
@@ -22,7 +22,7 @@ class GenerateOptionTest {
         this.src.setUnit(ParameterUnit.record);
         this.src.setTemplate("template.st");
         this.src.setOutputEncoding("MS932");
-        this.src.setOperation(DBConverter.Operation.INSERT);
+        this.src.setOperation(DbOperation.INSERT);
         this.src.setSqlFilePrefix("prefix");
         this.src.setSqlFileSuffix("suffix");
         this.src.setCommit("false");


### PR DESCRIPTION
## Summary
Refactored the `Operation` enum out of the `DBConverter` class into a standalone `DbOperation` enum in the `yo.dbunitcli.dataset` package. This improves code organization by separating the operation type definition from the converter implementation.

## Key Changes
- Created new `DbOperation` enum in `yo.dbunitcli.dataset` package with values: INSERT, UPDATE, DELETE, REFRESH, CLEAN_INSERT
- Removed the nested `Operation` enum from `DBConverter` class
- Updated `DBConverter` to use `DbOperation` instead of the nested `Operation` enum
- Extracted the operator creation logic from `Operation.operator()` method into a new private `createOperator()` method in `DBConverter`
- Updated all references across the codebase to use `DbOperation`:
  - `DataSetConverterParam` and its `Builder`
  - `GenerateDto` command class
  - `DataSetConverterDto` DTO class
  - `DataSetConverterOption` record
  - `GenerateOption` record
  - Test class `GenerateOptionTest`

## Implementation Details
- The `createOperator()` method in `DBConverter` now handles the switch logic that was previously in the enum's `operator()` method
- All imports updated to reference `yo.dbunitcli.dataset.DbOperation` instead of `yo.dbunitcli.dataset.converter.DBConverter.Operation`
- No functional changes to the operation behavior; this is purely a structural refactoring

https://claude.ai/code/session_013Y6EbFBrrtkztcFEbN1TPf