### PR TITLE
Add aria-label support to Button and ButtonIcon components

### DIFF
--- a/tauri/src/components/element/Button.tsx
+++ b/tauri/src/components/element/Button.tsx
@@ -58,12 +58,14 @@ export function Button(props: {
     , children: ReactNode
     , disabled?: boolean
     , id?: string
+    , ariaLabel?: string
     , handleClick: React.MouseEventHandler<HTMLButtonElement>
 }) {
     return (
         <button
             type="button"
             id={props.id}
+            aria-label={props.ariaLabel}
             disabled={props.disabled}
             className={`${props.buttonstyle}
                          ${props.textstyle}

--- a/tauri/src/components/element/ButtonIcon.tsx
+++ b/tauri/src/components/element/ButtonIcon.tsx
@@ -42,7 +42,7 @@ export function IconButton({ iconType, title, handleClick }: IconButtonProps & {
     const IconComponent = IconComponents[iconType];
 
     return (
-        <ButtonIcon title="" handleClick={handleClick}>
+        <ButtonIcon title={finalTitle} handleClick={handleClick}>
             <IconComponent title={finalTitle} />
         </ButtonIcon>
     );
@@ -118,6 +118,7 @@ export function ButtonIcon(props: {
             bgcolor=""
             textstyle="text-gray-500 hover:text-blue-600"
             border="outline-hidden"
+            ariaLabel={props.title || undefined}
             handleClick={props.handleClick}
         >
             {props.children}


### PR DESCRIPTION
## Summary
This PR improves accessibility by adding `aria-label` support to the Button and ButtonIcon components, enabling screen readers to properly announce button purposes.

## Key Changes
- Added `ariaLabel` optional prop to the `Button` component and connected it to the native `aria-label` HTML attribute
- Added `ariaLabel` prop to `ButtonIcon` component, passing the button title as the aria-label value
- Fixed `IconButton` to pass the `finalTitle` to `ButtonIcon` instead of an empty string, ensuring proper accessibility labeling

## Implementation Details
- The `ariaLabel` prop is optional and only applied when provided, maintaining backward compatibility
- In `ButtonIcon`, the aria-label is set to `props.title || undefined`, ensuring the label is only applied when a title exists
- The `IconButton` component now correctly propagates the title through to the underlying `ButtonIcon` for accessibility purposes

https://claude.ai/code/session_01FmVWFEmKqwLdJRfbwHmavd