### PR TITLE
Refactor optional parameter display logic in command forms

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -72,23 +72,29 @@ export default function CommandFormElements(
 	};
 	const toggleOptional = () => setShowOptional(!showOptional);
 
-	const jdbcElements = prop.elements.filter((e) =>
-		JDBC_FIELD_NAMES.includes(e.name as (typeof JDBC_FIELD_NAMES)[number]),
-	);
+	const isJdbcFieldName = (name: string) =>
+		JDBC_FIELD_NAMES.includes(name as (typeof JDBC_FIELD_NAMES)[number]);
+
+	const jdbcElements = prop.elements.filter((e) => isJdbcFieldName(e.name));
+
+	const firstOptionalNonJdbcElementName = prop.optionCaption
+		? prop.elements.find(
+				(e) => !isJdbcFieldName(e.name) && prop.optional?.(e.name),
+			)?.name
+		: undefined;
 
 	return (
 		<>
 			{prop.elements.map((element) => {
-				const isJdbcField = JDBC_FIELD_NAMES.includes(
-					element.name as (typeof JDBC_FIELD_NAMES)[number],
-				);
-				if (isJdbcField) {
+				if (isJdbcFieldName(element.name)) {
 					return null;
 				}
+				const showExpandButton =
+					element.name === firstOptionalNonJdbcElementName;
 				if (element.attribute.type === "FLG") {
 					return (
 						<Fragment key={prop.name + prop.prefix + element.name}>
-							{prop.optionCaption?.display(element.name) && (
+							{showExpandButton && (
 								<div className="pt-2.5">
 									<ExpandButton
 										toggleOptional={toggleOptional}
@@ -108,7 +114,7 @@ export default function CommandFormElements(
 				if (element.attribute.type === "ENUM") {
 					return (
 						<Fragment key={prop.name + prop.prefix + element.name}>
-							{prop.optionCaption?.display(element.name) && (
+							{showExpandButton && (
 								<div className="pt-2.5">
 									<ExpandButton
 										toggleOptional={toggleOptional}
@@ -128,7 +134,7 @@ export default function CommandFormElements(
 				}
 				return (
 					<Fragment key={prop.name + prop.prefix + element.name}>
-						{prop.optionCaption?.display(element.name) && (
+						{showExpandButton && (
 							<div className="pt-2.5">
 								<ExpandButton
 									toggleOptional={toggleOptional}

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -102,7 +102,7 @@ export type CommandParams = {
 	name: string;
 	prefix: string;
 	elements: CommandParam[];
-	optionCaption?: { caption: string; display: (_: string) => boolean };
+	optionCaption?: { caption: string };
 	optional?: (_: string) => boolean;
 };
 export type DatasetSource = CommandParams & {
@@ -154,10 +154,7 @@ class DatasetSourceImpl implements DatasetSource {
 					? this.indexRegExclude + 1
 					: this.indexExtension + 1,
 			),
-			{
-				caption: "traversal option",
-				display: (name) => name === "recursive",
-			},
+			{ caption: "traversal option" },
 			(param: string) =>
 				["recursive", "regInclude", "regExclude", "extension"].includes(param),
 		);
@@ -180,10 +177,7 @@ class DatasetSourceImpl implements DatasetSource {
 		return toCommandParams(
 			this,
 			this.elements.slice(this.indexOfSetting),
-			{
-				caption: "dataset option",
-				display: (name) => name === "regTableInclude",
-			},
+			{ caption: "dataset option" },
 			(param: string) =>
 				[
 					"regTableInclude",
@@ -234,17 +228,14 @@ export type ParameterizeParams = {
 const srcTypeDetail = new Map<
 	string,
 	{
-		optionCaption: { caption: string; display: (_: string) => boolean };
+		optionCaption: { caption: string };
 		optional: (_: string) => boolean;
 	}
 >([
 	[
 		"table",
 		{
-			optionCaption: {
-				caption: "table option",
-				display: (name: string) => name === "useJdbcMetaData",
-			},
+			optionCaption: { caption: "table option" },
 			optional: (name: string) =>
 				name !== "encoding" && !name.startsWith("jdbc"),
 		},
@@ -252,10 +243,7 @@ const srcTypeDetail = new Map<
 	[
 		"sql",
 		{
-			optionCaption: {
-				caption: "sql option",
-				display: (name: string) => name === "useJdbcMetaData",
-			},
+			optionCaption: { caption: "sql option" },
 			optional: (name: string) =>
 				name !== "encoding" && !name.startsWith("jdbc"),
 		},
@@ -263,30 +251,21 @@ const srcTypeDetail = new Map<
 	[
 		"csv",
 		{
-			optionCaption: {
-				caption: "csv option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "csv option" },
 			optional: (name: string) => name !== "encoding",
 		},
 	],
 	[
 		"csvq",
 		{
-			optionCaption: {
-				caption: "csvq option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "csvq option" },
 			optional: (name: string) => name !== "encoding",
 		},
 	],
 	[
 		"reg",
 		{
-			optionCaption: {
-				caption: "reg option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "reg option" },
 			optional: (name: string) =>
 				name !== "regDataSplit" && name !== "regHeaderSplit",
 		},
@@ -294,30 +273,21 @@ const srcTypeDetail = new Map<
 	[
 		"fixed",
 		{
-			optionCaption: {
-				caption: "fixed option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "fixed option" },
 			optional: (name: string) => name !== "fixedLength",
 		},
 	],
 	[
 		"xls",
 		{
-			optionCaption: {
-				caption: "xls option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "xls option" },
 			optional: (_: string) => true,
 		},
 	],
 	[
 		"xlsx",
 		{
-			optionCaption: {
-				caption: "xlsx option",
-				display: (name: string) => name === "headerName",
-			},
+			optionCaption: { caption: "xlsx option" },
 			optional: (_: string) => true,
 		},
 	],
@@ -325,7 +295,7 @@ const srcTypeDetail = new Map<
 function toCommandParams(
 	srcData: CommandParams,
 	elements: CommandParam[],
-	optionCaption?: { caption: string; display: (_: string) => boolean },
+	optionCaption?: { caption: string },
 	optional?: (_: string) => boolean,
 ): CommandParams {
 	return {


### PR DESCRIPTION
## Summary
This PR refactors the display logic for optional parameters in command forms by removing the `display` function from `optionCaption` and instead determining which parameter should show the expand button based on the first optional non-JDBC field.

## Key Changes
- **Type simplification**: Removed the `display: (_: string) => boolean` function from the `optionCaption` type definition in `CommandParam.ts`, leaving only the `caption` string property
- **Cleaned up data structures**: Removed all `display` function implementations from the `srcTypeDetail` map entries across all source types (table, sql, csv, csvq, reg, fixed, xls, xlsx)
- **Refactored display logic**: In `CommandFormElement.tsx`, replaced the conditional `prop.optionCaption?.display(element.name)` checks with a computed `showExpandButton` variable that identifies the first optional non-JDBC field name
- **Extracted helper function**: Created `isJdbcFieldName()` helper to reduce code duplication when checking if a field is a JDBC field

## Implementation Details
The new approach calculates `firstOptionalNonJdbcElementName` once at the component level by finding the first element that:
1. Is not a JDBC field
2. Is marked as optional via `prop.optional?.(e.name)`

This single element then displays the expand button, eliminating the need for per-element display logic and making the behavior more predictable and maintainable.

https://claude.ai/code/session_01PwpmpjsBCricv24xA9xarX