### PR TITLE
Refactor Header component to use DirectoryButton

### DIFF
--- a/tauri/src/app/main/Header.tsx
+++ b/tauri/src/app/main/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { DirIcon } from "../../components/element/Icon";
+import { DirectoryButton } from "../../components/element/ButtonIcon";
 import { useSelectParameter } from "../../context/SelectParameterProvider";
 import StartupForm from "../startup/StartupForm";
 
@@ -11,14 +11,7 @@ export default function Header() {
 			<div className="flex items-center justify-between">
 				<div className="flex items-center justify-start rtl:justify-end gap-2">
 					<h1>DBunit CLI</h1>
-					<button
-						type="button"
-						className="p-1 rounded-lg hover:bg-gray-200 transition duration-100"
-						onClick={() => setShowWorkspaceDialog(true)}
-						title="ChangeWorkspace"
-					>
-						<DirIcon title="ChangeWorkspace" />
-					</button>
+					<DirectoryButton title="ChangeWorkspace" handleClick={() => setShowWorkspaceDialog(true)} />
 				</div>
 				{selected.name && <h1>{`${selected.command}: ${selected.name}`}</h1>}
 			</div>


### PR DESCRIPTION
## Summary
Refactored the Header component to use a reusable `DirectoryButton` component instead of implementing the button inline with an icon.

## Key Changes
- Replaced inline button implementation with `DirectoryButton` component from `ButtonIcon` module
- Updated import statement from `DirIcon` to `DirectoryButton`
- Simplified Header component by removing button markup and styling (className, onClick handler, title attribute)
- Moved button logic to the new `DirectoryButton` component with `handleClick` prop

## Implementation Details
- The `DirectoryButton` component now encapsulates the button styling and behavior
- Props passed to `DirectoryButton`: `title="ChangeWorkspace"` and `handleClick={() => setShowWorkspaceDialog(true)}`
- This change improves code reusability and maintainability by centralizing the directory button implementation

https://claude.ai/code/session_01Nfp6UeiMYR5vTy5MM8GWWg