### PR TITLE
Return parent directory path from shell command endpoint

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -121,7 +121,7 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
     @Post(uri = "shell", produces = MediaType.TEXT_PLAIN)
     public String shell(@Body final CommandRequestDto body) throws IOException {
         try {
-            return this.workspace.saveShell(this.getCommandType(), body.getName());
+            return java.nio.file.Path.of(this.workspace.saveShell(this.getCommandType(), body.getName())).getParent().toString();
         } catch (IOException e) {
             throw e;
         } catch (final Throwable th) {


### PR DESCRIPTION
## Summary
Modified the shell command endpoint to return the parent directory path instead of the full file path returned by `saveShell()`.

## Key Changes
- Updated the `/shell` POST endpoint in `AbstractCommandController` to extract and return only the parent directory of the saved shell file
- Changed return value from direct `saveShell()` result to `Path.of(...).getParent().toString()`

## Implementation Details
The modification uses Java NIO's `Path` API to:
1. Convert the returned file path string to a `Path` object
2. Extract the parent directory using `getParent()`
3. Convert back to string for the response

This change aligns the shell endpoint's response with returning directory-level information rather than the full file path.

https://claude.ai/code/session_01FnumNWijgydmmNAHY14XQd