### PR TITLE
Add column headers to KeyValueText component

### DIFF
--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -293,39 +293,47 @@ export function KeyValueText(props: {
 		props.handleChange(props.index, { [key]: newVal.target.value });
 	const handleRemove = () => props.handleRemove(props.index);
 	return (
-		<div className="grid grid-cols-5 pb-2">
+		<>
 			{props.index === 0 && (
-				<InputLabel
-					id={props.name}
-					text={props.name}
-					required={false}
-					wStyle="p-2.5 w=1/5"
-				/>
-			)}
-			<ControllTextBox
-				name={props.name}
-				id={props.name}
-				required={true}
-				wStyle="col-start-2 p-2.5 w=1/5"
-				value={key}
-				handleChange={(ev) => setKey(ev.target.value)}
-				handleBlur={handleKeyBlur}
-			/>
-			<ControllTextBox
-				name={props.name}
-				id={props.name}
-				required={true}
-				wStyle="col-start-3 col-span-2 ml-1 "
-				value={value}
-				disabled={!key || key === ""}
-				handleChange={(ev) => setValue(ev.target.value)}
-				handleBlur={handleValueBlur}
-			/>
-			{props.index > 0 && (
-				<div className="col-start-5">
-					<RemoveButton handleClick={handleRemove} />
+				<div className="grid grid-cols-5 pb-1">
+					<span className="col-start-2 text-xs text-gray-500">name</span>
+					<span className="col-start-3 col-span-2 ml-1 text-xs text-gray-500">expression</span>
 				</div>
 			)}
-		</div>
+			<div className="grid grid-cols-5 pb-2">
+				{props.index === 0 && (
+					<InputLabel
+						id={props.name}
+						text={props.name}
+						required={false}
+						wStyle="p-2.5 w=1/5"
+					/>
+				)}
+				<ControllTextBox
+					name={props.name}
+					id={props.name}
+					required={true}
+					wStyle="col-start-2 p-2.5 w=1/5"
+					value={key}
+					handleChange={(ev) => setKey(ev.target.value)}
+					handleBlur={handleKeyBlur}
+				/>
+				<ControllTextBox
+					name={props.name}
+					id={props.name}
+					required={true}
+					wStyle="col-start-3 col-span-2 ml-1 "
+					value={value}
+					disabled={!key || key === ""}
+					handleChange={(ev) => setValue(ev.target.value)}
+					handleBlur={handleValueBlur}
+				/>
+				{props.index > 0 && (
+					<div className="col-start-5">
+						<RemoveButton handleClick={handleRemove} />
+					</div>
+				)}
+			</div>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary
Enhanced the KeyValueText component in the SettingDialog to display column headers ("name" and "expression") above the input fields for better UX clarity.

## Key Changes
- Wrapped the component output in a fragment (`<>...</>`) to accommodate the new header row
- Added a conditional header row that displays only when `index === 0` (first item)
- Header row includes two labeled columns: "name" (col-start-2) and "expression" (col-start-3, spanning 2 columns)
- Styled headers with `text-xs text-gray-500` for subtle visual distinction
- Maintained all existing functionality and layout of the input fields and remove button

## Implementation Details
- The header row uses the same grid structure (grid-cols-5) as the input row for alignment
- Headers only render once at the beginning of the list, reducing visual clutter
- Minimal styling changes ensure consistency with the existing design system

https://claude.ai/code/session_012ktZppiMSPgTYChiDVS1X7