### PR TITLE
Add CommandForm component tests with fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 tauri/src-tauri/Cargo.lock
 tauri/src/App.css
 tauri/bun.lock
+node_modules/

--- a/tauri/src/tests/app/form/CommandForm.test.tsx
+++ b/tauri/src/tests/app/form/CommandForm.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CommandForm from "../../../app/form/CommandForm";
+import type { SelectParameter } from "../../../model/CommandParam";
+import {
+	compareLoadResponseFixture,
+	convertLoadResponseFixture,
+	generateLoadResponseFixture,
+	parameterizeLoadResponseFixture,
+	runLoadResponseFixture,
+} from "./fixtures";
+
+// モック関数をホイスト（mockReset: true により各テスト前にリセットされるため beforeEach で再設定する）
+const {
+	mockRefreshSelectFn,
+	mockUseSelectParameter,
+	mockUseRefreshSelectParameter,
+	mockFormData,
+} = vi.hoisted(() => ({
+	mockRefreshSelectFn: vi.fn(),
+	mockUseSelectParameter: vi.fn(),
+	mockUseRefreshSelectParameter: vi.fn(),
+	mockFormData: vi.fn(),
+}));
+
+// 子フォームコンポーネントをモック
+vi.mock("../../../app/form/ConvertForm", () => ({
+	ConvertForm: ({ handleTypeSelect }: { handleTypeSelect: () => void }) => (
+		<div data-testid="mock-convert-form">
+			<button type="button" data-testid="type-select-btn" onClick={handleTypeSelect}>
+				select
+			</button>
+		</div>
+	),
+}));
+vi.mock("../../../app/form/CompareForm", () => ({
+	CompareForm: () => <div data-testid="mock-compare-form" />,
+}));
+vi.mock("../../../app/form/GenerateForm", () => ({
+	GenerateForm: () => <div data-testid="mock-generate-form" />,
+}));
+vi.mock("../../../app/form/RunForm", () => ({
+	RunForm: () => <div data-testid="mock-run-form" />,
+}));
+vi.mock("../../../app/form/ParameterizeForm", () => ({
+	ParameterizeForm: () => <div data-testid="mock-parameterize-form" />,
+}));
+
+// SelectParameterProvider の useSelectParameter をモック
+vi.mock("../../../context/SelectParameterProvider", () => ({
+	useSelectParameter: mockUseSelectParameter,
+}));
+
+// useSelectParameter フックをモック
+vi.mock("../../../hooks/useSelectParameter", () => ({
+	useRefreshSelectParameter: mockUseRefreshSelectParameter,
+}));
+
+beforeEach(() => {
+	mockUseRefreshSelectParameter.mockReturnValue(mockRefreshSelectFn);
+	mockFormData.mockReturnValue({ values: mockFormValues, validationError: false });
+});
+
+// 全コマンドの共通モック SelectParameter 値を生成
+function makeSelectParameter(command: string): SelectParameter {
+	return {
+		command,
+		name: "test-param",
+		convert: convertLoadResponseFixture,
+		compare: compareLoadResponseFixture,
+		generate: generateLoadResponseFixture,
+		run: runLoadResponseFixture,
+		parameterize: parameterizeLoadResponseFixture,
+		currentParameter: () => undefined,
+	} as unknown as SelectParameter;
+}
+
+const mockFormValues = { key: "val" as FormDataEntryValue };
+
+describe("CommandFormのテスト", () => {
+	it.each([
+		{ command: "convert", testId: "mock-convert-form" },
+		{ command: "compare", testId: "mock-compare-form" },
+		{ command: "generate", testId: "mock-generate-form" },
+		{ command: "run", testId: "mock-run-form" },
+		{ command: "parameterize", testId: "mock-parameterize-form" },
+	])(
+		"command=$commandのとき、対応するフォームが表示される",
+		({ command, testId }) => {
+			mockUseSelectParameter.mockReturnValue(makeSelectParameter(command));
+
+			render(<CommandForm formData={mockFormData} />);
+
+			expect(screen.getByTestId(testId)).toBeInTheDocument();
+		},
+	);
+
+	it("commandが未知のとき、何も表示されない", () => {
+		mockUseSelectParameter.mockReturnValue(makeSelectParameter("unknown"));
+
+		const { container } = render(<CommandForm formData={mockFormData} />);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("handleTypeSelectが呼ばれたとき、formDataの値でrefreshSelectが実行される", async () => {
+		mockUseSelectParameter.mockReturnValue(makeSelectParameter("convert"));
+
+		render(<CommandForm formData={mockFormData} />);
+
+		await userEvent.click(screen.getByTestId("type-select-btn"));
+
+		expect(mockFormData).toHaveBeenCalledWith(false);
+		expect(mockRefreshSelectFn).toHaveBeenCalledWith(mockFormValues);
+	});
+});

--- a/tauri/src/tests/app/form/fixtures.ts
+++ b/tauri/src/tests/app/form/fixtures.ts
@@ -1,0 +1,248 @@
+import type { CommandParam, DefaultPath } from "../../../model/CommandParam";
+
+// CommandParam 要素を生成するヘルパー
+function makeElement(
+	name: string,
+	type: string,
+	value: string,
+	defaultPath: DefaultPath,
+	required: boolean,
+	selectOption: string[] = [],
+): CommandParam {
+	return {
+		name,
+		value,
+		attribute: { type, required, selectOption, defaultPath },
+		optional: false,
+	};
+}
+
+// generate / run / parameterize で共通のテンプレートオプション要素
+const templateOptionElements: CommandParam[] = [
+	makeElement("encoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	makeElement("templateGroup", "FILE", "", "TEMPLATE", false),
+	makeElement("templateParameterAttribute", "TEXT", "param", "WORKSPACE", false),
+	makeElement("templateVarStart", "TEXT", "$", "WORKSPACE", false),
+	makeElement("templateVarStop", "TEXT", "$", "WORKSPACE", false),
+];
+
+// convert / compare / generate / parameterize srcData の共通 CSV 要素
+function makeCsvSrcDataElements(src: string): CommandParam[] {
+	return [
+		makeElement("srcType", "ENUM", "csv", "WORKSPACE", false, [
+			"table",
+			"sql",
+			"file",
+			"dir",
+			"csv",
+			"csvq",
+			"reg",
+			"fixed",
+			"xls",
+			"xlsx",
+		]),
+		makeElement("src", "FILE_OR_DIR", src, "DATASET", true),
+		makeElement("encoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+		makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("extension", "TEXT", "", "WORKSPACE", false),
+		makeElement("headerName", "TEXT", "", "WORKSPACE", false),
+		makeElement("startRow", "TEXT", "1", "WORKSPACE", false),
+		makeElement("addFileInfo", "FLG", "false", "WORKSPACE", false),
+		makeElement("delimiter", "TEXT", ",", "WORKSPACE", false),
+		makeElement("ignoreQuoted", "FLG", "false", "WORKSPACE", false),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("loadData", "FLG", "true", "WORKSPACE", false),
+		makeElement("includeMetaData", "FLG", "false", "WORKSPACE", false),
+	];
+}
+
+// convert-load-response.json をもとにしたフィクスチャ
+export const convertLoadResponseFixture = {
+	prefix: "",
+	elements: [] as CommandParam[],
+	srcData: {
+		prefix: "src",
+		elements: makeCsvSrcDataElements(
+			"src/test/resources/workspace/sample/resources/src/csv",
+		),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: [
+			makeElement("resultType", "ENUM", "xlsx", "WORKSPACE", false, [
+				"csv",
+				"xls",
+				"xlsx",
+				"table",
+			]),
+			makeElement("result", "DIR", "target/convert/result", "RESULT", false),
+			makeElement("resultPath", "TEXT", "", "WORKSPACE", false),
+			makeElement("exportEmptyTable", "FLG", "true", "WORKSPACE", false),
+			makeElement("exportHeader", "FLG", "true", "WORKSPACE", false),
+			makeElement("excelTable", "TEXT", "SHEET", "WORKSPACE", false),
+		],
+	},
+};
+
+// compare-load-response.json をもとにしたフィクスチャ
+export const compareLoadResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("targetType", "ENUM", "data", "WORKSPACE", false, [
+			"data",
+			"image",
+			"pdf",
+		]),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	newData: {
+		prefix: "new",
+		elements: makeCsvSrcDataElements("resources/src/csv/multi1.csv"),
+	},
+	oldData: {
+		prefix: "old",
+		elements: makeCsvSrcDataElements("resources/src/csv/multi2.csv"),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: [
+			makeElement("resultType", "ENUM", "csv", "WORKSPACE", true, [
+				"csv",
+				"xls",
+				"xlsx",
+			]),
+			makeElement("result", "DIR", "target/compare/result", "RESULT", false),
+			makeElement("resultPath", "TEXT", "", "WORKSPACE", false),
+			makeElement("exportEmptyTable", "FLG", "true", "WORKSPACE", false),
+			makeElement("exportHeader", "FLG", "true", "WORKSPACE", false),
+			makeElement("outputEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		],
+	},
+	expectData: {
+		prefix: "expect",
+		elements: [
+			makeElement("srcType", "ENUM", "none", "WORKSPACE", false, [
+				"none",
+				"sql",
+				"csv",
+				"csvq",
+				"xls",
+				"xlsx",
+			]),
+		],
+	},
+};
+
+// generate-load-response.json をもとにしたフィクスチャ
+export const generateLoadResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("generateType", "ENUM", "txt", "WORKSPACE", false, [
+			"txt",
+			"xlsx",
+			"xls",
+			"settings",
+			"sql",
+			"xlsxTemplate",
+		]),
+		makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
+			"record",
+			"table",
+			"dataset",
+		]),
+		makeElement("template", "FILE", "sample.stg", "TEMPLATE", true),
+		makeElement("result", "DIR", "target/generate/result", "RESULT", false),
+		makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
+		makeElement("outputEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	srcData: {
+		prefix: "src",
+		elements: makeCsvSrcDataElements("resources/src/csv"),
+	},
+	templateOption: {
+		prefix: "template",
+		elements: templateOptionElements,
+	},
+};
+
+// run-load-response.json をもとにしたフィクスチャ
+export const runLoadResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("scriptType", "ENUM", "sql", "WORKSPACE", false, [
+			"cmd",
+			"bat",
+			"sql",
+			"ant",
+		]),
+	],
+	srcData: {
+		prefix: "src",
+		elements: [
+			makeElement(
+				"src",
+				"FILE_OR_DIR",
+				"resources/sql/sample.sql",
+				"DATASET",
+				true,
+			),
+			makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+			makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("setting", "FILE", "", "SETTING", false),
+			makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+			makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		],
+	},
+	templateOption: {
+		prefix: "template",
+		elements: templateOptionElements,
+	},
+	jdbcOption: {
+		prefix: "jdbc",
+		elements: [
+			makeElement("jdbcProperties", "FILE", "", "JDBC", false),
+			makeElement("jdbcUrl", "TEXT", "", "WORKSPACE", false),
+			makeElement("jdbcUser", "TEXT", "", "WORKSPACE", false),
+			makeElement("jdbcPass", "TEXT", "", "WORKSPACE", false),
+		],
+	},
+};
+
+// parameterize-load-response.json をもとにしたフィクスチャ
+export const parameterizeLoadResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
+			"record",
+			"table",
+			"dataset",
+		]),
+		makeElement("parameterize", "FLG", "true", "WORKSPACE", false),
+		makeElement("ignoreFail", "FLG", "false", "WORKSPACE", false),
+		makeElement("cmd", "TEXT", "convert", "WORKSPACE", false),
+		makeElement("cmdParam", "TEXT", "", "WORKSPACE", false),
+		makeElement(
+			"template",
+			"FILE",
+			"csvToXlsx.txt",
+			"PARAMETERIZE_TEMPLATE",
+			false,
+		),
+	],
+	paramData: {
+		prefix: "param",
+		elements: makeCsvSrcDataElements("csvToXlsx.csv"),
+	},
+	templateOption: {
+		prefix: "template",
+		elements: templateOptionElements,
+	},
+};

