### PR TITLE
Add file filtering options to XLSX schema operations

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
@@ -37,6 +37,10 @@ public class XlsxSchemaController extends AbstractResourceFileController<JsonXls
                     .setSrc(new File(request.getSrc()))
                     .setRegTableInclude(request.getRegTableInclude())
                     .setRegTableExclude(request.getRegTableExclude())
+                    .setRecursive(request.isRecursive())
+                    .setRegInclude(request.getRegInclude())
+                    .setRegExclude(request.getRegExclude())
+                    .setExtension(request.getExtension())
                     .setHeaderName("header")
                     .setLoadData(false)
                     .build();

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/XlsxSheetsRequestDto.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/XlsxSheetsRequestDto.java
@@ -9,6 +9,10 @@ public class XlsxSheetsRequestDto {
     private String src;
     private String regTableInclude;
     private String regTableExclude;
+    private boolean recursive;
+    private String regInclude;
+    private String regExclude;
+    private String extension;
 
     public String getSrc() {
         return this.src;
@@ -32,5 +36,37 @@ public class XlsxSheetsRequestDto {
 
     public void setRegTableExclude(final String regTableExclude) {
         this.regTableExclude = regTableExclude;
+    }
+
+    public boolean isRecursive() {
+        return this.recursive;
+    }
+
+    public void setRecursive(final boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    public String getRegInclude() {
+        return this.regInclude;
+    }
+
+    public void setRegInclude(final String regInclude) {
+        this.regInclude = regInclude;
+    }
+
+    public String getRegExclude() {
+        return this.regExclude;
+    }
+
+    public void setRegExclude(final String regExclude) {
+        this.regExclude = regExclude;
+    }
+
+    public String getExtension() {
+        return this.extension;
+    }
+
+    public void setExtension(final String extension) {
+        this.extension = extension;
     }
 }

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -44,10 +44,18 @@ export default function CommandFormElements(
 	const srcElement = prop.elements.find((element) => element.name === "src");
 	const regTableIncludeElement = prop.elements.find((element) => element.name === "regTableInclude");
 	const regTableExcludeElement = prop.elements.find((element) => element.name === "regTableExclude");
+	const recursiveElement = prop.elements.find((element) => element.name === "recursive");
+	const regIncludeElement = prop.elements.find((element) => element.name === "regInclude");
+	const regExcludeElement = prop.elements.find((element) => element.name === "regExclude");
+	const extensionElement = prop.elements.find((element) => element.name === "extension");
 	const srcInfo: SrcInfo = {
 		srcPath: srcElement?.value ?? "",
 		regTableInclude: regTableIncludeElement?.value ?? "",
 		regTableExclude: regTableExcludeElement?.value ?? "",
+		recursive: recursiveElement?.value ?? "",
+		regInclude: regIncludeElement?.value ?? "",
+		regExclude: regExcludeElement?.value ?? "",
+		extension: extensionElement?.value ?? "",
 	};
 	const toggleOptional = () => setShowOptional(!showOptional);
 

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -5,6 +5,10 @@ export type SrcInfo = {
 	srcPath: string;
 	regTableInclude: string;
 	regTableExclude: string;
+	recursive: string;
+	regInclude: string;
+	regExclude: string;
+	extension: string;
 };
 
 export type Prop = {

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -19,15 +19,7 @@ export default function XlsxCellSettingDialog(props: {
         if (!props.srcInfo?.srcPath) {
             return;
         }
-        loadSheets(
-            props.srcInfo.srcPath,
-            props.srcInfo.regTableInclude,
-            props.srcInfo.regTableExclude,
-            props.srcInfo.recursive,
-            props.srcInfo.regInclude,
-            props.srcInfo.regExclude,
-            props.srcInfo.extension,
-        ).then(setSheetNames);
+        loadSheets(props.srcInfo).then(setSheetNames);
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
 

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -23,9 +23,13 @@ export default function XlsxCellSettingDialog(props: {
             props.srcInfo.srcPath,
             props.srcInfo.regTableInclude,
             props.srcInfo.regTableExclude,
+            props.srcInfo.recursive,
+            props.srcInfo.regInclude,
+            props.srcInfo.regExclude,
+            props.srcInfo.extension,
         ).then(setSheetNames);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude]);
+    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -19,15 +19,7 @@ export default function XlsxRowSettingDialog(props: {
         if (!props.srcInfo?.srcPath) {
             return;
         }
-        loadSheets(
-            props.srcInfo.srcPath,
-            props.srcInfo.regTableInclude,
-            props.srcInfo.regTableExclude,
-            props.srcInfo.recursive,
-            props.srcInfo.regInclude,
-            props.srcInfo.regExclude,
-            props.srcInfo.extension,
-        ).then(setSheetNames);
+        loadSheets(props.srcInfo).then(setSheetNames);
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
 

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -23,9 +23,13 @@ export default function XlsxRowSettingDialog(props: {
             props.srcInfo.srcPath,
             props.srcInfo.regTableInclude,
             props.srcInfo.regTableExclude,
+            props.srcInfo.recursive,
+            props.srcInfo.regInclude,
+            props.srcInfo.regExclude,
+            props.srcInfo.extension,
         ).then(setSheetNames);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude]);
+    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -114,7 +114,7 @@ async function deleteXlsxSchema(
 
 export const useXlsxSheets = () => {
 	const environment = useEnviroment();
-	return async (src: string, regTableInclude: string, regTableExclude: string): Promise<string[]> => {
+	return async (src: string, regTableInclude: string, regTableExclude: string, recursive: string, regInclude: string, regExclude: string, extension: string): Promise<string[]> => {
 		if (!src) {
 			return [];
 		}
@@ -123,7 +123,7 @@ export const useXlsxSheets = () => {
 			options: {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ src, regTableInclude, regTableExclude }),
+				body: JSON.stringify({ src, regTableInclude, regTableExclude, recursive: recursive === "true", regInclude, regExclude, extension }),
 			},
 		};
 		return fetchData(fetchParams)

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
+import type { SrcInfo } from "../app/form/FormElementProp";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { ResourcesSettings } from "../model/WorkspaceResources";
 import { XlsxSchema, type XlsxSchemaBuilder } from "../model/XlsxSchema";
@@ -114,8 +115,8 @@ async function deleteXlsxSchema(
 
 export const useXlsxSheets = () => {
 	const environment = useEnviroment();
-	return async (src: string, regTableInclude: string, regTableExclude: string, recursive: string, regInclude: string, regExclude: string, extension: string): Promise<string[]> => {
-		if (!src) {
+	return async (srcInfo: SrcInfo): Promise<string[]> => {
+		if (!srcInfo.srcPath) {
 			return [];
 		}
 		const fetchParams = {
@@ -123,7 +124,7 @@ export const useXlsxSheets = () => {
 			options: {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ src, regTableInclude, regTableExclude, recursive: recursive === "true", regInclude, regExclude, extension }),
+				body: JSON.stringify({ src: srcInfo.srcPath, regTableInclude: srcInfo.regTableInclude, regTableExclude: srcInfo.regTableExclude, recursive: srcInfo.recursive === "true", regInclude: srcInfo.regInclude, regExclude: srcInfo.regExclude, extension: srcInfo.extension }),
 			},
 		};
 		return fetchData(fetchParams)


### PR DESCRIPTION
## Summary
Extended the XLSX sheets request functionality to support additional file filtering and traversal options. This allows users to recursively search directories, filter files by extension, and apply regex patterns to file names in addition to existing table name filtering.

## Key Changes
- **Backend (Java)**: Added four new fields to `XlsxSheetsRequestDto`:
  - `recursive` (boolean): Enable recursive directory traversal
  - `regInclude` (String): Regex pattern for including files
  - `regExclude` (String): Regex pattern for excluding files
  - `extension` (String): File extension filter
  - Generated corresponding getter/setter methods for all new fields
  - Updated `XlsxSchemaController` to pass these parameters to the builder

- **Frontend (TypeScript/React)**: 
  - Extended `SrcInfo` type to include the four new filtering options
  - Updated `CommandFormElements` to extract and map the new form elements
  - Modified `useXlsxSheets` hook to accept and forward the new parameters
  - Updated both `XlsxCellSettingDialog` and `XlsxRowSettingDialog` to pass new parameters to the sheets API and include them in dependency arrays

## Implementation Details
- The `recursive` parameter is converted from string to boolean when serializing to JSON
- All new parameters are properly threaded through the form handling, API calls, and dialog components
- React dependency arrays updated to ensure proper re-rendering when filtering options change

https://claude.ai/code/session_01T8QhCvdxxFpkLS2agEk8Bx