### PR TITLE
Add bottom padding to form element

### DIFF
--- a/tauri/src/app/main/Form.tsx
+++ b/tauri/src/app/main/Form.tsx
@@ -24,7 +24,7 @@ export default function Form() {
 		<div className="p-2 rounded-lg mt-10">
 				<form
 					id={formid}
-					className="grid gap-6 mb-6 grid-cols-1"
+					className="grid gap-6 mb-6 pb-20 grid-cols-1"
 					noValidate
 					onSubmit={(e) => {
 						e.preventDefault();


### PR DESCRIPTION
## Summary
Added bottom padding to the main form element to improve spacing and prevent content from being cut off at the bottom of the viewport.

## Changes
- Added `pb-20` (padding-bottom) Tailwind CSS class to the form element in Form.tsx

## Details
This change ensures there is adequate spacing between the form content and the bottom of the page/viewport, improving the user experience when scrolling and interacting with form elements near the bottom of the page.

https://claude.ai/code/session_01PqPShfV1cocGWcwViVagAR