--- a/tauri/vite.config.ts
+++ b/tauri/vite.config.ts
@@ -1,6 +1,30 @@
 /// <reference types="vitest" />
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+
+// テスト実行時に存在しない CSS ファイル（App.css など生成ファイル）を空モジュールとして扱うプラグイン
+const missingCssFallback = {
+	name: "missing-css-fallback",
+	enforce: "pre" as const,
+	resolveId(id: string, importer?: string) {
+		if (!id.endsWith(".css") || !importer) {
+			return null;
+		}
+		const resolved = resolve(dirname(importer), id);
+		if (!existsSync(resolved)) {
+			return "\0virtual:empty-css";
+		}
+		return null;
+	},
+	load(id: string) {
+		if (id === "\0virtual:empty-css") {
+			return "";
+		}
+		return null;
+	},
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -10,6 +34,7 @@ export default defineConfig(async () => ({
 				plugins: [["babel-plugin-react-compiler"]],
 			},
 		}),
+		missingCssFallback,
 	],
 	build: {
 		target: "esnext",


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the CommandForm component, including test fixtures for all command types and a Vite configuration enhancement to handle missing CSS files during testing.

## Key Changes
- **Added test fixtures** (`fixtures.ts`): Created reusable test data fixtures for all five command types (convert, compare, generate, run, parameterize) based on their respective load-response JSON structures
  - Implemented `makeElement()` helper function to generate CommandParam objects
  - Extracted common CSV source data elements into `makeCsvSrcDataElements()` helper
  - Defined fixtures for each command type with proper element hierarchies and default values

- **Added CommandForm component tests** (`CommandForm.test.tsx`): Comprehensive test suite covering:
  - Rendering of correct child form components based on command type
  - Handling of unknown command types
  - Form data refresh behavior when type selection occurs
  - Mocked all child form components and hooks to isolate CommandForm logic

- **Enhanced Vite configuration** (`vite.config.ts`): Added `missingCssFallback` plugin to handle CSS imports that don't exist during test execution (e.g., generated files like App.css), preventing test failures due to missing CSS modules

- **Updated .gitignore**: Added `node_modules/` to ignore list

## Notable Implementation Details
- Test fixtures follow the actual JSON structure of command load responses, ensuring realistic test scenarios
- Mocks are hoisted and reset between tests using Vitest's `mockReset: true` behavior
- The Vite CSS fallback plugin uses virtual module resolution to gracefully handle missing CSS files without breaking the test pipeline

https://claude.ai/code/session_01F5dkDq5fR3brKzjC5jdzz7