### PR TITLE
Refactor dialog button layouts and consolidate close button logic

### DIFF
--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -44,22 +44,24 @@ export default function Footer(prop: {
 	return (
 		<>
 			<ResultDialog hidden={running.resultMessage === ""}>
-				<div className="p-4 md:p-5 text-center">
+				<div className="p-4 md:p-5">
 					<h3 className="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
 						{running.resultMessage}
 					</h3>
-					{running.resultDir && (
-						<BlueButton
-							title="Open Directory"
-							handleClick={() => openDirectory(running.resultDir)}
+					<div className="flex items-center justify-end gap-2">
+						{running.resultDir && (
+							<BlueButton
+								title="Open Directory"
+								handleClick={() => openDirectory(running.resultDir)}
+							/>
+						)}
+						<WhiteButton
+							title="Close"
+							handleClick={() => {
+								setRunning({ command: "", resultMessage: "", resultDir: "" });
+							}}
 						/>
-					)}
-					<WhiteButton
-						title="Close"
-						handleClick={() => {
-							setRunning({ command: "", resultMessage: "", resultDir: "" });
-						}}
-					/>
+					</div>
 				</div>
 			</ResultDialog>
 			{parameter.command && (

--- a/tauri/src/app/main/Header.tsx
+++ b/tauri/src/app/main/Header.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { WhiteButton } from "../../components/element/Button";
 import { DirIcon } from "../../components/element/Icon";
 import { useSelectParameter } from "../../context/SelectParameterProvider";
 import StartupForm from "../startup/StartupForm";
@@ -42,10 +41,7 @@ function WorkspaceDialog({ onClose }: { onClose: () => void }) {
 			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200 w-full max-w-4xl"
 		>
 			<div className="p-4 rounded-lg mt-2">
-				<StartupForm onSelect={onClose} />
-				<div className="flex items-center justify-end mt-2">
-					<WhiteButton title="Close" handleClick={onClose} />
-				</div>
+				<StartupForm onSelect={onClose} onClose={onClose} />
 			</div>
 		</dialog>
 	);

--- a/tauri/src/app/startup/StartupForm.tsx
+++ b/tauri/src/app/startup/StartupForm.tsx
@@ -7,13 +7,13 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { BlueButton, ButtonWithIcon } from "../../components/element/Button";
+import { BlueButton, ButtonWithIcon, WhiteButton } from "../../components/element/Button";
 import { DirIcon } from "../../components/element/Icon";
 import { ControllTextBox, InputLabel } from "../../components/element/Input";
 import { useWorkspaceContext } from "../../context/WorkspaceResourcesProvider";
 import { useWorkspaceUpdate } from "../../hooks/useWorkspaceResources";
 
-const StartupForm: React.FC<{ onSelect: () => void }> = ({ onSelect }) => {
+const StartupForm: React.FC<{ onSelect: () => void; onClose?: () => void }> = ({ onSelect, onClose }) => {
 	const context = useWorkspaceContext();
 	const workspaceUpdate = useWorkspaceUpdate();
 	const [workspace, setWorkspace] = useState(context.workspace);
@@ -88,10 +88,9 @@ const StartupForm: React.FC<{ onSelect: () => void }> = ({ onSelect }) => {
 					error={errors.resultBase}
 				/>
 			</div>
-			<div className="grid grid-cols-6">
-				<div className="col-start-5 flex items-center justify-end">
-					<BlueButton title="confirm" handleClick={() => handleSelect()} />
-				</div>
+			<div className="flex items-center justify-end gap-2">
+				<BlueButton title="confirm" handleClick={() => handleSelect()} />
+				{onClose && <WhiteButton title="Close" handleClick={onClose} />}
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Summary
This PR refactors button layouts across multiple dialog components to use consistent flexbox patterns and consolidates close button handling by passing it as a prop to the StartupForm component.

## Key Changes
- **Footer.tsx**: Updated ResultDialog button layout to use flexbox (`flex items-center justify-end gap-2`) instead of text-center alignment, wrapping both "Open Directory" and "Close" buttons in a flex container
- **StartupForm.tsx**: 
  - Added `WhiteButton` to imports
  - Added optional `onClose` prop to component signature
  - Refactored button container from `grid grid-cols-6` to flexbox (`flex items-center justify-end gap-2`)
  - Conditionally render "Close" button when `onClose` prop is provided
- **Header.tsx**: 
  - Removed `WhiteButton` import (no longer needed)
  - Removed separate close button wrapper div from WorkspaceDialog
  - Pass `onClose` prop directly to StartupForm instead of rendering close button separately

## Implementation Details
The changes establish a consistent button layout pattern using flexbox with gap spacing across dialog components. The StartupForm now handles its own close button rendering when the callback is provided, reducing duplication and improving component encapsulation. This makes the component more reusable in different contexts where a close button may or may not be needed.

https://claude.ai/code/session_01W16VKXwCuLTiDZqfEf1Am3