### PR TITLE
Move SrcInfo type to CommandParam model

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -29,7 +29,8 @@ import XlsxSchemaEditButton, {
 	RemoveXlsxSchemaButton,
 } from "../settings/XlsxSchemaEditButton";
 import { DirectoryChooser, FileChooser } from "./Chooser";
-import type { FileProp, Prop, SelectProp, SrcInfo } from "./FormElementProp";
+import type { SrcInfo } from "../../model/CommandParam";
+import type { FileProp, Prop, SelectProp } from "./FormElementProp";
 import JdbcFormSection, { JDBC_FIELD_NAMES } from "./JdbcFormSection";
 
 export default function CommandFormElements(

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -1,15 +1,7 @@
 import type { Dispatch, SetStateAction } from "react";
-import type { CommandParam } from "../../model/CommandParam";
+import type { CommandParam, SrcInfo } from "../../model/CommandParam";
 
-export type SrcInfo = {
-	srcPath: string;
-	regTableInclude: string;
-	regTableExclude: string;
-	recursive: string;
-	regInclude: string;
-	regExclude: string;
-	extension: string;
-};
+export type { SrcInfo };
 
 export type Prop = {
 	prefix: string;

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -1,8 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { CommandParam, SrcInfo } from "../../model/CommandParam";
 
-export type { SrcInfo };
-
 export type Prop = {
 	prefix: string;
 	element: CommandParam;

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -3,7 +3,7 @@ import { Arrays, Check, Fieldset, SettingDialog, Text } from "../../components/d
 import { ResourceDatalist } from "../../components/element/Input";
 import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
 import type { CellSetting } from "../../model/XlsxSchema";
-import type { SrcInfo } from "../form/FormElementProp";
+import type { SrcInfo } from "../../model/CommandParam";
 
 export default function XlsxCellSettingDialog(props: {
     setting: CellSetting;

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -3,7 +3,7 @@ import { Check, Fieldset, SettingDialog, Text } from "../../components/dialog";
 import { ResourceDatalist } from "../../components/element/Input";
 import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
 import type { RowSetting } from "../../model/XlsxSchema";
-import type { SrcInfo } from "../form/FormElementProp";
+import type { SrcInfo } from "../../model/CommandParam";
 
 export default function XlsxRowSettingDialog(props: {
     setting: RowSetting;

--- a/tauri/src/app/settings/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/settings/XlsxSchemaDialog.tsx
@@ -12,7 +12,7 @@ import {
 	XlsxSchema,
 } from "../../model/XlsxSchema";
 import { saveOnSuccess } from "../../utils/fetchUtils";
-import type { SrcInfo } from "../form/FormElementProp";
+import type { SrcInfo } from "../../model/CommandParam";
 import XlsxCellSettingDialog from "./XlsxCellSettingDialog";
 import XlsxRowSettingDialog from "./XlsxRowSettingDialog";
 

--- a/tauri/src/app/settings/XlsxSchemaEditButton.tsx
+++ b/tauri/src/app/settings/XlsxSchemaEditButton.tsx
@@ -1,5 +1,5 @@
 import { useDeleteXlsxSchema } from "../../hooks/useXlsxSchema";
-import type { SrcInfo } from "../form/FormElementProp";
+import type { SrcInfo } from "../../model/CommandParam";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useState } from "react";
-import type { SrcInfo } from "../app/form/FormElementProp";
+import type { SrcInfo } from "../model/CommandParam";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { ResourcesSettings } from "../model/WorkspaceResources";

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -336,3 +336,13 @@ function toCommandParams(
 		optional: optional,
 	};
 }
+
+export type SrcInfo = {
+	srcPath: string;
+	regTableInclude: string;
+	regTableExclude: string;
+	recursive: string;
+	regInclude: string;
+	regExclude: string;
+	extension: string;
+};


### PR DESCRIPTION
## Summary
Consolidate the `SrcInfo` type definition by moving it from the form layer to the model layer, improving code organization and reducing circular dependency risks.

## Key Changes
- Moved `SrcInfo` type definition from `tauri/src/app/form/FormElementProp.ts` to `tauri/src/model/CommandParam.ts`
- Updated all import statements across the codebase to reference `SrcInfo` from its new location in the model layer:
  - `CommandFormElement.tsx`
  - `XlsxCellSettingDialog.tsx`
  - `XlsxRowSettingDialog.tsx`
  - `XlsxSchemaDialog.tsx`
  - `XlsxSchemaEditButton.tsx`
  - `useXlsxSchema.ts` hook

## Implementation Details
The `SrcInfo` type, which defines source information properties (srcPath, regTableInclude, regTableExclude, recursive, regInclude, regExclude, extension), is now properly located in the `CommandParam` model file where it logically belongs. This change improves the separation of concerns by keeping model types in the model layer rather than the form layer, making the codebase more maintainable and reducing potential circular dependency issues.

https://claude.ai/code/session_01PqkaoL25wbzq66C2foaRjw