### PR TITLE
Refactor remove buttons into dropdown menu and standardize button naming

### DIFF
--- a/tauri/.claude/rules/ui-consistency.md
+++ b/tauri/.claude/rules/ui-consistency.md
@@ -48,7 +48,7 @@ paths:
 | ダイアログを起動（プレビュー・参照系） | `PreviewButton` | JdbcPropertiesPreviewButton |
 | ファイル選択ダイアログ | `FileButton` | FileChooser の FileButton |
 | ディレクトリ選択ダイアログ | `DirectoryButton` | DirectoryChooser の DirectoryButton |
-| リソース削除 | `RemoveButton` 系 | RemoveDatasetSettingButton 等 |
+| リソース削除 | `DeleteButton` | RemoveDatasetSettingButton 等 |
 
 ## ExpandButton の caption
 - パターン: `"<type> option"`（英語小文字）

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -1,4 +1,3 @@
-import type React from "react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { BlueSettingButton, ExpandButton } from "../../components/element/ButtonIcon";
 import {
@@ -203,11 +202,9 @@ function Text(prop: Prop) {
 							hidden={prop.hidden}
 							srcType={srcType}
 							srcInfo={srcInfo}
+							isValueInDatalist={isValueInDatalist}
 						/>
 					)}
-					{isValueInDatalist &&
-						!prop.hidden &&
-						renderRemoveButton(prop.element.name, path, setPath, srcType)}
 				</div>
 			</div>
 		</div>
@@ -222,7 +219,8 @@ function DropDownMenu({
 	hidden,
 	srcType,
 	srcInfo,
-}: FileProp & { srcType?: string; datasources?: string[] }) {
+	isValueInDatalist,
+}: FileProp & { srcType?: string; datasources?: string[]; isValueInDatalist?: boolean }) {
 	const [showMenu, setShowMenu] = useState(false);
 	const { connectionOk } = useJdbcConnectionState();
 	const buttonRef = useRef<HTMLDivElement>(null);
@@ -259,7 +257,7 @@ function DropDownMenu({
 	}, [showMenu]);
 
 	return (
-		<div className="relative mr-24" ref={buttonRef}>
+		<div className="relative" ref={buttonRef}>
 			<BlueSettingButton handleClick={() => setShowMenu(!showMenu)} />
 			{showMenu && (
 				<div
@@ -328,6 +326,21 @@ function DropDownMenu({
 									setPath={setPath}
 									onSelect={() => setShowMenu(false)}
 								/>
+							</li>
+						)}
+						{element.name === "setting" && !hidden && isValueInDatalist && (
+							<li>
+								<RemoveDatasetSettingButton path={path} setPath={setPath} />
+							</li>
+						)}
+						{element.name === "xlsxSchema" && !hidden && isValueInDatalist && (
+							<li>
+								<RemoveXlsxSchemaButton path={path} setPath={setPath} />
+							</li>
+						)}
+						{(srcType === "sql" || srcType === "table") && !hidden && isValueInDatalist && (
+							<li>
+								<RemoveSqlEditorButton path={path} setPath={setPath} type={srcType as QueryDatasourceType} />
 							</li>
 						)}
 					</ul>
@@ -403,27 +416,4 @@ function getId(prefix: string, name: string): string {
 }
 function getName(prefix: string, name: string): string {
 	return prefix ? `-${prefix}.${name}` : `-${name}`;
-}
-function renderRemoveButton(
-	elementName: string,
-	path: string,
-	setPath: (path: string) => void,
-	srcType?: string,
-): React.ReactElement | null {
-	if (elementName === "setting") {
-		return <RemoveDatasetSettingButton path={path} setPath={setPath} />;
-	}
-	if (elementName === "xlsxSchema") {
-		return <RemoveXlsxSchemaButton path={path} setPath={setPath} />;
-	}
-	if (srcType === "sql" || srcType === "table") {
-		return (
-			<RemoveSqlEditorButton
-				path={path}
-				setPath={setPath}
-				type={srcType as QueryDatasourceType}
-			/>
-		);
-	}
-	return null;
 }

--- a/tauri/src/app/settings/ResourceEditButton.tsx
+++ b/tauri/src/app/settings/ResourceEditButton.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useState } from 'react';
-import { EditButton, RemoveButton } from '../../components/element/ButtonIcon';
+import { DeleteButton, EditButton } from '../../components/element/ButtonIcon';
 
 /**
  * ResourcesEditButton と RemoveResource が共通で受け取るプロパティ
@@ -62,7 +62,7 @@ export function RemoveResource({ deleteResource, path, setPath }: RemoveResource
         }
     };
 
-    return <RemoveButton title="" handleClick={handleRemove} />;
+    return <DeleteButton title="" handleClick={handleRemove} />;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR refactors the remove button UI pattern by moving remove buttons from standalone elements into a dropdown menu, and standardizes button naming conventions across the codebase by replacing `RemoveButton` with `DeleteButton`.

## Key Changes
- **CommandFormElement.tsx**: 
  - Removed unused `React` type import
  - Moved remove button rendering logic from the `Text` component into the `DropDownMenu` component
  - Added `isValueInDatalist` prop to `DropDownMenu` to conditionally render remove buttons
  - Removed the `renderRemoveButton` helper function and integrated its logic directly into the dropdown menu's list items
  - Removed `mr-24` margin class from the dropdown container
  - Remove buttons for dataset settings, xlsx schema, and SQL/table sources now appear as menu items in the dropdown

- **ResourceEditButton.tsx**:
  - Updated import to use `DeleteButton` instead of `RemoveButton`
  - Changed `RemoveResource` component to render `DeleteButton` instead of `RemoveButton`

- **ui-consistency.md**:
  - Updated documentation to reflect the new standard: `DeleteButton` is now the standard component for resource deletion operations

## Implementation Details
The refactoring consolidates the remove button UI into the existing dropdown menu pattern, reducing visual clutter and providing a more organized interface. The conditional rendering logic ensures remove buttons only appear when appropriate (when `isValueInDatalist` is true and the element is not hidden).

https://claude.ai/code/session_01E96QaG44azpUm7cVgeeuJ4