### PR TITLE
Refactor JDBC form buttons to use blue dropdown menu pattern

### DIFF
--- a/tauri/.claude/rules/ui-consistency.md
+++ b/tauri/.claude/rules/ui-consistency.md
@@ -28,16 +28,23 @@ paths:
 
 ## テキストボックス横のアイコンボタン
 
-- 配色は**グレーの IconButton 系**（`EditButton`, `PreviewButton`, `FileButton`, `SettingButton` 等）で統一
-- `ButtonWithIcon`（青背景）はテキストボックス横には使わない
-- ボタン並び順: [プレビュー/編集系] → [削除系（`RemoveButton`）] → [それ以外（ファイル/ディレクトリ選択系）]
+- **配色はブルー（`BlueButtonIcon` 系）でラベルなし**に統一
+- グレーの `IconButton` 系（`EditButton`, `FileButton` 等）はテキストボックス横に直接使わない
+- **アイコンが2つ以上必要な場合**は `BlueSettingButton` のドロップダウンメニューにまとめる
+- ドロップダウン内のアイテムはグレーの `IconButton` 系（テキストラベル付き）でよい
 
-### アイコンボタンの用途別コンポーネント
+### テキストボックス横ボタンの用途別コンポーネント
+
+| 状況 | コンポーネント | 例 |
+|------|--------------|-----|
+| アイコン1つ（単一操作） | `BlueEditButton` 等 `BlueButtonIcon` 系 | JdbcUrlBuilderButton |
+| アイコン2つ以上（複数操作） | `BlueSettingButton`（ドロップダウン） | CommandFormElement の DropDownMenu, JdbcPropertiesDropDownMenu |
+
+### ドロップダウン内のアイコンボタン
 
 | 用途 | コンポーネント | 例 |
 |------|--------------|-----|
