### PR TITLE
fix(tauri): metadataSetting を datasetSettings にリネームしてバックエンドの JSON キーに…

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -163,7 +163,7 @@ function Text(prop: Prop) {
 	if (element.name === "src" && isSqlRelatedType(srcType ?? "")) {
 		resourceFiles = settings.querys(srcType);
 	} else if (element.name === "setting") {
-		resourceFiles = settings.metadataSetting;
+		resourceFiles = settings.datasetSettings;
 	} else if (element.name === "xlsxSchema") {
 		resourceFiles = settings.xlsxSchemas;
 	} else if (element.name === "templateGroup") {

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -85,7 +85,7 @@ async function saveDatasetSettings(
 		.then((response) => response.json())
 		.then((settings: string[]) => {
 			setResourcesSettings((current) =>
-				current.with({ metadataSetting: settings }),
+				current.with({ datasetSettings: settings }),
 			);
 			return "success" as OperationResult;
 		})
@@ -113,7 +113,7 @@ async function deleteDatasetSettings(
 		.then((response) => response.json())
 		.then((settings: string[]) => {
 			setResourcesSettings((current) =>
-				current.with({ metadataSetting: settings }),
+				current.with({ datasetSettings: settings }),
 			);
 			return "success" as OperationResult;
 		})

--- a/tauri/src/model/WorkspaceResources.ts
+++ b/tauri/src/model/WorkspaceResources.ts
@@ -106,7 +106,7 @@ export class ParameterList {
 	}
 }
 export type ResourcesSettingsBuilder = {
-	metadataSetting?: string[];
+	datasetSettings?: string[];
 	xlsxSchemas?: string[];
 	jdbcFiles?: string[];
 	templateFiles?: string[];
@@ -119,13 +119,13 @@ export class ResourcesSettings {
 	static from(builder: ResourcesSettingsBuilder): ResourcesSettings {
 		return new ResourcesSettings(builder);
 	}
-	readonly metadataSetting: string[];
+	readonly datasetSettings: string[];
 	readonly xlsxSchemas: string[];
 	readonly jdbcFiles: string[];
 	readonly templateFiles: string[];
 	readonly queryFiles: QueryFiles;
 	constructor(builder: ResourcesSettingsBuilder) {
-		this.metadataSetting = builder.metadataSetting ?? [];
+		this.datasetSettings = builder.datasetSettings ?? [];
 		this.xlsxSchemas = builder.xlsxSchemas ?? [];
 		this.jdbcFiles = builder.jdbcFiles ?? [];
 		this.templateFiles = builder.templateFiles ?? [];

--- a/tauri/src/tests/hooks/useDatasetSettings.test.tsx
+++ b/tauri/src/tests/hooks/useDatasetSettings.test.tsx
@@ -84,11 +84,11 @@ describe('DatasetSettingsProviderのテスト', () => {
                 return { resources, saveDatasetSettings }
             }, { wrapper });
             await act(async () => {rerender()});
-            expect(result.current.resources.metadataSetting).toStrictEqual(mockWorkspaceResources.resources.metadataSetting);
+            expect(result.current.resources.datasetSettings).toStrictEqual(mockWorkspaceResources.resources.datasetSettings);
             await act(async () => {
                 result.current.saveDatasetSettings('test-setting', DatasetSettings.create());
             });
-            expect(result.current.resources.metadataSetting).toStrictEqual(mockUpdatedSettings);
+            expect(result.current.resources.datasetSettings).toStrictEqual(mockUpdatedSettings);
         });
     });
 
@@ -100,11 +100,11 @@ describe('DatasetSettingsProviderのテスト', () => {
                 return { resources, deleteDatasetSettings }
             }, { wrapper });
             await act(async () => {rerender()});
-            expect(result.current.resources.metadataSetting).toStrictEqual(mockWorkspaceResources.resources.metadataSetting);
+            expect(result.current.resources.datasetSettings).toStrictEqual(mockWorkspaceResources.resources.datasetSettings);
             await act(async () => {
                 result.current.deleteDatasetSettings('test-setting');
             });
-            expect(result.current.resources.metadataSetting).toStrictEqual(mockRemainingSettings);
+            expect(result.current.resources.datasetSettings).toStrictEqual(mockRemainingSettings);
         });
     });
 });

--- a/tauri/src/tests/setup.tsx
+++ b/tauri/src/tests/setup.tsx
@@ -23,7 +23,7 @@ export const workspaceResourcesFixture: WorkspaceResources = {
 		parameterize: ['param1'],
 	},
 	resources: ResourcesSettings.from({
-		metadataSetting: ['setting1'],
+		datasetSettings: ['setting1'],
 		xlsxSchemas: ['schema1'],
 		jdbcFiles: ['jdbc1'],
 		templateFiles: ['template1'],


### PR DESCRIPTION
…合わせる

ResourcesDto.java が "datasetSettings" キーでシリアライズするが、 ResourcesSettingsBuilder が "metadataSetting" を期待していたため、 /workspace/resources から取得した初期データが設定されず
アプリ起動時に -src.setting の datalist が常に空になっていた。

フロントエンドのフィールド名をバックエンドの JSON キー名 "datasetSettings" に統一。

https://claude.ai/code/session_013R1gLSBymKfS76pb1w3Att