### PR TITLE
Fix logical operator in ParameterizeOption argument validation

### DIFF
--- a/core/src/main/java/yo/dbunitcli/application/command/ParameterizeOption.java
+++ b/core/src/main/java/yo/dbunitcli/application/command/ParameterizeOption.java
@@ -44,8 +44,8 @@ public record ParameterizeOption(
         }
 
         private boolean isNotSrcArg(final String prefix, final String it) {
-            return !it.startsWith("-" + prefix + ".src=") || !it.startsWith("-" + prefix + ".srcType=")
-                    || !it.startsWith("-src=") || !it.startsWith("-srcType=");
+            return !it.startsWith("-" + prefix + ".src=") && !it.startsWith("-" + prefix + ".srcType=")
+                    && !it.startsWith("-src=") && !it.startsWith("-srcType=");
         }
 
         private boolean paramTypeIsNone(final List<String> list) {


### PR DESCRIPTION
## Summary
Fixed a critical logic error in the `isNotSrcArg` method where OR operators (`||`) were incorrectly used instead of AND operators (`&&`), causing the argument validation to always return true.

## Key Changes
- Changed logical operators from OR (`||`) to AND (`&&`) in the `isNotSrcArg` method
- This fixes the condition to correctly identify when a string argument is NOT one of the source-related arguments

## Implementation Details
The original logic with OR operators would always evaluate to true because at least one of the conditions would always be true (e.g., if a string starts with `-prefix.src=`, it won't start with `-src=`). By switching to AND operators, the method now correctly returns true only when the argument doesn't match ANY of the source argument patterns, which is the intended behavior for filtering out source-related arguments.

https://claude.ai/code/session_0131qMLXx3hmjjYcP2zxEw64