### PR TITLE
Extract dropdown menu logic into reusable component

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -1,8 +1,6 @@
-import { Fragment, useEffect, useRef, useState } from "react";
-import {
-	BlueSettingButton,
-	ExpandButton,
-} from "../../components/element/ButtonIcon";
+import { Fragment, useState } from "react";
+import { ExpandButton } from "../../components/element/ButtonIcon";
+import DropDownMenu from "../../components/element/DropDownMenu";
 import {
 	CheckBox,
 	ControllTextBox,
@@ -213,7 +211,7 @@ function Text(prop: Prop) {
 				</div>
 				<div className="flex">
 					{showDopDownMenu && !prop.hidden && (
-						<DropDownMenu
+						<TextDropDownMenu
 							prefix={prop.prefix}
 							element={prop.element}
 							path={path}
@@ -230,7 +228,7 @@ function Text(prop: Prop) {
 	);
 }
 
-function DropDownMenu({
+function TextDropDownMenu({
 	prefix,
 	element,
 	path,
@@ -241,150 +239,105 @@ function DropDownMenu({
 	isValueInDatalist,
 }: FileProp & {
 	srcType?: string;
-	datasources?: string[];
 	isValueInDatalist?: boolean;
 }) {
-	const [showMenu, setShowMenu] = useState(false);
 	const { connectionOk } = useJdbcConnectionState();
-	const buttonRef = useRef<HTMLDivElement>(null);
-	const menuRef = useRef<HTMLDivElement>(null);
-	const [menuPosition, setMenuPosition] = useState<"right" | "left">("right");
-	useEffect(() => {
-		if (showMenu && buttonRef.current) {
-			const rect = buttonRef.current.getBoundingClientRect();
-			const viewportWidth = window.innerWidth;
-			const menuWidth = 96;
-
-			if (rect.right + menuWidth > viewportWidth) {
-				setMenuPosition("left");
-			} else {
-				setMenuPosition("right");
-			}
-		}
-		function handleClickOutside(event: MouseEvent) {
-			if (
-				menuRef.current &&
-				!menuRef.current.contains(event.target as Node) &&
-				buttonRef.current &&
-				!buttonRef.current.contains(event.target as Node)
-			) {
-				setShowMenu(false);
-			}
-		}
-		if (showMenu) {
-			document.addEventListener("mousedown", handleClickOutside);
-			return () => {
-				document.removeEventListener("mousedown", handleClickOutside);
-			};
-		}
-	}, [showMenu]);
 
 	return (
-		<div className="relative" ref={buttonRef}>
-			<BlueSettingButton handleClick={() => setShowMenu(!showMenu)} />
-			{showMenu && (
-				<div
-					ref={menuRef}
-					className="absolute z-50 p-4 text-gray-900 bg-white border border-gray-100 rounded-lg shadow-md"
-					style={{
-						...(menuPosition === "right"
-							? { left: "100%", top: 0 }
-							: { right: "100%", top: 0 }),
-					}}
-				>
-					<ul className="space-y-4">
-						{element.name === "setting" && !hidden && (
+		<DropDownMenu>
+			{(closeMenu) => (
+				<>
+					{element.name === "setting" && !hidden && (
+						<li>
+							<DatasetSettingEditButton path={path} setPath={setPath} />
+						</li>
+					)}
+					{element.name === "xlsxSchema" && !hidden && (
+						<li>
+							<XlsxSchemaEditButton
+								path={path}
+								setPath={setPath}
+								srcInfo={srcInfo}
+							/>
+						</li>
+					)}
+					{element.name === "src" &&
+						!hidden &&
+						isSqlRelatedType(srcType ?? "") && (
 							<li>
-								<DatasetSettingEditButton path={path} setPath={setPath} />
-							</li>
-						)}
-						{element.name === "xlsxSchema" && !hidden && (
-							<li>
-								<XlsxSchemaEditButton
+								<SqlEditorButton
+									type={srcType as QueryDatasourceType}
 									path={path}
 									setPath={setPath}
-									srcInfo={srcInfo}
 								/>
 							</li>
 						)}
-						{element.name === "src" &&
-							!hidden &&
-							isSqlRelatedType(srcType ?? "") && (
-								<li>
-									<SqlEditorButton
-										type={srcType as QueryDatasourceType}
-										path={path}
-										setPath={setPath}
-									/>
-								</li>
-							)}
-						{element.name === "src" &&
-							!hidden &&
-							srcType === "table" &&
-							connectionOk && (
-								<li>
-									<JdbcTableSelectorButton path={path} setPath={setPath} />
-								</li>
-							)}
-						{element.name === "templateGroup" && !hidden && (
+					{element.name === "src" &&
+						!hidden &&
+						srcType === "table" &&
+						connectionOk && (
 							<li>
-								<TemplateEditButton path={path} setPath={setPath} />
+								<JdbcTableSelectorButton path={path} setPath={setPath} />
 							</li>
 						)}
-						{element.name === "templateGroup" && !hidden && isValueInDatalist && (
+					{element.name === "templateGroup" && !hidden && (
+						<li>
+							<TemplateEditButton path={path} setPath={setPath} />
+						</li>
+					)}
+					{element.name === "templateGroup" && !hidden && isValueInDatalist && (
+						<li>
+							<RemoveTemplateButton path={path} setPath={setPath} />
+						</li>
+					)}
+					{element.name === "setting" && !hidden && isValueInDatalist && (
+						<li>
+							<RemoveDatasetSettingButton path={path} setPath={setPath} />
+						</li>
+					)}
+					{element.name === "xlsxSchema" && !hidden && isValueInDatalist && (
+						<li>
+							<RemoveXlsxSchemaButton path={path} setPath={setPath} />
+						</li>
+					)}
+					{(srcType === "sql" || srcType === "table") &&
+						!hidden &&
+						isValueInDatalist && (
 							<li>
-								<RemoveTemplateButton path={path} setPath={setPath} />
-							</li>
-						)}
-						{element.name === "setting" && !hidden && isValueInDatalist && (
-							<li>
-								<RemoveDatasetSettingButton path={path} setPath={setPath} />
-							</li>
-						)}
-						{element.name === "xlsxSchema" && !hidden && isValueInDatalist && (
-							<li>
-								<RemoveXlsxSchemaButton path={path} setPath={setPath} />
-							</li>
-						)}
-						{(srcType === "sql" || srcType === "table") &&
-							!hidden &&
-							isValueInDatalist && (
-								<li>
-									<RemoveSqlEditorButton
-										path={path}
-										setPath={setPath}
-										type={srcType as QueryDatasourceType}
-									/>
-								</li>
-							)}
-						{element.attribute.type.includes("FILE") && (
-							<li>
-								<FileChooser
-									prefix={prefix}
-									element={element}
-									srcType={srcType}
+								<RemoveSqlEditorButton
 									path={path}
 									setPath={setPath}
-									onSelect={() => setShowMenu(false)}
+									type={srcType as QueryDatasourceType}
 								/>
 							</li>
 						)}
-						{element.attribute.type.includes("DIR") && (
-							<li>
-								<DirectoryChooser
-									prefix={prefix}
-									element={element}
-									srcType={srcType}
-									path={path}
-									setPath={setPath}
-									onSelect={() => setShowMenu(false)}
-								/>
-							</li>
-						)}
-					</ul>
-				</div>
+					{element.attribute.type.includes("FILE") && (
+						<li>
+							<FileChooser
+								prefix={prefix}
+								element={element}
+								srcType={srcType}
+								path={path}
+								setPath={setPath}
+								onSelect={closeMenu}
+							/>
+						</li>
+					)}
+					{element.attribute.type.includes("DIR") && (
+						<li>
+							<DirectoryChooser
+								prefix={prefix}
+								element={element}
+								srcType={srcType}
+								path={path}
+								setPath={setPath}
+								onSelect={closeMenu}
+							/>
+						</li>
+					)}
+				</>
 			)}
-		</div>
+		</DropDownMenu>
 	);
 }
 function Check(prop: Prop) {

--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -2,12 +2,14 @@ import {
 	type Dispatch,
 	type SetStateAction,
 	useCallback,
-	useEffect,
-	useRef,
 	useState,
 } from "react";
 import { BlueButton } from "../../components/element/Button";
-import { BlueEditButton, BlueSettingButton, PreviewButton } from "../../components/element/ButtonIcon";
+import {
+	BlueEditButton,
+	PreviewButton,
+} from "../../components/element/ButtonIcon";
+import DropDownMenu from "../../components/element/DropDownMenu";
 import {
 	ControllTextBox,
 	InputLabel,
@@ -133,8 +135,7 @@ function JdbcTextField({
 	const hasButton = isJdbcUrl || isJdbcProperties;
 
 	const setPath: Dispatch<SetStateAction<string>> = (action) => {
-		const newPath =
-			typeof action === "function" ? action(value) : action;
+		const newPath = typeof action === "function" ? action(value) : action;
 		onValueChange(element.name, newPath);
 	};
 
@@ -169,12 +170,7 @@ function JdbcTextField({
 							onApplyValues={onApplyValues}
 						/>
 					)}
-					{isJdbcUrl && (
-						<JdbcUrlBuilderButton
-							path={value}
-							setPath={setPath}
-						/>
-					)}
+					{isJdbcUrl && <JdbcUrlBuilderButton path={value} setPath={setPath} />}
 				</div>
 			</div>
 		</div>
@@ -246,85 +242,42 @@ function JdbcPropertiesDropDownMenu({
 }) {
 	const settings = useResourcesSettings();
 	const isValueInDatalist = settings.jdbcFiles.includes(path);
-	const [showMenu, setShowMenu] = useState(false);
-	const buttonRef = useRef<HTMLDivElement>(null);
-	const menuRef = useRef<HTMLDivElement>(null);
-	const [menuPosition, setMenuPosition] = useState<"right" | "left">("right");
-
-	useEffect(() => {
-		if (showMenu && buttonRef.current) {
-			const rect = buttonRef.current.getBoundingClientRect();
-			const menuWidth = 96;
-			if (rect.right + menuWidth > window.innerWidth) {
-				setMenuPosition("left");
-			} else {
-				setMenuPosition("right");
-			}
-		}
-		function handleClickOutside(event: MouseEvent) {
-			if (
-				menuRef.current &&
-				!menuRef.current.contains(event.target as Node) &&
-				buttonRef.current &&
-				!buttonRef.current.contains(event.target as Node)
-			) {
-				setShowMenu(false);
-			}
-		}
-		if (showMenu) {
-			document.addEventListener("mousedown", handleClickOutside);
-			return () => {
-				document.removeEventListener("mousedown", handleClickOutside);
-			};
-		}
-	}, [showMenu]);
 
 	return (
-		<div className="relative mr-24" ref={buttonRef}>
-			<BlueSettingButton handleClick={() => setShowMenu(!showMenu)} />
-			{showMenu && (
-				<div
-					ref={menuRef}
-					className="absolute z-50 p-4 text-gray-900 bg-white border border-gray-100 rounded-lg shadow-md"
-					style={{
-						...(menuPosition === "right"
-							? { left: "100%", top: 0 }
-							: { right: "100%", top: 0 }),
-					}}
-				>
-					<ul className="space-y-4">
-						{path && onApplyValues && (
-							<li>
-								<JdbcPropertiesPreviewButton
-									path={path}
-									onApplyValues={onApplyValues}
-								/>
-							</li>
-						)}
-						{path && isValueInDatalist && (
-							<li>
-								<RemoveJdbcPropertiesButton
-									path={path}
-									setPath={(value) => {
-										setPath(value);
-										setShowMenu(false);
-									}}
-								/>
-							</li>
-						)}
+		<DropDownMenu className="mr-24">
+			{(closeMenu) => (
+				<>
+					{path && onApplyValues && (
 						<li>
-							<FileChooser
-								prefix={prefix}
-								element={element}
+							<JdbcPropertiesPreviewButton
 								path={path}
-								setPath={setPath}
-								onSelect={() => setShowMenu(false)}
+								onApplyValues={onApplyValues}
 							/>
 						</li>
-					</ul>
-				</div>
+					)}
+					{path && isValueInDatalist && (
+						<li>
+							<RemoveJdbcPropertiesButton
+								path={path}
+								setPath={(value) => {
+									setPath(value);
+									closeMenu();
+								}}
+							/>
+						</li>
+					)}
+					<li>
+						<FileChooser
+							prefix={prefix}
+							element={element}
+							path={path}
+							setPath={setPath}
+							onSelect={closeMenu}
+						/>
+					</li>
+				</>
 			)}
-		</div>
+		</DropDownMenu>
 	);
 }
 
@@ -398,9 +351,7 @@ function JdbcSavePropertiesButton({
 	const [showDialog, setShowDialog] = useState(false);
 
 	const hasAnyValue =
-		!!jdbcValues.jdbcUrl ||
-		!!jdbcValues.jdbcUser ||
-		!!jdbcValues.jdbcPass;
+		!!jdbcValues.jdbcUrl || !!jdbcValues.jdbcUser || !!jdbcValues.jdbcPass;
 
 	return (
 		<>

--- a/tauri/src/components/element/DropDownMenu.tsx
+++ b/tauri/src/components/element/DropDownMenu.tsx
@@ -1,0 +1,74 @@
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { BlueSettingButton } from "./ButtonIcon";
+
+export default function DropDownMenu({
+	children,
+	className,
+}: {
+	children: (closeMenu: () => void) => ReactNode;
+	className?: string;
+}) {
+	const [showMenu, setShowMenu] = useState(false);
+	const [menuPosition, setMenuPosition] = useState<"right" | "left">("right");
+	const buttonRef = useRef<HTMLDivElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (showMenu && buttonRef.current) {
+			const rect = buttonRef.current.getBoundingClientRect();
+			const menuWidth = 96;
+			if (rect.right + menuWidth > window.innerWidth) {
+				setMenuPosition("left");
+			} else {
+				setMenuPosition("right");
+			}
+		}
+		function handleClickOutside(event: MouseEvent) {
+			if (
+				menuRef.current &&
+				!menuRef.current.contains(event.target as Node) &&
+				buttonRef.current &&
+				!buttonRef.current.contains(event.target as Node)
+			) {
+				setShowMenu(false);
+			}
+		}
+		if (showMenu) {
+			document.addEventListener("mousedown", handleClickOutside);
+		}
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [showMenu]);
+
+	const closeMenu = useCallback(() => setShowMenu(false), []);
+	const toggleMenu = useCallback(() => setShowMenu((prev) => !prev), []);
+
+	return (
+		<div
+			className={`relative${className ? ` ${className}` : ""}`}
+			ref={buttonRef}
+		>
+			<BlueSettingButton handleClick={toggleMenu} />
+			{showMenu && (
+				<div
+					ref={menuRef}
+					className="absolute z-50 p-4 text-gray-900 bg-white border border-gray-100 rounded-lg shadow-md"
+					style={
+						menuPosition === "right"
+							? { left: "100%", top: 0 }
+							: { right: "100%", top: 0 }
+					}
+				>
+					<ul className="space-y-4">{children(closeMenu)}</ul>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Refactored duplicate dropdown menu logic into a new reusable `DropDownMenu` component to reduce code duplication and improve maintainability across the codebase.

## Key Changes
- **Created new `DropDownMenu` component** (`tauri/src/components/element/DropDownMenu.tsx`):
  - Encapsulates all dropdown menu state management (visibility, positioning)
  - Handles click-outside detection and menu positioning logic
  - Accepts children as a render function that receives a `closeMenu` callback
  - Supports optional `className` prop for styling flexibility

- **Refactored `CommandFormElement.tsx`**:
  - Removed `BlueSettingButton` import (now handled by `DropDownMenu`)
  - Removed unused `useEffect`, `useRef`, and `useRef` hooks
  - Renamed local `DropDownMenu` function to `TextDropDownMenu` to avoid naming conflict
  - Simplified `TextDropDownMenu` by delegating menu state/positioning to the new component
  - Updated `FileChooser` and `DirectoryChooser` to use `closeMenu` callback instead of `setShowMenu`

- **Refactored `JdbcFormSection.tsx`**:
  - Removed `BlueSettingButton` import from button imports
  - Removed duplicate menu state management code from `JdbcPropertiesDropDownMenu`
  - Simplified component to use new `DropDownMenu` with render function pattern
  - Updated callbacks to use `closeMenu` instead of `setShowMenu`
  - Added `DropDownMenu` import

## Implementation Details
- The new `DropDownMenu` component uses a render function pattern (`children` prop) to provide the `closeMenu` callback to its content
- Menu positioning logic (left/right) is preserved and centralized
- Click-outside detection remains unchanged in functionality but is now reusable
- All styling and button behavior remains consistent with the original implementation

https://claude.ai/code/session_01BqXKZQVA2Rp9DyR1k83Pa8