### PR TITLE
Refactor ResourceFileDialog to use showModal API

### DIFF
--- a/tauri/src/components/dialog/ResourceFileDialog.tsx
+++ b/tauri/src/components/dialog/ResourceFileDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BlueButton, WhiteButton } from "../element/Button";
 import { ControllTextBox, InputLabel } from "../element/Input";
 
@@ -15,10 +15,14 @@ export default function ResourceFileDialog({
 	fileName,
 	handleSave,
 }: DialogProps) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	useEffect(() => {
+		dialogRef.current?.showModal();
+	}, []);
 	const [value, setValue] = useState(fileName);
 	return (
 		<dialog
-			open
+			ref={dialogRef}
 			onClose={handleDialogClose}
 			className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
 		>

--- a/tauri/src/components/dialog/ResourceFileDialog.tsx
+++ b/tauri/src/components/dialog/ResourceFileDialog.tsx
@@ -16,10 +16,10 @@ export default function ResourceFileDialog({
 	handleSave,
 }: DialogProps) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
+	const [value, setValue] = useState(fileName);
 	useEffect(() => {
 		dialogRef.current?.showModal();
 	}, []);
-	const [value, setValue] = useState(fileName);
 	return (
 		<dialog
 			ref={dialogRef}


### PR DESCRIPTION
## Summary
Refactored the ResourceFileDialog component to use the HTML Dialog API's `showModal()` method instead of the `open` attribute for better control over dialog presentation.

## Key Changes
- Added `useRef` hook to create a reference to the dialog element
- Added `useEffect` hook to programmatically call `showModal()` on component mount
- Replaced the `open` attribute with a `ref` attribute pointing to the dialog element
- Updated imports to include `useEffect` and `useRef` from React

## Implementation Details
The dialog now uses the imperative `showModal()` API instead of the declarative `open` attribute. This approach provides better control over when the modal is displayed and allows for more sophisticated dialog lifecycle management if needed in the future. The effect runs once on mount (empty dependency array) to ensure the modal is shown when the component is first rendered.

https://claude.ai/code/session_01QAWGjkykdtK1V6Dn1DKsb5