### PR TITLE
Refactor hooks to use useCallback and fix dependency arrays

### DIFF
--- a/tauri/src/app/settings/JdbcPropertiesPreviewDialog.tsx
+++ b/tauri/src/app/settings/JdbcPropertiesPreviewDialog.tsx
@@ -26,7 +26,6 @@ export default function JdbcPropertiesPreviewDialog({
 	const [content, setContent] = useState<Record<string, string> | null>(null);
 	const readContent = useJdbcReadContent();
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: readContent is recreated each render but functionally stable
 	useEffect(() => {
 		let cancelled = false;
 		readContent(path).then((result) => {
@@ -37,7 +36,7 @@ export default function JdbcPropertiesPreviewDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [path]);
+	}, [path, readContent]);
 
 	const jdbcFormValues = content !== null ? toJdbcFormValues(content) : {};
 

--- a/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
+++ b/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SettingDialog } from "../../components/dialog";
 import { useJdbcTables } from "../../hooks/useJdbc";
 import { useSaveDataSource } from "../../hooks/useQueryDatasource";
@@ -107,16 +107,17 @@ export default function JdbcTableSelectorDialog({
 	const [loading, setLoading] = useState(true);
 	const getJdbcTables = useJdbcTables();
 	const saveDataSource = useSaveDataSource();
+	const jdbcValuesRef = useRef(jdbcValues);
+	const currentContentRef = useRef(currentContent);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: load tables once on mount with props captured at open time
 	useEffect(() => {
 		const load = async () => {
 			setLoading(true);
 			try {
-				const result = await getJdbcTables(jdbcValues);
+				const result = await getJdbcTables(jdbcValuesRef.current);
 				setTables(result);
 				const existing = new Set(
-					currentContent
+					currentContentRef.current
 						.split("\n")
 						.map((t) => t.trim())
 						.filter((t) => t.length > 0),
@@ -127,7 +128,7 @@ export default function JdbcTableSelectorDialog({
 			}
 		};
 		void load();
-	}, []);
+	}, [getJdbcTables]);
 
 	const toggleTable = (table: string) => {
 		setSelected((prev) => {

--- a/tauri/src/app/settings/TemplateEditDialog.tsx
+++ b/tauri/src/app/settings/TemplateEditDialog.tsx
@@ -16,7 +16,6 @@ export default function TemplateEditDialog({
 	const loadContent = useTemplateLoadContent();
 	const saveContent = useTemplateSaveContent();
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: loadContent is recreated each render but functionally stable
 	useEffect(() => {
 		if (!name) {
 			setContent("");
@@ -31,7 +30,7 @@ export default function TemplateEditDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [name]);
+	}, [name, loadContent]);
 
 	const handleSave = (path: string) =>
 		saveOnSuccess(

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -14,14 +14,20 @@ export default function XlsxCellSettingDialog(props: {
     const [target, setTarget] = useState(props.setting);
     const [sheetNames, setSheetNames] = useState<string[]>([]);
     const loadSheets = useXlsxSheets();
+    const srcPath = props.srcInfo?.srcPath ?? "";
+    const regTableInclude = props.srcInfo?.regTableInclude ?? "";
+    const regTableExclude = props.srcInfo?.regTableExclude ?? "";
+    const recursive = props.srcInfo?.recursive ?? "";
+    const regInclude = props.srcInfo?.regInclude ?? "";
+    const regExclude = props.srcInfo?.regExclude ?? "";
+    const extension = props.srcInfo?.extension ?? "";
 
     useEffect(() => {
-        if (!props.srcInfo?.srcPath) {
+        if (!srcPath) {
             return;
         }
-        loadSheets(props.srcInfo).then(setSheetNames);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
+        loadSheets({ srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension }).then(setSheetNames);
+    }, [srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension, loadSheets]);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Arrays, Check, Fieldset, SettingDialog, Text } from "../../components/dialog";
 import { ResourceDatalist } from "../../components/element/Input";
-import { useXlsxSheets } from "../../hooks/useXlsxSchema";
+import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
 import type { CellSetting } from "../../model/XlsxSchema";
 import type { SrcInfo } from "../form/FormElementProp";
 
@@ -12,22 +12,7 @@ export default function XlsxCellSettingDialog(props: {
     handleCommit: (newSettings: CellSetting) => void;
 }) {
     const [target, setTarget] = useState(props.setting);
-    const [sheetNames, setSheetNames] = useState<string[]>([]);
-    const loadSheets = useXlsxSheets();
-    const srcPath = props.srcInfo?.srcPath ?? "";
-    const regTableInclude = props.srcInfo?.regTableInclude ?? "";
-    const regTableExclude = props.srcInfo?.regTableExclude ?? "";
-    const recursive = props.srcInfo?.recursive ?? "";
-    const regInclude = props.srcInfo?.regInclude ?? "";
-    const regExclude = props.srcInfo?.regExclude ?? "";
-    const extension = props.srcInfo?.extension ?? "";
-
-    useEffect(() => {
-        if (!srcPath) {
-            return;
-        }
-        loadSheets({ srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension }).then(setSheetNames);
-    }, [srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension, loadSheets]);
+    const sheetNames = useSrcInfoSheets(props.srcInfo);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Check, Fieldset, SettingDialog, Text } from "../../components/dialog";
 import { ResourceDatalist } from "../../components/element/Input";
-import { useXlsxSheets } from "../../hooks/useXlsxSchema";
+import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
 import type { RowSetting } from "../../model/XlsxSchema";
 import type { SrcInfo } from "../form/FormElementProp";
 
@@ -12,22 +12,7 @@ export default function XlsxRowSettingDialog(props: {
     handleCommit: (newSettings: RowSetting) => void;
 }) {
     const [target, setTarget] = useState(props.setting);
-    const [sheetNames, setSheetNames] = useState<string[]>([]);
-    const loadSheets = useXlsxSheets();
-    const srcPath = props.srcInfo?.srcPath ?? "";
-    const regTableInclude = props.srcInfo?.regTableInclude ?? "";
-    const regTableExclude = props.srcInfo?.regTableExclude ?? "";
-    const recursive = props.srcInfo?.recursive ?? "";
-    const regInclude = props.srcInfo?.regInclude ?? "";
-    const regExclude = props.srcInfo?.regExclude ?? "";
-    const extension = props.srcInfo?.extension ?? "";
-
-    useEffect(() => {
-        if (!srcPath) {
-            return;
-        }
-        loadSheets({ srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension }).then(setSheetNames);
-    }, [srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension, loadSheets]);
+    const sheetNames = useSrcInfoSheets(props.srcInfo);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -14,14 +14,20 @@ export default function XlsxRowSettingDialog(props: {
     const [target, setTarget] = useState(props.setting);
     const [sheetNames, setSheetNames] = useState<string[]>([]);
     const loadSheets = useXlsxSheets();
+    const srcPath = props.srcInfo?.srcPath ?? "";
+    const regTableInclude = props.srcInfo?.regTableInclude ?? "";
+    const regTableExclude = props.srcInfo?.regTableExclude ?? "";
+    const recursive = props.srcInfo?.recursive ?? "";
+    const regInclude = props.srcInfo?.regInclude ?? "";
+    const regExclude = props.srcInfo?.regExclude ?? "";
+    const extension = props.srcInfo?.extension ?? "";
 
     useEffect(() => {
-        if (!props.srcInfo?.srcPath) {
+        if (!srcPath) {
             return;
         }
-        loadSheets(props.srcInfo).then(setSheetNames);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.srcInfo?.srcPath, props.srcInfo?.regTableInclude, props.srcInfo?.regTableExclude, props.srcInfo?.recursive, props.srcInfo?.regInclude, props.srcInfo?.regExclude, props.srcInfo?.extension]);
+        loadSheets({ srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension }).then(setSheetNames);
+    }, [srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension, loadSheets]);
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>

--- a/tauri/src/hooks/useJdbc.ts
+++ b/tauri/src/hooks/useJdbc.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
@@ -50,7 +51,7 @@ function toJdbcRequestBody(jdbcValues: Record<string, string>) {
 
 export const useJdbcReadContent = () => {
 	const { apiUrl } = useEnviroment();
-	return async (path: string): Promise<Record<string, string>> => {
+	return useCallback(async (path: string): Promise<Record<string, string>> => {
 		const params = {
 			endpoint: `${apiUrl}jdbc/read-content`,
 			options: {
@@ -66,12 +67,12 @@ export const useJdbcReadContent = () => {
 			handleFetchError((e as Error).message, params);
 			return {};
 		}
-	};
+	}, [apiUrl]);
 };
 
 export const useJdbcTables = () => {
 	const { apiUrl } = useEnviroment();
-	return async (jdbcValues: Record<string, string>): Promise<string[]> => {
+	return useCallback(async (jdbcValues: Record<string, string>): Promise<string[]> => {
 		const params = {
 			endpoint: `${apiUrl}jdbc/tables`,
 			options: {
@@ -87,7 +88,7 @@ export const useJdbcTables = () => {
 			handleFetchError((e as Error).message, params);
 			return [];
 		}
-	};
+	}, [apiUrl]);
 };
 
 export const useJdbcConnectionTest = () => {

--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import { fetchData, handleFetchError } from "../utils/fetchUtils";
@@ -6,7 +7,7 @@ type OperationResult = "success" | "failed";
 
 export const useTemplateLoadContent = () => {
 	const { apiUrl } = useEnviroment();
-	return async (name: string): Promise<string> => {
+	return useCallback(async (name: string): Promise<string> => {
 		const params = {
 			endpoint: `${apiUrl}template/load`,
 			options: {
@@ -23,7 +24,7 @@ export const useTemplateLoadContent = () => {
 			handleFetchError((e as Error).message, params);
 			return "";
 		}
-	};
+	}, [apiUrl]);
 };
 
 export const useDeleteTemplate = () => {

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import type { SrcInfo } from "../app/form/FormElementProp";
@@ -114,13 +115,13 @@ async function deleteXlsxSchema(
 }
 
 export const useXlsxSheets = () => {
-	const environment = useEnviroment();
-	return async (srcInfo: SrcInfo): Promise<string[]> => {
+	const { apiUrl } = useEnviroment();
+	return useCallback(async (srcInfo: SrcInfo): Promise<string[]> => {
 		if (!srcInfo.srcPath) {
 			return [];
 		}
 		const fetchParams = {
-			endpoint: `${environment.apiUrl}xlsx-schema/sheets`,
+			endpoint: `${apiUrl}xlsx-schema/sheets`,
 			options: {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
@@ -130,5 +131,5 @@ export const useXlsxSheets = () => {
 		return fetchData(fetchParams)
 			.then((r) => r.json())
 			.catch(() => []);
-	};
+	}, [apiUrl]);
 };

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import type { SrcInfo } from "../app/form/FormElementProp";
@@ -132,4 +132,25 @@ export const useXlsxSheets = () => {
 			.then((r) => r.json())
 			.catch(() => []);
 	}, [apiUrl]);
+};
+
+export const useSrcInfoSheets = (srcInfo: SrcInfo | undefined): string[] => {
+	const [sheetNames, setSheetNames] = useState<string[]>([]);
+	const loadSheets = useXlsxSheets();
+	const srcPath = srcInfo?.srcPath ?? "";
+	const regTableInclude = srcInfo?.regTableInclude ?? "";
+	const regTableExclude = srcInfo?.regTableExclude ?? "";
+	const recursive = srcInfo?.recursive ?? "";
+	const regInclude = srcInfo?.regInclude ?? "";
+	const regExclude = srcInfo?.regExclude ?? "";
+	const extension = srcInfo?.extension ?? "";
+
+	useEffect(() => {
+		if (!srcPath) {
+			return;
+		}
+		loadSheets({ srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension }).then(setSheetNames);
+	}, [srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension, loadSheets]);
+
+	return sheetNames;
 };


### PR DESCRIPTION
## Summary
This PR refactors several custom hooks to properly memoize async functions using `useCallback` and fixes dependency array issues in components that use these hooks. This improves performance by preventing unnecessary re-renders and ensures hooks follow React best practices.

## Key Changes

- **useXlsxSchema.ts**: 
  - Wrapped `useXlsxSheets` return function with `useCallback` to memoize it based on `apiUrl` dependency
  - Created new `useSrcInfoSheets` hook that encapsulates the sheet loading logic with proper dependency tracking
  - Extracts individual properties from `SrcInfo` to ensure accurate dependency array tracking

- **useJdbc.ts**:
  - Wrapped `useJdbcReadContent` and `useJdbcTables` return functions with `useCallback` to memoize them based on `apiUrl` dependency

- **useTemplate.ts**:
  - Wrapped `useTemplateLoadContent` return function with `useCallback` to memoize it based on `apiUrl` dependency

- **Component Updates**:
  - **XlsxCellSettingDialog.tsx** and **XlsxRowSettingDialog.tsx**: Replaced manual `useEffect` + `useState` logic with the new `useSrcInfoSheets` hook, eliminating code duplication and fixing dependency array issues
  - **JdbcTableSelectorDialog.tsx**: Added `useRef` to capture initial prop values and fixed dependency array to include `getJdbcTables`
  - **JdbcPropertiesPreviewDialog.tsx** and **TemplateEditDialog.tsx**: Added missing dependencies (`readContent` and `loadContent`) to dependency arrays

## Implementation Details

- The new `useSrcInfoSheets` hook properly handles all `SrcInfo` properties as individual dependencies, preventing stale closures
- Using `useRef` in `JdbcTableSelectorDialog` preserves the original intent of loading tables once on mount while satisfying React's exhaustive dependencies rule
- Removed `biome-ignore` comments that were suppressing legitimate linting warnings

https://claude.ai/code/session_01KzisSNkqz29Y7BXFAa8UMk