### PR TITLE
Fix JDBC properties removal and menu auto-close behavior

### DIFF
--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -167,6 +167,7 @@ function JdbcTextField({
 							path={value}
 							setPath={setPath}
 							onApplyValues={onApplyValues}
+							isValueInDatalist={resourceFiles.includes(value)}
 						/>
 					)}
 					{isJdbcUrl && (
@@ -237,12 +238,14 @@ function JdbcPropertiesDropDownMenu({
 	path,
 	setPath,
 	onApplyValues,
+	isValueInDatalist,
 }: {
 	prefix: string;
 	element: CommandParam;
 	path: string;
 	setPath: Dispatch<SetStateAction<string>>;
 	onApplyValues?: (values: Partial<Record<string, string>>) => void;
+	isValueInDatalist: boolean;
 }) {
 	const [showMenu, setShowMenu] = useState(false);
 	const buttonRef = useRef<HTMLDivElement>(null);
@@ -299,11 +302,14 @@ function JdbcPropertiesDropDownMenu({
 								/>
 							</li>
 						)}
-						{path && (
+						{path && isValueInDatalist && (
 							<li>
 								<RemoveJdbcPropertiesButton
 									path={path}
-									setPath={setPath}
+									setPath={(value) => {
+										setPath(value);
+										setShowMenu(false);
+									}}
 								/>
 							</li>
 						)}

--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -167,7 +167,6 @@ function JdbcTextField({
 							path={value}
 							setPath={setPath}
 							onApplyValues={onApplyValues}
-							isValueInDatalist={resourceFiles.includes(value)}
 						/>
 					)}
 					{isJdbcUrl && (
@@ -238,15 +237,15 @@ function JdbcPropertiesDropDownMenu({
 	path,
 	setPath,
 	onApplyValues,
-	isValueInDatalist,
 }: {
 	prefix: string;
 	element: CommandParam;
 	path: string;
 	setPath: Dispatch<SetStateAction<string>>;
 	onApplyValues?: (values: Partial<Record<string, string>>) => void;
-	isValueInDatalist: boolean;
 }) {
+	const settings = useResourcesSettings();
+	const isValueInDatalist = settings.jdbcFiles.includes(path);
 	const [showMenu, setShowMenu] = useState(false);
 	const buttonRef = useRef<HTMLDivElement>(null);
 	const menuRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
This PR improves the JDBC properties dropdown menu by adding validation for file existence before allowing removal and automatically closing the menu after a file is removed.

## Key Changes
- Added `useResourcesSettings()` hook to access the list of available JDBC files
- Added validation to only show the "Remove" button when the selected path exists in the `jdbcFiles` list
- Modified the `setPath` callback in `RemoveJdbcPropertiesButton` to automatically close the dropdown menu after removal

## Implementation Details
- The `isValueInDatalist` check ensures users can only remove JDBC properties for files that are actually registered in the system
- The menu auto-closes after removal by calling `setShowMenu(false)` in the path setter callback, providing better UX by preventing the menu from staying open with an invalid/removed selection

https://claude.ai/code/session_01Uc6NMZrtPafvWFNrSr649F