### PR TITLE
Refactor template editing to support creation and deletion

### DIFF
--- a/tauri/.claude/rules/ui-consistency.md
+++ b/tauri/.claude/rules/ui-consistency.md
@@ -44,7 +44,7 @@ paths:
 
 | 用途 | コンポーネント | 例 |
 |------|--------------|-----|
-| ダイアログを起動（編集・ビルダー系） | `EditButton` | DatasetSettingEditButton, TemplatePreviewButton |
+| ダイアログを起動（編集・ビルダー系） | `EditButton` | DatasetSettingEditButton, TemplateEditButton |
 | ダイアログを起動（プレビュー・参照系） | `PreviewButton` | JdbcPropertiesPreviewButton |
 | リソース削除 | `DeleteButton` | RemoveDatasetSettingButton 等 |
 | ファイル選択ダイアログ | `FileButton` | FileChooser の FileButton |

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -24,9 +24,9 @@ import JdbcTableSelectorButton from "../settings/JdbcTableSelectorButton";
 import SqlEditorButton, {
 	RemoveSqlEditorButton,
 } from "../settings/SqlEditorButton";
-import TemplatePreviewButton, {
+import TemplateEditButton, {
 	RemoveTemplateButton,
-} from "../settings/TemplatePreviewButton";
+} from "../settings/TemplateEditButton";
 import XlsxSchemaEditButton, {
 	RemoveXlsxSchemaButton,
 } from "../settings/XlsxSchemaEditButton";
