### PR TITLE
Refactor template hooks to use useCallback and improve type safety

### DIFF
--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -1,9 +1,7 @@
 import { useCallback } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
-import { fetchData, handleFetchError } from "../utils/fetchUtils";
-
-type OperationResult = "success" | "failed";
+import { type OperationResult, fetchData, handleFetchError } from "../utils/fetchUtils";
 
 export const useTemplateLoadContent = () => {
 	const { apiUrl } = useEnviroment();
@@ -30,7 +28,7 @@ export const useTemplateLoadContent = () => {
 export const useDeleteTemplate = () => {
 	const { apiUrl } = useEnviroment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string): Promise<OperationResult> => {
+	return useCallback(async (name: string): Promise<OperationResult> => {
 		const params = {
 			endpoint: `${apiUrl}template/delete`,
 			options: {
@@ -48,13 +46,13 @@ export const useDeleteTemplate = () => {
 			handleFetchError((e as Error).message, params);
 			return "failed";
 		}
-	};
+	}, [apiUrl, setResourcesSettings]);
 };
 
 export const useTemplateSaveContent = () => {
 	const { apiUrl } = useEnviroment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string, content: string): Promise<void> => {
+	return useCallback(async (name: string, content: string): Promise<OperationResult> => {
 		const params = {
 			endpoint: `${apiUrl}template/save`,
 			options: {
@@ -67,8 +65,10 @@ export const useTemplateSaveContent = () => {
 			const response = await fetchData(params);
 			const settings = (await response.json()) as string[];
 			setResourcesSettings((current) => current.with({ templateFiles: settings }));
+			return "success";
 		} catch (e) {
 			handleFetchError((e as Error).message, params);
+			return "failed";
 		}
-	};
+	}, [apiUrl, setResourcesSettings]);
 };


### PR DESCRIPTION
## Summary
This PR refactors the template-related hooks in `useTemplate.ts` to improve performance and maintainability by wrapping async functions with `useCallback` and consolidating type definitions.

## Key Changes
- **Moved `OperationResult` type**: Exported `OperationResult` type from `fetchUtils` instead of defining it locally in the hook file, improving type reusability
- **Added `useCallback` wrapper**: Wrapped async functions in `useDeleteTemplate` and `useTemplateSaveContent` hooks with `useCallback` to prevent unnecessary re-renders and maintain referential equality
- **Added dependency arrays**: Included `[apiUrl, setResourcesSettings]` as dependencies for the `useCallback` hooks to ensure proper memoization
- **Improved return type consistency**: Updated `useTemplateSaveContent` to return `OperationResult` instead of `void`, making it consistent with `useDeleteTemplate`
- **Added explicit return statements**: Added `return "success"` and `return "failed"` statements in `useTemplateSaveContent` to properly indicate operation status

## Implementation Details
- The `useCallback` optimization ensures that the returned async functions maintain stable references across re-renders, which is important for performance when these functions are passed as dependencies to other hooks or effects
- The consolidated `OperationResult` type definition reduces duplication and makes it easier to maintain consistent operation result handling across the codebase

https://claude.ai/code/session_0148DwR2otf3MdKnnTqap7Rp