### PR TITLE
Fix button alignment and CSS class syntax in StartupForm

### DIFF
--- a/tauri/src/app/startup/StartupForm.tsx
+++ b/tauri/src/app/startup/StartupForm.tsx
@@ -110,7 +110,7 @@ const InputField: React.FC<{
 				id={`${id}_label`}
 				text={label}
 				required={required}
-				wStyle="col-start-1 p-2.5 w=1/6"
+				wStyle="col-start-1 p-2.5 w-1/6"
 			/>
 			<div className="flex col-start-2 col-span-4 p-2">
 				<ControllTextBox

--- a/tauri/src/app/startup/StartupForm.tsx
+++ b/tauri/src/app/startup/StartupForm.tsx
@@ -88,7 +88,7 @@ const StartupForm: React.FC<{ onSelect: () => void; onClose?: () => void }> = ({
 					error={errors.resultBase}
 				/>
 			</div>
-			<div className="flex items-center justify-end gap-2">
+			<div className="flex items-center justify-center gap-2">
 				<BlueButton title="confirm" handleClick={() => handleSelect()} />
 				{onClose && <WhiteButton title="Close" handleClick={onClose} />}
 			</div>

--- a/tauri/src/app/startup/StartupForm.tsx
+++ b/tauri/src/app/startup/StartupForm.tsx
@@ -88,7 +88,7 @@ const StartupForm: React.FC<{ onSelect: () => void; onClose?: () => void }> = ({
 					error={errors.resultBase}
 				/>
 			</div>
-			<div className="flex items-center justify-center gap-2">
+			<div className={`flex items-center gap-2 ${onClose ? "justify-end" : "justify-center"}`}>
 				<BlueButton title="confirm" handleClick={() => handleSelect()} />
 				{onClose && <WhiteButton title="Close" handleClick={onClose} />}
 			</div>


### PR DESCRIPTION
## Summary
This PR fixes two UI issues in the StartupForm component: conditional button alignment and a CSS class syntax error.

## Key Changes
- **Button alignment**: Updated the button container to conditionally use `justify-end` when the close button is present, or `justify-center` when it's not. This ensures proper spacing whether the form is used as a modal (with close button) or standalone.
- **CSS class fix**: Corrected the `wStyle` prop in InputField from `w=1/6` to `w-1/6` to use valid Tailwind CSS syntax (hyphen instead of equals sign).

## Implementation Details
- The button container now uses a template literal with conditional logic to apply the appropriate justify class based on the `onClose` prop
- The width class now properly follows Tailwind's naming convention for fractional widths

https://claude.ai/code/session_01GCQJnqH7E62GNYc9GmVrwF