### PR TITLE
fix(core): createOperator()のdefaultをcase CLEAN_INSERTに変更し末尾改行を追加

### DIFF
--- a/core/src/main/java/yo/dbunitcli/dataset/converter/DBConverter.java
+++ b/core/src/main/java/yo/dbunitcli/dataset/converter/DBConverter.java
@@ -35,7 +35,7 @@ public class DBConverter implements IDataSetConverter {
             case UPDATE -> new UpdateOperator(connection);
             case DELETE -> new DeleteOperator(connection);
             case REFRESH -> new RefreshOperator(connection);
-            default -> new CleanInsertOperator(connection);
+            case CLEAN_INSERT -> new CleanInsertOperator(connection);
         };
     }
 


### PR DESCRIPTION
- switch式のdefaultをcase CLEAN_INSERTに変更 将来DbOperationに値が追加された際にコンパイルエラーで検出できるようにする
- DBConverter.javaのファイル末尾改行を追加

https://claude.ai/code/session_013Y6EbFBrrtkztcFEbN1TPf