@@ -328,7 +328,7 @@ function DropDownMenu({
 							)}
 						{element.name === "templateGroup" && !hidden && (
 							<li>
-								<TemplatePreviewButton path={path} setPath={setPath} />
+								<TemplateEditButton path={path} setPath={setPath} />
 							</li>
 						)}
 						{element.name === "templateGroup" && !hidden && isValueInDatalist && (

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -24,7 +24,9 @@ import JdbcTableSelectorButton from "../settings/JdbcTableSelectorButton";
 import SqlEditorButton, {
 	RemoveSqlEditorButton,
 } from "../settings/SqlEditorButton";
-import TemplatePreviewButton from "../settings/TemplatePreviewButton";
+import TemplatePreviewButton, {
+	RemoveTemplateButton,
+} from "../settings/TemplatePreviewButton";
 import XlsxSchemaEditButton, {
 	RemoveXlsxSchemaButton,
 } from "../settings/XlsxSchemaEditButton";
@@ -324,9 +326,14 @@ function DropDownMenu({
 									<JdbcTableSelectorButton path={path} setPath={setPath} />
 								</li>
 							)}
-						{element.name === "templateGroup" && !hidden && path && (
+						{element.name === "templateGroup" && !hidden && (
 							<li>
-								<TemplatePreviewButton path={path} />
+								<TemplatePreviewButton path={path} setPath={setPath} />
+							</li>
+						)}
+						{element.name === "templateGroup" && !hidden && isValueInDatalist && (
+							<li>
+								<RemoveTemplateButton path={path} setPath={setPath} />
 							</li>
 						)}
 						{element.name === "setting" && !hidden && isValueInDatalist && (

--- a/tauri/src/app/settings/TemplateEditButton.tsx
+++ b/tauri/src/app/settings/TemplateEditButton.tsx
@@ -4,7 +4,7 @@ import { SettingDialog } from "../../components/dialog/SettingDialog";
 import { useTemplateLoadContent, useTemplateSaveContent, useDeleteTemplate } from "../../hooks/useTemplate";
 import { RemoveResource, type ResourceEditButtonProp } from "./ResourceEditButton";
 
-function TemplatePreviewDialog({
+function TemplateEditDialog({
 	name,
 	setPath,
 	handleDialogClose,
@@ -74,7 +74,7 @@ function TemplatePreviewDialog({
 	);
 }
 
-export default function TemplatePreviewButton({
+export default function TemplateEditButton({
 	path,
 	setPath,
 }: {
@@ -86,7 +86,7 @@ export default function TemplatePreviewButton({
 		<>
 			<EditButton handleClick={() => setShowDialog(true)} />
 			{showDialog && (
-				<TemplatePreviewDialog
+				<TemplateEditDialog
 					name={path}
 					setPath={setPath}
 					handleDialogClose={() => setShowDialog(false)}

--- a/tauri/src/app/settings/TemplatePreviewButton.tsx
+++ b/tauri/src/app/settings/TemplatePreviewButton.tsx
@@ -1,25 +1,43 @@
 import { useEffect, useState } from "react";
 import { EditButton } from "../../components/element/ButtonIcon";
 import { SettingDialog } from "../../components/dialog/SettingDialog";
-import { useTemplateLoadContent, useTemplateSaveContent } from "../../hooks/useTemplate";
+import { useTemplateLoadContent, useTemplateSaveContent, useDeleteTemplate } from "../../hooks/useTemplate";
+import { RemoveResource, type ResourceEditButtonProp } from "./ResourceEditButton";
 
 function TemplatePreviewDialog({
 	name,
+	setPath,
 	handleDialogClose,
 }: {
 	name: string;
+	setPath?: (path: string) => void;
 	handleDialogClose: () => void;
 }) {
+	const [fileNameInput, setFileNameInput] = useState("");
 	const [content, setContent] = useState<string | null>(null);
 	const loadContent = useTemplateLoadContent();
 	const saveContent = useTemplateSaveContent();
 
 	useEffect(() => {
-		loadContent(name).then(setContent);
-	}, [name]);
+		if (!name) {
+			setContent("");
+			return;
+		}
+		let cancelled = false;
+		loadContent(name).then((result) => {
+			if (!cancelled) {
+				setContent(result);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [name, loadContent]);
 
 	const handleCommit = async (newContent: string) => {
-		await saveContent(name, newContent);
+		const effectiveName = name || fileNameInput;
+		await saveContent(effectiveName, newContent);
+		setPath?.(effectiveName);
 		handleDialogClose();
 	};
 
@@ -32,7 +50,16 @@ function TemplatePreviewDialog({
 		>
 			<div className="w-[800px]">
 				<h2 className="text-lg font-bold mb-2">Template File Edit</h2>
-				<p className="text-sm text-gray-500 mb-3 break-all">{name}</p>
+				{name ? (
+					<p className="text-sm text-gray-500 mb-3 break-all">{name}</p>
+				) : (
+					<input
+						className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-2 w-full mb-3 focus-visible:ring-3 ring-indigo-300"
+						placeholder="File name"
+						value={fileNameInput}
+						onChange={(e) => setFileNameInput(e.target.value)}
+					/>
+				)}
 				{content === null ? (
 					<p className="text-sm text-gray-400 p-3">Loading...</p>
 				) : (
@@ -47,7 +74,13 @@ function TemplatePreviewDialog({
 	);
 }
 
-export default function TemplatePreviewButton({ path }: { path: string }) {
+export default function TemplatePreviewButton({
+	path,
+	setPath,
+}: {
+	path: string;
+	setPath?: (path: string) => void;
+}) {
 	const [showDialog, setShowDialog] = useState(false);
 	return (
 		<>
@@ -55,9 +88,15 @@ export default function TemplatePreviewButton({ path }: { path: string }) {
 			{showDialog && (
 				<TemplatePreviewDialog
 					name={path}
+					setPath={setPath}
 					handleDialogClose={() => setShowDialog(false)}
 				/>
 			)}
 		</>
 	);
+}
+
+export function RemoveTemplateButton({ path, setPath }: ResourceEditButtonProp) {
+	const deleteTemplate = useDeleteTemplate();
+	return <RemoveResource path={path} setPath={setPath} deleteResource={deleteTemplate} />;
 }

--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -1,5 +1,8 @@
 import { useEnviroment } from "../context/EnviromentProvider";
+import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import { fetchData, handleFetchError } from "../utils/fetchUtils";
+
+type OperationResult = "success" | "failed";
 
 export const useTemplateLoadContent = () => {
 	const { apiUrl } = useEnviroment();
@@ -19,6 +22,30 @@ export const useTemplateLoadContent = () => {
 		} catch (e) {
 			handleFetchError((e as Error).message, params);
 			return "";
+		}
+	};
+};
+
+export const useDeleteTemplate = () => {
+	const { apiUrl } = useEnviroment();
+	const setResourcesSettings = useSetResourcesSettings();
+	return async (name: string): Promise<OperationResult> => {
+		const params = {
+			endpoint: `${apiUrl}template/delete`,
+			options: {
+				method: "POST",
+				headers: { "Content-Type": "text/plain" },
+				body: name,
+			},
+		};
+		try {
+			const response = await fetchData(params);
+			const settings = (await response.json()) as string[];
+			setResourcesSettings((current) => current.with({ templateFiles: settings }));
+			return "success";
+		} catch (e) {
+			handleFetchError((e as Error).message, params);
+			return "failed";
 		}
 	};
 };


### PR DESCRIPTION
## Summary
Renamed and enhanced the template preview/edit functionality to support creating new templates and deleting existing ones. The component now handles both editing existing templates and creating new ones from scratch.

## Key Changes
- **Renamed `TemplatePreviewButton` to `TemplateEditButton`**: Better reflects the component's purpose as an editor rather than just a preview tool
- **Added template creation support**: The edit dialog now allows creating new templates by accepting a file name input when no existing template is selected
- **Added `RemoveTemplateButton` component**: New button for deleting templates with proper state management
- **Implemented `useDeleteTemplate` hook**: New hook that calls the template delete API endpoint and updates the workspace resources settings
- **Enhanced dialog logic**: 
  - Shows file name input field for new templates
  - Shows file path display for existing templates
  - Properly handles the `setPath` callback to update parent component state after save/create operations
- **Updated `CommandFormElement` usage**: 
  - Now shows edit button for all template groups (not just when path exists)
  - Added separate remove button that only appears when a template is selected
- **Updated documentation**: Fixed UI consistency guide to reference the renamed component

## Implementation Details
- The `TemplateEditDialog` component manages loading, editing, and saving template content
- Cancellation logic prevents state updates after unmount during async operations
- The delete operation updates the workspace resources settings to reflect the removed template
- Both edit and delete operations properly manage dialog state and parent component callbacks

https://claude.ai/code/session_01USMjqGB1pdur6UJAs8bvRF