-| 複数の選択肢を持つドロップダウンメニュー | `SettingButton` | CommandFormElement の DropDownMenu |
-| ダイアログを起動（編集・ビルダー系） | `EditButton` | JdbcUrlBuilderButton, TemplatePreviewButton |
+| ダイアログを起動（編集・ビルダー系） | `EditButton` | DatasetSettingEditButton, TemplatePreviewButton |
 | ダイアログを起動（プレビュー・参照系） | `PreviewButton` | JdbcPropertiesPreviewButton |
 | ファイル選択ダイアログ | `FileButton` | FileChooser の FileButton |
 | ディレクトリ選択ダイアログ | `DirectoryButton` | DirectoryChooser の DirectoryButton |

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { Fragment, useEffect, useRef, useState } from "react";
-import { ExpandButton, SettingButton } from "../../components/element/ButtonIcon";
+import { BlueSettingButton, ExpandButton } from "../../components/element/ButtonIcon";
 import {
 	CheckBox,
 	ControllTextBox,
@@ -260,7 +260,7 @@ function DropDownMenu({
 
 	return (
 		<div className="relative mr-24" ref={buttonRef}>
-			<SettingButton handleClick={() => setShowMenu(!showMenu)} />
+			<BlueSettingButton handleClick={() => setShowMenu(!showMenu)} />
 			{showMenu && (
 				<div
 					ref={menuRef}

--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -2,10 +2,12 @@ import {
 	type Dispatch,
 	type SetStateAction,
 	useCallback,
+	useEffect,
+	useRef,
 	useState,
 } from "react";
 import { BlueButton } from "../../components/element/Button";
-import { EditButton, PreviewButton } from "../../components/element/ButtonIcon";
+import { BlueEditButton, BlueSettingButton, PreviewButton } from "../../components/element/ButtonIcon";
 import {
 	ControllTextBox,
 	InputLabel,
@@ -122,8 +124,6 @@ function JdbcTextField({
 	onValueChange: (name: string, value: string) => void;
 	onApplyValues?: (values: Partial<Record<string, string>>) => void;
 }) {
-	const [showJdbcUrlBuilder, setShowJdbcUrlBuilder] = useState(false);
-	const [showPreview, setShowPreview] = useState(false);
 	const settings = useResourcesSettings();
 	const labelText = prefix ? `-${prefix}.${element.name}` : `-${element.name}`;
 	const id = prefix ? `${prefix}_${element.name}` : element.name;
@@ -160,34 +160,19 @@ function JdbcTextField({
 					)}
 				</div>
 				<div className="flex">
-					{isJdbcProperties && value && onApplyValues && (
-						<JdbcPropertiesPreviewButton
-							path={value}
-							showDialog={showPreview}
-							setShowDialog={setShowPreview}
-							onApplyValues={onApplyValues}
-						/>
-					)}
-					{isJdbcProperties && value && (
-						<RemoveJdbcPropertiesButton
-							path={value}
-							setPath={(v) => onValueChange(element.name, v)}
-						/>
-					)}
 					{isJdbcProperties && (
-						<FileChooser
+						<JdbcPropertiesDropDownMenu
 							prefix={prefix}
 							element={element}
 							path={value}
 							setPath={setPath}
+							onApplyValues={onApplyValues}
 						/>
 					)}
 					{isJdbcUrl && (
 						<JdbcUrlBuilderButton
 							path={value}
 							setPath={setPath}
-							showDialog={showJdbcUrlBuilder}
-							setShowDialog={setShowJdbcUrlBuilder}
 						/>
 					)}
 				</div>
@@ -198,15 +183,12 @@ function JdbcTextField({
 
 function JdbcPropertiesPreviewButton({
 	path,
-	showDialog,
-	setShowDialog,
 	onApplyValues,
 }: {
 	path: string;
-	showDialog: boolean;
-	setShowDialog: (show: boolean) => void;
 	onApplyValues: (values: Partial<Record<string, string>>) => void;
 }) {
+	const [showDialog, setShowDialog] = useState(false);
 	return (
 		<>
 			<PreviewButton handleClick={() => setShowDialog(true)} />
@@ -227,17 +209,14 @@ function JdbcPropertiesPreviewButton({
 function JdbcUrlBuilderButton({
 	path,
 	setPath,
-	showDialog,
-	setShowDialog,
 }: {
 	path: string;
 	setPath: Dispatch<SetStateAction<string>>;
-	showDialog: boolean;
-	setShowDialog: Dispatch<SetStateAction<boolean>>;
 }) {
+	const [showDialog, setShowDialog] = useState(false);
 	return (
 		<>
-			<EditButton handleClick={() => setShowDialog(true)} />
+			<BlueEditButton handleClick={() => setShowDialog(true)} />
 			{showDialog && (
 				<JdbcUrlBuilderDialog
 					currentUrl={path}
@@ -249,6 +228,98 @@ function JdbcUrlBuilderButton({
 				/>
 			)}
 		</>
+	);
+}
+
+function JdbcPropertiesDropDownMenu({
+	prefix,
+	element,
+	path,
+	setPath,
+	onApplyValues,
+}: {
+	prefix: string;
+	element: CommandParam;
+	path: string;
+	setPath: Dispatch<SetStateAction<string>>;
+	onApplyValues?: (values: Partial<Record<string, string>>) => void;
+}) {
+	const [showMenu, setShowMenu] = useState(false);
+	const buttonRef = useRef<HTMLDivElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
+	const [menuPosition, setMenuPosition] = useState<"right" | "left">("right");
+
+	useEffect(() => {
+		if (showMenu && buttonRef.current) {
+			const rect = buttonRef.current.getBoundingClientRect();
+			const menuWidth = 96;
+			if (rect.right + menuWidth > window.innerWidth) {
+				setMenuPosition("left");
+			} else {
+				setMenuPosition("right");
+			}
+		}
+		function handleClickOutside(event: MouseEvent) {
+			if (
+				menuRef.current &&
+				!menuRef.current.contains(event.target as Node) &&
+				buttonRef.current &&
+				!buttonRef.current.contains(event.target as Node)
+			) {
+				setShowMenu(false);
+			}
+		}
+		if (showMenu) {
+			document.addEventListener("mousedown", handleClickOutside);
+			return () => {
+				document.removeEventListener("mousedown", handleClickOutside);
+			};
+		}
+	}, [showMenu]);
+
+	return (
+		<div className="relative mr-24" ref={buttonRef}>
+			<BlueSettingButton handleClick={() => setShowMenu(!showMenu)} />
+			{showMenu && (
+				<div
+					ref={menuRef}
+					className="absolute z-50 p-4 text-gray-900 bg-white border border-gray-100 rounded-lg shadow-md"
+					style={{
+						...(menuPosition === "right"
+							? { left: "100%", top: 0 }
+							: { right: "100%", top: 0 }),
+					}}
+				>
+					<ul className="space-y-4">
+						{path && onApplyValues && (
+							<li>
+								<JdbcPropertiesPreviewButton
+									path={path}
+									onApplyValues={onApplyValues}
+								/>
+							</li>
+						)}
+						{path && (
+							<li>
+								<RemoveJdbcPropertiesButton
+									path={path}
+									setPath={setPath}
+								/>
+							</li>
+						)}
+						<li>
+							<FileChooser
+								prefix={prefix}
+								element={element}
+								path={path}
+								setPath={setPath}
+								onSelect={() => setShowMenu(false)}
+							/>
+						</li>
+					</ul>
+				</div>
+			)}
+		</div>
 	);
 }
 

--- a/tauri/src/components/element/ButtonIcon.tsx
+++ b/tauri/src/components/element/ButtonIcon.tsx
@@ -126,3 +126,40 @@ export function ButtonIcon(props: {
         </Button>
     );
 }
+
+export function BlueButtonIcon(props: {
+    title?: string;
+    handleClick: React.MouseEventHandler<HTMLButtonElement>;
+    children: ReactNode;
+}) {
+    return (
+        <Button
+            buttonstyle="flex items-center p-2 ms-2"
+            bgcolor="bg-indigo-500 hover:bg-indigo-600"
+            textstyle=""
+            border="border border-gray-300"
+            ariaLabel={props.title || undefined}
+            handleClick={props.handleClick}
+        >
+            {props.children}
+        </Button>
+    );
+}
+
+export function BlueSettingButton(props: IconButtonProps) {
+    const title = props.title ?? 'setting';
+    return (
+        <BlueButtonIcon title={title} handleClick={props.handleClick}>
+            <SettingIcon title={title} fill="white" />
+        </BlueButtonIcon>
+    );
+}
+
+export function BlueEditButton(props: IconButtonProps) {
+    const title = props.title ?? 'edit';
+    return (
+        <BlueButtonIcon title={title} handleClick={props.handleClick}>
+            <EditIcon title={title} fill="white" />
+        </BlueButtonIcon>
+    );
+}


### PR DESCRIPTION
## Summary
Refactored the JDBC form section to consolidate multiple icon buttons into a blue dropdown menu, improving UI consistency and reducing visual clutter. This aligns with the updated UI consistency guidelines for handling multiple operations on text input fields.

## Key Changes

- **New `JdbcPropertiesDropDownMenu` component**: Consolidates preview, remove, and file chooser actions into a single `BlueSettingButton` with a dropdown menu that intelligently positions itself to avoid viewport overflow
- **Moved state management**: Moved `showDialog` state from parent (`JdbcTextField`) into child components (`JdbcPropertiesPreviewButton` and `JdbcUrlBuilderButton`) for better encapsulation
- **New blue button components**: Added `BlueButtonIcon`, `BlueSettingButton`, and `BlueEditButton` to `ButtonIcon.tsx` for consistent styling of textbox-adjacent buttons
- **Updated `JdbcUrlBuilderButton`**: Changed from gray `EditButton` to `BlueEditButton` for visual consistency
- **Updated `CommandFormElement`**: Replaced `SettingButton` with `BlueSettingButton` to match new pattern
- **Updated UI consistency guidelines**: Documented the new pattern for handling multiple operations (use `BlueSettingButton` dropdown when 2+ icons needed, single `BlueButtonIcon` variants for single operations)

## Implementation Details

- The dropdown menu uses `useRef` and `useEffect` to handle click-outside detection and dynamic positioning
- Menu position automatically switches from right to left alignment if it would overflow the viewport
- Dropdown items use gray `IconButton` variants with text labels for clarity within the menu context
- The pattern maintains backward compatibility while improving the visual hierarchy and reducing button clutter

https://claude.ai/code/session_01K2W9Vg4zBzm1p9PYPyj3yW