### PR TITLE
Add template file preview functionality

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -30,6 +30,7 @@ import { DirectoryChooser, FileChooser } from "./Chooser";
 import type { FileProp, Prop, SelectProp, SrcInfo } from "./FormElementProp";
 import { useJdbcConnectionState } from "../../context/JdbcConnectionProvider";
 import JdbcFormSection, { JDBC_FIELD_NAMES } from "./JdbcFormSection";
+import TemplatePreviewButton from "../settings/TemplatePreviewButton";
 
 export default function CommandFormElements(
 	prop: {
@@ -307,6 +308,11 @@ function DropDownMenu({
 									<JdbcTableSelectorButton path={path} setPath={setPath} />
 								</li>
 							)}
+						{element.name === "templateGroup" && !hidden && path && (
+							<li>
+								<TemplatePreviewButton path={path} />
+							</li>
+						)}
 						{element.attribute.type.includes("FILE") && (
 							<li>
 								<FileChooser

--- a/tauri/src/app/settings/TemplatePreviewButton.tsx
+++ b/tauri/src/app/settings/TemplatePreviewButton.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+import { ButtonWithIcon, WhiteButton } from "../../components/element/Button";
+import { FileIcon } from "../../components/element/Icon";
+import { useTemplateLoadContent } from "../../hooks/useTemplate";
+
+function TemplatePreviewDialog({
+	name,
+	handleDialogClose,
+}: {
+	name: string;
+	handleDialogClose: () => void;
+}) {
+	const [content, setContent] = useState<string | null>(null);
+	const loadContent = useTemplateLoadContent();
+	const dialogRef = useRef<HTMLDialogElement>(null);
+
+	useEffect(() => {
+		dialogRef.current?.showModal();
+	}, []);
+
+	useEffect(() => {
+		loadContent(name).then(setContent);
+	}, [name, loadContent]);
+
+	return (
+		<dialog
+			ref={dialogRef}
+			onClose={handleDialogClose}
+			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
+		>
+			<div className="p-4 rounded-lg mt-2">
+				<div className="w-[800px]">
+					<h2 className="text-lg font-bold mb-2">Template File Preview</h2>
+					<p className="text-sm text-gray-500 mb-3 break-all">{name}</p>
+					{content === null ? (
+						<p className="text-sm text-gray-400 p-3">Loading...</p>
+					) : (
+						<pre className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all">
+							{content}
+						</pre>
+					)}
+				</div>
+			</div>
+			<div className="flex items-center justify-end p-4 gap-2">
+				<WhiteButton title="Close" handleClick={handleDialogClose} />
+			</div>
+		</dialog>
+	);
+}
+
+export default function TemplatePreviewButton({ path }: { path: string }) {
+	const [showDialog, setShowDialog] = useState(false);
+	return (
+		<>
+			<ButtonWithIcon
+				handleClick={() => setShowDialog(true)}
+				id="templatePreviewButton"
+			>
+				<FileIcon title="Preview Template" fill="white" />
+			</ButtonWithIcon>
+			{showDialog && (
+				<TemplatePreviewDialog
+					name={path}
+					handleDialogClose={() => setShowDialog(false)}
+				/>
+			)}
+		</>
+	);
+}

--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -1,0 +1,24 @@
+import { useEnviroment } from "../context/EnviromentProvider";
+import { fetchData, handleFetchError } from "../utils/fetchUtils";
+
+export const useTemplateLoadContent = () => {
+	const { apiUrl } = useEnviroment();
+	return async (name: string): Promise<string> => {
+		const params = {
+			endpoint: `${apiUrl}template/load`,
+			options: {
+				method: "POST",
+				headers: { "Content-Type": "text/plain" },
+				body: name,
+			},
+		};
+		try {
+			const response = await fetchData(params);
+			const data = (await response.json()) as { content?: string };
+			return data.content ?? "";
+		} catch (e) {
+			handleFetchError((e as Error).message, params);
+			return "";
+		}
+	};
+};


### PR DESCRIPTION
## Summary
This PR adds the ability to preview template file contents directly from the UI. Users can now click a preview button to view the content of selected template files in a modal dialog.

## Key Changes
- **New Component**: `TemplatePreviewButton` - A button component that triggers a modal dialog to display template file contents
- **New Hook**: `useTemplateLoadContent` - Custom hook that handles fetching template file content from the backend API
- **Integration**: Added preview button to the template group form element in `CommandFormElement.tsx`

## Implementation Details
- The preview button appears next to template group form fields when a template path is selected
- Template content is loaded asynchronously via a POST request to the `template/load` endpoint
- The modal dialog displays the template file name and content in a scrollable `<pre>` element with word wrapping
- Loading state is shown while content is being fetched
- Error handling is implemented via the existing `handleFetchError` utility
- The dialog uses the native HTML `<dialog>` element with `showModal()` for proper modal behavior

https://claude.ai/code/session_012U7cSiK3uGN2ABDXRorzMV