### PR TITLE
Improve dialog styling and add fieldset legends

### DIFF
--- a/tauri/src/app/settings/DatasetSettingDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingDialog.tsx
@@ -16,7 +16,7 @@ export default function DatasetSettingDaialog(props: {
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>
-            <Fieldset>
+            <Fieldset legend="Target">
                 <Select name="target" defaultValue={target.handler()} handleOnChange={handleTargetChange}>
                     <option value="name">name</option>
                     <option value="pattern">pattern</option>
@@ -26,7 +26,7 @@ export default function DatasetSettingDaialog(props: {
                 </Select>
                 {renderTargetContent(target, setTarget)}
             </Fieldset>
-            <Fieldset>
+            <Fieldset legend="Split / Rename">
                 <Check name="split"
                     value={target.split ? "true" : "false"}
                     handleOnChange={checked => setTarget(cur => cur.withSplit(checked))}
@@ -65,11 +65,11 @@ export default function DatasetSettingDaialog(props: {
                     </>
                 }
             </Fieldset>
-            <Fieldset>
+            <Fieldset legend="Additional Columns">
                 <ExpandButton
                     toggleOptional={toggleOptional}
                     showOptional={showOptional}
-                    caption="Additinaol Columns"
+                    caption="additional columns"
                 />
                 {showOptional && (
                     <>
@@ -92,7 +92,7 @@ export default function DatasetSettingDaialog(props: {
                     </>
                 )}
             </Fieldset>
-            <Fieldset>
+            <Fieldset legend="Filter / Order">
                 <Arrays name="exclude" values={target.exclude}
                     handleChange={(text, index) => setTarget(cur => cur.replaceExclude(text, index))}
                     handleRemove={(index) => setTarget(cur => cur.removeExclude(index))}

--- a/tauri/src/app/settings/DatasetSettingsDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingsDialog.tsx
@@ -58,23 +58,21 @@ function Dialog(props: {
 				newSetting={newDatasetSetting}
 				getKey={(setting) => setting.displayName()}
 			/>
-			<div className="mt-4">
-				<SettingTable<DatasetSetting>
-					caption="Common Settings"
-					settings={dataSettings.commonSettings}
-					setSettings={(convertCommon) => setDataSettings((cur) => {
-						const updatedCommonSettings = convertCommon(cur.commonSettings);
-						return new DatasetSettings(cur.settings, updatedCommonSettings);
-					})}
-					addSettings={(current, settings) => [...current, settings]}
-					updateSettings={(current, before, after) => current.map((setting) => (setting === before ? after : setting))}
-					deleteSettings={(current, settings) => current.filter((setting) => setting !== settings)}
-					renderSetting={(setting) => setting.displayName()}
-					SettingDialogComponent={DatasetSettingDaialog}
-					newSetting={newDatasetSetting}
-					getKey={(setting) => setting.displayName()}
-				/>
-			</div>
+			<SettingTable<DatasetSetting>
+				caption="Common Settings"
+				settings={dataSettings.commonSettings}
+				setSettings={(convertCommon) => setDataSettings((cur) => {
+					const updatedCommonSettings = convertCommon(cur.commonSettings);
+					return new DatasetSettings(cur.settings, updatedCommonSettings);
+				})}
+				addSettings={(current, settings) => [...current, settings]}
+				updateSettings={(current, before, after) => current.map((setting) => (setting === before ? after : setting))}
+				deleteSettings={(current, settings) => current.filter((setting) => setting !== settings)}
+				renderSetting={(setting) => setting.displayName()}
+				SettingDialogComponent={DatasetSettingDaialog}
+				newSetting={newDatasetSetting}
+				getKey={(setting) => setting.displayName()}
+			/>
 		</ResourceFileDialog>
 	);
 }

--- a/tauri/src/app/settings/DatasetSettingsDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingsDialog.tsx
@@ -58,21 +58,23 @@ function Dialog(props: {
 				newSetting={newDatasetSetting}
 				getKey={(setting) => setting.displayName()}
 			/>
-			<SettingTable<DatasetSetting>
-				caption="Common Settings"
-				settings={dataSettings.commonSettings}
-				setSettings={(convertCommon) => setDataSettings((cur) => {
-					const updatedCommonSettings = convertCommon(cur.commonSettings);
-					return new DatasetSettings(cur.settings, updatedCommonSettings);
-				})}
-				addSettings={(current, settings) => [...current, settings]}
-				updateSettings={(current, before, after) => current.map((setting) => (setting === before ? after : setting))}
-				deleteSettings={(current, settings) => current.filter((setting) => setting !== settings)}
-				renderSetting={(setting) => setting.displayName()}
-				SettingDialogComponent={DatasetSettingDaialog}
-				newSetting={newDatasetSetting}
-				getKey={(setting) => setting.displayName()}
-			/>
+			<div className="mt-4">
+				<SettingTable<DatasetSetting>
+					caption="Common Settings"
+					settings={dataSettings.commonSettings}
+					setSettings={(convertCommon) => setDataSettings((cur) => {
+						const updatedCommonSettings = convertCommon(cur.commonSettings);
+						return new DatasetSettings(cur.settings, updatedCommonSettings);
+					})}
+					addSettings={(current, settings) => [...current, settings]}
+					updateSettings={(current, before, after) => current.map((setting) => (setting === before ? after : setting))}
+					deleteSettings={(current, settings) => current.filter((setting) => setting !== settings)}
+					renderSetting={(setting) => setting.displayName()}
+					SettingDialogComponent={DatasetSettingDaialog}
+					newSetting={newDatasetSetting}
+					getKey={(setting) => setting.displayName()}
+				/>
+			</div>
 		</ResourceFileDialog>
 	);
 }

--- a/tauri/src/app/settings/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/settings/XlsxSchemaDialog.tsx
@@ -59,23 +59,21 @@ function Dialog(props: {
                 newSetting={createRowSetting}
                 getKey={(setting) => setting.displayName()}
             />
-            <div className="mt-4">
-                <SettingTable<CellSetting>
-                    caption="Random Cell Mapping Tables"
-                    settings={xlsxSchema.cells}
-                    setSettings={(convertCells) => setXlsxSchema((cur) => {
-                        const updatedCells = convertCells(cur.cells);
-                        return new XlsxSchema(cur.rows, updatedCells);
-                    })}
-                    addSettings={(current, settings) => [...current, settings]}
-                    updateSettings={(current, before, after) => current.map((cell) => (cell === before ? after : cell))}
-                    deleteSettings={(current, settings) => current.filter((cell) => cell !== settings)}
-                    renderSetting={(setting) => setting.displayName()}
-                    SettingDialogComponent={XlsxCellSettingDialog}
-                    newSetting={createCellSetting}
-                    getKey={(setting) => setting.displayName()}
-                />
-            </div>
+            <SettingTable<CellSetting>
+                caption="Random Cell Mapping Tables"
+                settings={xlsxSchema.cells}
+                setSettings={(convertCells) => setXlsxSchema((cur) => {
+                    const updatedCells = convertCells(cur.cells);
+                    return new XlsxSchema(cur.rows, updatedCells);
+                })}
+                addSettings={(current, settings) => [...current, settings]}
+                updateSettings={(current, before, after) => current.map((cell) => (cell === before ? after : cell))}
+                deleteSettings={(current, settings) => current.filter((cell) => cell !== settings)}
+                renderSetting={(setting) => setting.displayName()}
+                SettingDialogComponent={XlsxCellSettingDialog}
+                newSetting={createCellSetting}
+                getKey={(setting) => setting.displayName()}
+            />
         </ResourceFileDialog>
     );
 }

--- a/tauri/src/app/settings/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/settings/XlsxSchemaDialog.tsx
@@ -59,21 +59,23 @@ function Dialog(props: {
                 newSetting={createRowSetting}
                 getKey={(setting) => setting.displayName()}
             />
-            <SettingTable<CellSetting>
-                caption="Random Cell Mapping Tables"
-                settings={xlsxSchema.cells}
-                setSettings={(convertCells) => setXlsxSchema((cur) => {
-                    const updatedCells = convertCells(cur.cells);
-                    return new XlsxSchema(cur.rows, updatedCells);
-                })}
-                addSettings={(current, settings) => [...current, settings]}
-                updateSettings={(current, before, after) => current.map((cell) => (cell === before ? after : cell))}
-                deleteSettings={(current, settings) => current.filter((cell) => cell !== settings)}
-                renderSetting={(setting) => setting.displayName()}
-                SettingDialogComponent={XlsxCellSettingDialog}
-                newSetting={createCellSetting}
-                getKey={(setting) => setting.displayName()}
-            />
+            <div className="mt-4">
+                <SettingTable<CellSetting>
+                    caption="Random Cell Mapping Tables"
+                    settings={xlsxSchema.cells}
+                    setSettings={(convertCells) => setXlsxSchema((cur) => {
+                        const updatedCells = convertCells(cur.cells);
+                        return new XlsxSchema(cur.rows, updatedCells);
+                    })}
+                    addSettings={(current, settings) => [...current, settings]}
+                    updateSettings={(current, before, after) => current.map((cell) => (cell === before ? after : cell))}
+                    deleteSettings={(current, settings) => current.filter((cell) => cell !== settings)}
+                    renderSetting={(setting) => setting.displayName()}
+                    SettingDialogComponent={XlsxCellSettingDialog}
+                    newSetting={createCellSetting}
+                    getKey={(setting) => setting.displayName()}
+                />
+            </div>
         </ResourceFileDialog>
     );
 }

--- a/tauri/src/components/dialog/ResourceFileDialog.tsx
+++ b/tauri/src/components/dialog/ResourceFileDialog.tsx
@@ -22,14 +22,14 @@ export default function ResourceFileDialog({
 			onClose={handleDialogClose}
 			className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
 		>
-			<div className="relative overflow-x-auto">{children}</div>
+			<div className="relative overflow-x-auto flex flex-col gap-4">{children}</div>
 			<div className="p-4">
 				<div className="grid grid-cols-5 pb-2">
 					<InputLabel
 						id="fileNameLabel"
 						text="name"
 						required={false}
-						wStyle="p-2.5 w=1/5"
+						wStyle="p-2.5 w-1/5"
 					/>
 					<ControllTextBox
 						name="fileName"

--- a/tauri/src/components/dialog/ResourceFileDialog.tsx
+++ b/tauri/src/components/dialog/ResourceFileDialog.tsx
@@ -23,7 +23,7 @@ export default function ResourceFileDialog({
 			className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
 		>
 			<div className="relative overflow-x-auto">{children}</div>
-			<div className="right-1 w-full flex items-center justify-end">
+			<div className="p-4">
 				<div className="grid grid-cols-5 pb-2">
 					<InputLabel
 						id="fileNameLabel"
@@ -35,12 +35,12 @@ export default function ResourceFileDialog({
 						name="fileName"
 						id="fileName"
 						required={true}
-						wStyle="col-start-2 col-span-4 mr-2"
+						wStyle="col-start-2 col-span-4"
 						value={value}
 						handleChange={(ev) => setValue(ev.target.value)}
 					/>
 				</div>
-				<div className="flex items-center justify-end p-4 gap-2">
+				<div className="flex items-center justify-end gap-2">
 					<BlueButton title="Save" handleClick={() => handleSave(value)} />
 					<WhiteButton title="Close" handleClick={handleDialogClose} />
 				</div>

--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -43,9 +43,14 @@ export function SettingDialog<T>(props: SettingDialogProps<T>) {
 	);
 }
 
-export function Fieldset(props: { children: ReactNode }) {
+export function Fieldset(props: { children: ReactNode; legend?: string }) {
 	return (
 		<fieldset className="border border-gray-200 p-2.5 m-2">
+			{props.legend && (
+				<legend className="text-xs font-semibold text-gray-500 px-1">
+					{props.legend}
+				</legend>
+			)}
 			{props.children}
 		</fieldset>
 	);

--- a/tauri/src/components/dialog/SettingTable.tsx
+++ b/tauri/src/components/dialog/SettingTable.tsx
@@ -50,14 +50,14 @@ export default function SettingTable<T>({
                     }}
                 />
             )}
-            <table className="table-fixed">
-                <caption className="caption-top">{caption}</caption>
+            <table className="table-fixed w-full">
+                <caption className="caption-top text-sm font-semibold text-gray-700 text-left px-2 py-1">{caption}</caption>
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                     <tr>
-                        <th scope="col" className="px-6 py-3 border-4">
+                        <th scope="col" className="px-6 py-3 border">
                             Target
                         </th>
-                        <th scope="col" className="px-6 py-3 border-4">
+                        <th scope="col" className="px-6 py-3 border">
                             Action
                         </th>
                     </tr>
@@ -65,10 +65,10 @@ export default function SettingTable<T>({
                 <tbody>
                     {settings?.map((setting) => (
                         <tr key={getKey(setting)}>
-                            <th scope="row" className="px-6 min-w-80 max-w-80 text-left text-sm text-gray-900 border-4">
+                            <th scope="row" className="px-6 min-w-80 max-w-80 text-left text-sm text-gray-900 border">
                                 {renderSetting(setting)}
                             </th>
-                            <td className="px-6 border-4">
+                            <td className="px-6 border">
                                 <div className="flex">
                                     <EditButton handleClick={() => setSelectSettings({ setting, action: "update" })} />
                                     <DeleteButton handleClick={() => setSettings((current) => deleteSettings(current, setting))} />

--- a/tauri/src/components/dialog/SettingTable.tsx
+++ b/tauri/src/components/dialog/SettingTable.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { AddButton, CopyButton, DeleteButton, EditButton } from "../element/ButtonIcon";
 
-interface SttingTableProps<T> {
+interface SettingTableProps<T> {
     caption: string;
     settings: T[];
     setSettings: (convertFunction: (currentSettings: T[]) => T[]) => void;
@@ -29,7 +29,7 @@ export default function SettingTable<T>({
     SettingDialogComponent,
     newSetting,
     getKey,
-}: SttingTableProps<T>) {
+}: SettingTableProps<T>) {
     const defaultState = { setting: newSetting(), action: "" };
     const [selectSettings, setSelectSettings] = useState(defaultState);
 
@@ -63,7 +63,7 @@ export default function SettingTable<T>({
                     </tr>
                 </thead>
                 <tbody>
-                    {settings?.map((setting) => (
+                    {settings.map((setting) => (
                         <tr key={getKey(setting)}>
                             <th scope="row" className="px-6 min-w-80 max-w-80 text-left text-sm text-gray-900 border">
                                 {renderSetting(setting)}


### PR DESCRIPTION
## Summary
This PR enhances the visual presentation and usability of settings dialogs by improving spacing, adding descriptive legends to fieldsets, and refining table styling.

## Key Changes
- **Added fieldset legends** in DatasetSettingDialog to provide clear section headers ("Target", "Split / Rename", "Additional Columns", "Filter / Order")
- **Enhanced Fieldset component** to support optional legend prop with consistent styling
- **Improved SettingTable styling**:
  - Added `w-full` class for full-width tables
  - Enhanced caption styling with better typography and padding
  - Changed border thickness from `border-4` to `border` for cleaner appearance
- **Added spacing wrapper** around SettingTable components in DatasetSettingsDialog and XlsxSchemaDialog with `mt-4` margin class
- **Refined ResourceFileDialog layout**:
  - Improved padding structure with `p-4` wrapper
  - Removed unnecessary `mr-2` margin from input field
  - Cleaned up button container spacing
- **Fixed typo** in caption text ("Additinaol" → "additional")

## Implementation Details
- Fieldset legends use consistent styling: `text-xs font-semibold text-gray-500 px-1`
- Table captions now use: `text-sm font-semibold text-gray-700 text-left px-2 py-1`
- All changes maintain backward compatibility with existing components

https://claude.ai/code/session_01DmNx5A8gD2vcA1S4cEgD4k