### PR TITLE
Update template save to sync resource settings

### DIFF
--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -52,6 +52,7 @@ export const useDeleteTemplate = () => {
 
 export const useTemplateSaveContent = () => {
 	const { apiUrl } = useEnviroment();
+	const setResourcesSettings = useSetResourcesSettings();
 	return async (name: string, content: string): Promise<void> => {
 		const params = {
 			endpoint: `${apiUrl}template/save`,
@@ -62,7 +63,9 @@ export const useTemplateSaveContent = () => {
 			},
 		};
 		try {
-			await fetchData(params);
+			const response = await fetchData(params);
+			const settings = (await response.json()) as string[];
+			setResourcesSettings((current) => current.with({ templateFiles: settings }));
 		} catch (e) {
 			handleFetchError((e as Error).message, params);
 		}


### PR DESCRIPTION
## Summary
Updated the `useTemplateSaveContent` hook to persist template file settings after saving template content.

## Key Changes
- Added `setResourcesSettings` hook to update resource settings state
- Modified the template save endpoint response handling to parse the returned template files list
- Updated resource settings with the new template files array after successful save operation

## Implementation Details
The hook now:
1. Captures the response from the `fetchData` call when saving template content
2. Parses the response as a JSON array of strings (template files)
3. Updates the resource settings state with the returned template files using the immutable `with()` method

This ensures that the UI stays in sync with the server's template file state after a save operation.

https://claude.ai/code/session_013R1gLSBymKfS76pb1w3Att