### PR TITLE
Add table names preview feature for dataset settings

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
@@ -1,12 +1,27 @@
 package yo.dbunitcli.sidecar.controller;
 
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.serde.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import yo.dbunitcli.application.dto.DataSetLoadDto;
+import yo.dbunitcli.application.option.DataSetLoadOption;
+import yo.dbunitcli.common.Parameter;
+import yo.dbunitcli.dataset.ComparableDataSetParam;
+import yo.dbunitcli.dataset.producer.ComparableDataSetLoader;
 import yo.dbunitcli.sidecar.domain.project.ResourceFile;
 import yo.dbunitcli.sidecar.domain.project.Workspace;
 import yo.dbunitcli.sidecar.dto.DatasetRequestDto;
+import yo.dbunitcli.sidecar.dto.DatasetTableNamesRequestDto;
+
+import java.util.Arrays;
 
 @Controller("dataset-setting")
 public class DatasetSettingsController extends AbstractResourceFileController<DatasetRequestDto> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatasetSettingsController.class);
 
     public DatasetSettingsController(final Workspace workspace) {
         super(workspace);
@@ -15,5 +30,45 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
     @Override
     protected ResourceFile getResourceFile() {
         return this.workspace.resources().datasetSetting();
+    }
+
+    @Post(uri = "table-names", produces = MediaType.APPLICATION_JSON)
+    public String tableNames(@Body final DatasetTableNamesRequestDto request) {
+        try {
+            final DataSetLoadDto dto = new DataSetLoadDto();
+            dto.setSrc(request.getSrc());
+            dto.setSrcType(yo.dbunitcli.dataset.DataSourceType.valueOf(request.getSrcType()));
+            dto.setRegTableInclude(request.getRegTableInclude());
+            dto.setRegTableExclude(request.getRegTableExclude());
+            dto.setRecursive(String.valueOf(request.isRecursive()));
+            dto.setRegInclude(request.getRegInclude());
+            dto.setRegExclude(request.getRegExclude());
+            dto.setExtension(request.getExtension());
+            dto.setLoadData("false");
+            dto.setXlsxSchemaSource(request.getXlsxSchema());
+            dto.setFixedLength(request.getFixedLength());
+            dto.setRegHeaderSplit(request.getRegHeaderSplit());
+            dto.setRegDataSplit(request.getRegDataSplit());
+            dto.setEncoding(request.getEncoding());
+            dto.setDelimiter(request.getDelimiter());
+            dto.setIgnoreQuoted(request.isIgnoreQuoted());
+            dto.setHeaderName(request.getHeaderName());
+            dto.setStartRow(request.getStartRow());
+            dto.setAddFileInfo(request.isAddFileInfo());
+            dto.getJdbc().setJdbcUrl(request.getJdbcUrl());
+            dto.getJdbc().setJdbcUser(request.getJdbcUser());
+            dto.getJdbc().setJdbcPass(request.getJdbcPass());
+            dto.getJdbc().setJdbcProperties(request.getJdbcProperties());
+
+            final DataSetLoadOption option = new DataSetLoadOption("", dto);
+            final ComparableDataSetParam param = option.getParam().build();
+            return ObjectMapper.getDefault().writeValueAsString(
+                    Arrays.asList(new ComparableDataSetLoader(Parameter.none())
+                            .loadDataSet(param).getTableNames())
+            );
+        } catch (final Throwable th) {
+            LOGGER.warn("Could not get table names", th);
+            return "[]";
+        }
     }
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
@@ -17,8 +17,6 @@ import yo.dbunitcli.sidecar.domain.project.Workspace;
 import yo.dbunitcli.sidecar.dto.DatasetRequestDto;
 import yo.dbunitcli.sidecar.dto.DatasetTableNamesRequestDto;
 
-import java.util.Arrays;
-
 @Controller("dataset-setting")
 public class DatasetSettingsController extends AbstractResourceFileController<DatasetRequestDto> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatasetSettingsController.class);
@@ -63,8 +61,8 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
             final DataSetLoadOption option = new DataSetLoadOption("", dto);
             final ComparableDataSetParam param = option.getParam().build();
             return ObjectMapper.getDefault().writeValueAsString(
-                    Arrays.asList(new ComparableDataSetLoader(Parameter.none())
-                            .loadDataSet(param).getTableNames())
+                    new ComparableDataSetLoader(Parameter.none())
+                            .loadDataSet(param).getTableNames()
             );
         } catch (final Throwable th) {
             LOGGER.warn("Could not get table names", th);

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
@@ -1,0 +1,221 @@
+package yo.dbunitcli.sidecar.dto;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class DatasetTableNamesRequestDto {
+
+    // 基本
+    private String srcType;
+    private String src;
+
+    // ファイルトラバーサル共通
+    private String regTableInclude;
+    private String regTableExclude;
+    private boolean recursive;
+    private String regInclude;
+    private String regExclude;
+    private String extension;
+
+    // xlsx / xls 用
+    private String xlsxSchema;
+
+    // fixed 用
+    private String fixedLength;
+
+    // reg (regex) 用
+    private String regHeaderSplit;
+    private String regDataSplit;
+
+    // csv / fixed / reg 共通
+    private String encoding;
+    private String delimiter;
+    private boolean ignoreQuoted;
+
+    // 汎用
+    private String headerName;
+    private String startRow;
+    private boolean addFileInfo;
+
+    // sql / table タイプ向け JDBC 情報
+    private String jdbcUrl;
+    private String jdbcUser;
+    private String jdbcPass;
+    private String jdbcProperties;
+
+    public String getSrcType() {
+        return this.srcType;
+    }
+
+    public void setSrcType(final String srcType) {
+        this.srcType = srcType;
+    }
+
+    public String getSrc() {
+        return this.src;
+    }
+
+    public void setSrc(final String src) {
+        this.src = src;
+    }
+
+    public String getRegTableInclude() {
+        return this.regTableInclude;
+    }
+
+    public void setRegTableInclude(final String regTableInclude) {
+        this.regTableInclude = regTableInclude;
+    }
+
+    public String getRegTableExclude() {
+        return this.regTableExclude;
+    }
+
+    public void setRegTableExclude(final String regTableExclude) {
+        this.regTableExclude = regTableExclude;
+    }
+
+    public boolean isRecursive() {
+        return this.recursive;
+    }
+
+    public void setRecursive(final boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    public String getRegInclude() {
+        return this.regInclude;
+    }
+
+    public void setRegInclude(final String regInclude) {
+        this.regInclude = regInclude;
+    }
+
+    public String getRegExclude() {
+        return this.regExclude;
+    }
+
+    public void setRegExclude(final String regExclude) {
+        this.regExclude = regExclude;
+    }
+
+    public String getExtension() {
+        return this.extension;
+    }
+
+    public void setExtension(final String extension) {
+        this.extension = extension;
+    }
+
+    public String getXlsxSchema() {
+        return this.xlsxSchema;
+    }
+
+    public void setXlsxSchema(final String xlsxSchema) {
+        this.xlsxSchema = xlsxSchema;
+    }
+
+    public String getFixedLength() {
+        return this.fixedLength;
+    }
+
+    public void setFixedLength(final String fixedLength) {
+        this.fixedLength = fixedLength;
+    }
+
+    public String getRegHeaderSplit() {
+        return this.regHeaderSplit;
+    }
+
+    public void setRegHeaderSplit(final String regHeaderSplit) {
+        this.regHeaderSplit = regHeaderSplit;
+    }
+
+    public String getRegDataSplit() {
+        return this.regDataSplit;
+    }
+
+    public void setRegDataSplit(final String regDataSplit) {
+        this.regDataSplit = regDataSplit;
+    }
+
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+    public void setEncoding(final String encoding) {
+        this.encoding = encoding;
+    }
+
+    public String getDelimiter() {
+        return this.delimiter;
+    }
+
+    public void setDelimiter(final String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public boolean isIgnoreQuoted() {
+        return this.ignoreQuoted;
+    }
+
+    public void setIgnoreQuoted(final boolean ignoreQuoted) {
+        this.ignoreQuoted = ignoreQuoted;
+    }
+
+    public String getHeaderName() {
+        return this.headerName;
+    }
+
+    public void setHeaderName(final String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String getStartRow() {
+        return this.startRow;
+    }
+
+    public void setStartRow(final String startRow) {
+        this.startRow = startRow;
+    }
+
+    public boolean isAddFileInfo() {
+        return this.addFileInfo;
+    }
+
+    public void setAddFileInfo(final boolean addFileInfo) {
+        this.addFileInfo = addFileInfo;
+    }
+
+    public String getJdbcUrl() {
+        return this.jdbcUrl;
+    }
+
+    public void setJdbcUrl(final String jdbcUrl) {
+        this.jdbcUrl = jdbcUrl;
+    }
+
+    public String getJdbcUser() {
+        return this.jdbcUser;
+    }
+
+    public void setJdbcUser(final String jdbcUser) {
+        this.jdbcUser = jdbcUser;
+    }
+
+    public String getJdbcPass() {
+        return this.jdbcPass;
+    }
+
+    public void setJdbcPass(final String jdbcPass) {
+        this.jdbcPass = jdbcPass;
+    }
+
+    public String getJdbcProperties() {
+        return this.jdbcProperties;
+    }
+
+    public void setJdbcProperties(final String jdbcProperties) {
+        this.jdbcProperties = jdbcProperties;
+    }
+}

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -18,6 +18,7 @@ import {
 import DatasetSettingEditButton, {
 	RemoveDatasetSettingButton,
 } from "../settings/DatasetSettingEditButton";
+import DatasetTableNamesPreviewButton from "../settings/DatasetTableNamesPreviewButton";
 import JdbcTableSelectorButton from "../settings/JdbcTableSelectorButton";
 import SqlEditorButton, {
 	RemoveSqlEditorButton,
@@ -280,6 +281,11 @@ function TextDropDownMenu({
 		<DropDownMenu>
 			{(closeMenu) => (
 				<>
+					{element.name === "setting" && !hidden && datasetSrcInfo && (
+						<li>
+							<DatasetTableNamesPreviewButton datasetSrcInfo={datasetSrcInfo} />
+						</li>
+					)}
 					{element.name === "setting" && !hidden && (
 						<li>
 							<DatasetSettingEditButton path={path} setPath={setPath} datasetSrcInfo={datasetSrcInfo} />

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../components/element/Input";
 import { useJdbcConnectionState } from "../../context/JdbcConnectionProvider";
 import { useResourcesSettings } from "../../context/WorkspaceResourcesProvider";
-import type { CommandParams, SrcInfo } from "../../model/CommandParam";
+import type { CommandParams, DatasetSrcInfo, SrcInfo } from "../../model/CommandParam";
 import {
 	isSqlRelatedType,
 	type QueryDatasourceType,
@@ -69,6 +69,30 @@ export default function CommandFormElements(
 		regInclude: regIncludeElement?.value ?? "",
 		regExclude: regExcludeElement?.value ?? "",
 		extension: extensionElement?.value ?? "",
+	};
+	const xlsxSchemaElement = prop.elements.find((e) => e.name === "xlsxSchema");
+	const fixedLengthElement = prop.elements.find((e) => e.name === "fixedLength");
+	const regHeaderSplitElement = prop.elements.find((e) => e.name === "regHeaderSplit");
+	const regDataSplitElement = prop.elements.find((e) => e.name === "regDataSplit");
+	const encodingElement = prop.elements.find((e) => e.name === "encoding");
+	const delimiterElement = prop.elements.find((e) => e.name === "delimiter");
+	const ignoreQuotedElement = prop.elements.find((e) => e.name === "ignoreQuoted");
+	const headerNameElement = prop.elements.find((e) => e.name === "headerName");
+	const startRowElement = prop.elements.find((e) => e.name === "startRow");
+	const addFileInfoElement = prop.elements.find((e) => e.name === "addFileInfo");
+	const datasetSrcInfo: DatasetSrcInfo = {
+		...srcInfo,
+		srcType,
+		xlsxSchema: xlsxSchemaElement?.value ?? "",
+		fixedLength: fixedLengthElement?.value ?? "",
+		regHeaderSplit: regHeaderSplitElement?.value ?? "",
+		regDataSplit: regDataSplitElement?.value ?? "",
+		encoding: encodingElement?.value ?? "",
+		delimiter: delimiterElement?.value ?? "",
+		ignoreQuoted: ignoreQuotedElement?.value === "true",
+		headerName: headerNameElement?.value ?? "",
+		startRow: startRowElement?.value ?? "",
+		addFileInfo: addFileInfoElement?.value === "true",
 	};
 	const toggleOptional = () => setShowOptional(!showOptional);
 
@@ -149,6 +173,7 @@ export default function CommandFormElements(
 							hidden={prop.optional?.(element.name) && !showOptional}
 							srcType={element.name === "src" ? srcType : undefined}
 							srcInfo={element.name === "xlsxSchema" ? srcInfo : undefined}
+							datasetSrcInfo={element.name === "setting" ? datasetSrcInfo : undefined}
 						/>
 					</Fragment>
 				);
@@ -161,7 +186,7 @@ export default function CommandFormElements(
 }
 function Text(prop: Prop) {
 	const [path, setPath] = useState(prop.element.value);
-	const { element, srcType, srcInfo } = prop;
+	const { element, srcType, srcInfo, datasetSrcInfo } = prop;
 	const settings = useResourcesSettings();
 	let resourceFiles: string[] = [];
 	if (element.name === "src" && isSqlRelatedType(srcType ?? "")) {
@@ -225,6 +250,7 @@ function Text(prop: Prop) {
 							hidden={prop.hidden}
 							srcType={srcType}
 							srcInfo={srcInfo}
+							datasetSrcInfo={datasetSrcInfo}
 							isValueInDatalist={isValueInDatalist}
 						/>
 					)}
@@ -242,6 +268,7 @@ function TextDropDownMenu({
 	hidden,
 	srcType,
 	srcInfo,
+	datasetSrcInfo,
 	isValueInDatalist,
 }: FileProp & {
 	srcType?: string;
@@ -255,7 +282,7 @@ function TextDropDownMenu({
 				<>
 					{element.name === "setting" && !hidden && (
 						<li>
-							<DatasetSettingEditButton path={path} setPath={setPath} />
+							<DatasetSettingEditButton path={path} setPath={setPath} datasetSrcInfo={datasetSrcInfo} />
 						</li>
 					)}
 					{element.name === "xlsxSchema" && !hidden && (

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import type { CommandParam, SrcInfo } from "../../model/CommandParam";
+import type { CommandParam, DatasetSrcInfo, SrcInfo } from "../../model/CommandParam";
 
 export type Prop = {
 	prefix: string;
@@ -7,6 +7,7 @@ export type Prop = {
 	hidden?: boolean;
 	srcType?: string;
 	srcInfo?: SrcInfo;
+	datasetSrcInfo?: DatasetSrcInfo;
 };
 export type FileProp = Prop & {
 	path: string;
@@ -14,6 +15,7 @@ export type FileProp = Prop & {
 	onSelect?: () => void;
 	srcType?: string;
 	srcInfo?: SrcInfo;
+	datasetSrcInfo?: DatasetSrcInfo;
 };
 export type SelectProp = Prop & {
 	handleTypeSelect: (selected: string) => Promise<void>;

--- a/tauri/src/app/settings/DatasetSettingDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingDialog.tsx
@@ -17,7 +17,7 @@ export default function DatasetSettingDialog(props: {
     const handleTargetChange = async (select: string) => setTarget(current => current.replace(select))
     const [showOptional, setShowOptional] = useState(false);
     const toggleOptional = () => setShowOptional(!showOptional)
-    const tableNames = useDatasetTableNames(props.datasetSrcInfo);
+    const { tableNames } = useDatasetTableNames(props.datasetSrcInfo);
     const tableList = tableNames.length > 0 ? "tableName_list" : undefined;
 
     return (

--- a/tauri/src/app/settings/DatasetSettingDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingDialog.tsx
@@ -2,17 +2,23 @@ import type React from "react";
 import { useState } from "react";
 import { Arrays, Check, Fieldset, KeyValues, Select, SettingDialog, Text } from "../../components/dialog";
 import { ExpandButton } from "../../components/element/ButtonIcon";
+import { ResourceDatalist } from "../../components/element/Input";
+import { useDatasetTableNames } from "../../hooks/useDatasetSettings";
+import type { DatasetSrcInfo } from "../../model/CommandParam";
 import type { DatasetSetting } from "../../model/DatasetSettings";
 
 export default function DatasetSettingDialog(props: {
     setting: DatasetSetting
     handleDialogClose: () => void;
     handleCommit: (newSettings: DatasetSetting) => void;
+    datasetSrcInfo?: DatasetSrcInfo;
 }) {
     const [target, setTarget] = useState(props.setting)
     const handleTargetChange = async (select: string) => setTarget(current => current.replace(select))
     const [showOptional, setShowOptional] = useState(false);
     const toggleOptional = () => setShowOptional(!showOptional)
+    const tableNames = useDatasetTableNames(props.datasetSrcInfo);
+    const tableList = tableNames.length > 0 ? "tableName_list" : undefined;
 
     return (
         <SettingDialog setting={target} handleDialogClose={props.handleDialogClose} handleCommit={props.handleCommit}>
@@ -24,7 +30,10 @@ export default function DatasetSettingDialog(props: {
                     <option value="innerJoin">innerJoin</option>
                     <option value="fullJoin">fullJoin</option>
                 </Select>
-                {renderTargetContent(target, setTarget)}
+                {renderTargetContent(target, setTarget, tableList)}
+                {tableNames.length > 0 && (
+                    <ResourceDatalist id="tableName" resources={tableNames} />
+                )}
             </Fieldset>
             <Fieldset legend="Split / Rename">
                 <Check name="split"
@@ -121,14 +130,17 @@ export default function DatasetSettingDialog(props: {
 function renderTargetContent(
     target: DatasetSetting,
     setTarget: React.Dispatch<React.SetStateAction<DatasetSetting>>,
+    tableList: string | undefined,
 ): React.ReactElement {
     if (target.join()) {
         return (
             <>
                 <Text name="left" value={target.join()?.left ?? ""}
+                    list={tableList}
                     handleChange={newVal => setTarget(cur => cur.replaceJoin({ left: newVal.target.value }))}
                 />
                 <Text name="right" value={target.join()?.right ?? ""}
+                    list={tableList}
                     handleChange={newVal => setTarget(cur => cur.replaceJoin({ right: newVal.target.value }))}
                 />
                 <Select name="condition" defaultValue={target.join()?.on ? "on" : "column"}
@@ -157,6 +169,7 @@ function renderTargetContent(
                     handleChange={(text) => setTarget(cur => cur.replacePattern({ string: text.target.value }))}
                 />
                 <Arrays name="patternExclue" values={target.pattern?.exclude ?? []}
+                    list={tableList}
                     handleChange={(text, index) => setTarget(cur => cur.replacePatternExclude(text, index))}
                     handleRemove={(index) => setTarget(cur => cur.removePatternExclude(index))}
                 />
@@ -166,6 +179,7 @@ function renderTargetContent(
     return (
         <>
             <Arrays name="name" values={target.name ?? []}
+                list={tableList}
                 handleChange={(text, index) => setTarget(cur => cur.replaceName(text, index))}
                 handleRemove={(index) => setTarget(cur => cur.removeName(index))}
             />

--- a/tauri/src/app/settings/DatasetSettingEditButton.tsx
+++ b/tauri/src/app/settings/DatasetSettingEditButton.tsx
@@ -1,14 +1,20 @@
 import { useDeleteDatasetSettings } from "../../hooks/useDatasetSettings";
+import type { DatasetSrcInfo } from "../../model/CommandParam";
 import DatasetSettingsDialog from "./DatasetSettingsDialog";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,
 } from "./ResourceEditButton";
 
+type DatasetSettingEditButtonProp = ResourceEditButtonProp & {
+	datasetSrcInfo?: DatasetSrcInfo;
+};
+
 export default function DatasetSettingEditButton({
 	path,
 	setPath,
-}: ResourceEditButtonProp) {
+	datasetSrcInfo,
+}: DatasetSettingEditButtonProp) {
 	const renderDialog = (open: boolean, closeDialog: () => void) => {
 		if (!open) {
 			return null;
@@ -21,6 +27,7 @@ export default function DatasetSettingEditButton({
 					setPath(newPath);
 					closeDialog();
 				}}
+				datasetSrcInfo={datasetSrcInfo}
 			/>
 		);
 	};

--- a/tauri/src/app/settings/DatasetSettingsDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingsDialog.tsx
@@ -4,6 +4,7 @@ import {
 	useLoadDatasetSettings,
 	useSaveDatasetSettings,
 } from "../../hooks/useDatasetSettings";
+import type { DatasetSrcInfo } from "../../model/CommandParam";
 import type { DatasetSetting } from "../../model/DatasetSettings";
 import {
 	DatasetSettings,
@@ -16,6 +17,7 @@ export default function DatasetSettingsDialog(props: {
 	fileName: string;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
+	datasetSrcInfo?: DatasetSrcInfo;
 }) {
 	const loadSettings = useLoadDatasetSettings();
 	return (
@@ -25,6 +27,7 @@ export default function DatasetSettingsDialog(props: {
 				fileName={props.fileName}
 				handleDialogClose={props.handleDialogClose}
 				handleSave={props.handleSave}
+				datasetSrcInfo={props.datasetSrcInfo}
 			/>
 		</Suspense>
 	);
@@ -34,6 +37,7 @@ function Dialog(props: {
 	fileName: string;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
+	datasetSrcInfo?: DatasetSrcInfo;
 }) {
 	const saveSettings = useSaveDatasetSettings();
 	const dataSettingsData = use(props.promise);
@@ -60,7 +64,14 @@ function Dialog(props: {
 					})
 				}
 				renderSetting={(setting) => setting.displayName()}
-				SettingDialogComponent={DatasetSettingDialog}
+				SettingDialogComponent={({ setting, handleDialogClose, handleCommit }) => (
+					<DatasetSettingDialog
+						setting={setting}
+						handleDialogClose={handleDialogClose}
+						handleCommit={handleCommit}
+						datasetSrcInfo={props.datasetSrcInfo}
+					/>
+				)}
 				newSetting={newDatasetSetting}
 				getKey={(setting) => setting.displayName()}
 			/>
@@ -74,7 +85,14 @@ function Dialog(props: {
 					})
 				}
 				renderSetting={(setting) => setting.displayName()}
-				SettingDialogComponent={DatasetSettingDialog}
+				SettingDialogComponent={({ setting, handleDialogClose, handleCommit }) => (
+					<DatasetSettingDialog
+						setting={setting}
+						handleDialogClose={handleDialogClose}
+						handleCommit={handleCommit}
+						datasetSrcInfo={props.datasetSrcInfo}
+					/>
+				)}
 				newSetting={newDatasetSetting}
 				getKey={(setting) => setting.displayName()}
 			/>

--- a/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
+++ b/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
@@ -23,6 +23,30 @@ export default function DatasetTableNamesPreviewButton({
 	);
 }
 
+function TableContent({
+	tableNames,
+	loading,
+}: {
+	tableNames: string[];
+	loading: boolean;
+}) {
+	if (loading) {
+		return <p className="text-sm text-gray-400 p-3">Loading...</p>;
+	}
+	if (tableNames.length === 0) {
+		return <p className="text-sm text-gray-400 p-3">No tables found.</p>;
+	}
+	return (
+		<ul className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 space-y-1">
+			{tableNames.map((name) => (
+				<li key={name} className="text-gray-700">
+					{name}
+				</li>
+			))}
+		</ul>
+	);
+}
+
 function DatasetTableNamesPreviewDialog({
 	datasetSrcInfo,
 	handleDialogClose,
@@ -31,7 +55,7 @@ function DatasetTableNamesPreviewDialog({
 	handleDialogClose: () => void;
 }) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
-	const tableNames = useDatasetTableNames(datasetSrcInfo);
+	const { tableNames, loading } = useDatasetTableNames(datasetSrcInfo);
 	useEffect(() => {
 		dialogRef.current?.showModal();
 	}, []);
@@ -44,17 +68,7 @@ function DatasetTableNamesPreviewDialog({
 		>
 			<div className="p-4 rounded-lg mt-2">
 				<h2 className="text-lg font-bold mb-2">Table List Preview</h2>
-				{tableNames.length === 0 ? (
-					<p className="text-sm text-gray-400 p-3">No tables found.</p>
-				) : (
-					<ul className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 space-y-1">
-						{tableNames.map((name) => (
-							<li key={name} className="text-gray-700">
-								{name}
-							</li>
-						))}
-					</ul>
-				)}
+				<TableContent tableNames={tableNames} loading={loading} />
 			</div>
 			<div className="flex items-center justify-end p-4 gap-2">
 				<WhiteButton title="Close" handleClick={handleDialogClose} />

--- a/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
+++ b/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+import { WhiteButton } from "../../components/element/Button";
+import { PreviewButton } from "../../components/element/ButtonIcon";
+import { useDatasetTableNames } from "../../hooks/useDatasetSettings";
+import type { DatasetSrcInfo } from "../../model/CommandParam";
+
+export default function DatasetTableNamesPreviewButton({
+	datasetSrcInfo,
+}: {
+	datasetSrcInfo: DatasetSrcInfo;
+}) {
+	const [showDialog, setShowDialog] = useState(false);
+	return (
+		<>
+			<PreviewButton handleClick={() => setShowDialog(true)} />
+			{showDialog && (
+				<DatasetTableNamesPreviewDialog
+					datasetSrcInfo={datasetSrcInfo}
+					handleDialogClose={() => setShowDialog(false)}
+				/>
+			)}
+		</>
+	);
+}
+
+function DatasetTableNamesPreviewDialog({
+	datasetSrcInfo,
+	handleDialogClose,
+}: {
+	datasetSrcInfo: DatasetSrcInfo;
+	handleDialogClose: () => void;
+}) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const tableNames = useDatasetTableNames(datasetSrcInfo);
+	useEffect(() => {
+		dialogRef.current?.showModal();
+	}, []);
+
+	return (
+		<dialog
+			ref={dialogRef}
+			onClose={handleDialogClose}
+			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
+		>
+			<div className="p-4 rounded-lg mt-2">
+				<h2 className="text-lg font-bold mb-2">Table List Preview</h2>
+				{tableNames.length === 0 ? (
+					<p className="text-sm text-gray-400 p-3">No tables found.</p>
+				) : (
+					<ul className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 space-y-1">
+						{tableNames.map((name) => (
+							<li key={name} className="text-gray-700">
+								{name}
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+			<div className="flex items-center justify-end p-4 gap-2">
+				<WhiteButton title="Close" handleClick={handleDialogClose} />
+			</div>
+		</dialog>
+	);
+}

--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -198,6 +198,7 @@ export function Arrays(props: {
 	handleChange: (text: string, index: number) => void;
 	handleRemove: (index: number) => void;
 	ignoreLabel?: boolean;
+	list?: string;
 }) {
 	return (
 		<>
@@ -210,6 +211,7 @@ export function Arrays(props: {
 					handleChange={props.handleChange}
 					handleRemove={props.handleRemove}
 					ignoreLabel={props.ignoreLabel}
+					list={props.list}
 				/>
 			) : (
 				props.values.map((val, index) => {
@@ -222,6 +224,7 @@ export function Arrays(props: {
 							handleChange={props.handleChange}
 							handleRemove={props.handleRemove}
 							ignoreLabel={props.ignoreLabel}
+							list={props.list}
 						/>
 					);
 				})
@@ -248,6 +251,7 @@ export function ArraysText(props: {
 	handleChange: (text: string, index: number) => void;
 	handleRemove: (index: number) => void;
 	ignoreLabel?: boolean;
+	list?: string;
 }) {
 	const [text, setText] = useState(props.val);
 	const handleBlur = (newVal: React.FocusEvent<HTMLInputElement>) =>
@@ -271,6 +275,7 @@ export function ArraysText(props: {
 				value={text}
 				handleChange={(ev) => setText(ev.target.value)}
 				handleBlur={handleBlur}
+				list={props.list}
 			/>
 			{props.index > 0 && (
 				<div className="col-start-3">

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -79,7 +79,7 @@ export const useDatasetTableNames = (
 			return;
 		}
 		loadTableNames(srcInfo as DatasetSrcInfo, jdbcValues).then(setTableNames);
-	}, [srcPath, srcType, connectionOk, loadTableNames]);
+	}, [srcPath, srcType, connectionOk, jdbcValues, loadTableNames]);
 
 	return tableNames;
 };

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -1,6 +1,9 @@
 import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useJdbcConnectionState } from "../context/JdbcConnectionProvider";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
+import type { DatasetSrcInfo } from "../model/CommandParam";
 import {
 	DatasetSettings,
 	type DatasetSettingsBuilder,
@@ -9,6 +12,77 @@ import type { ResourcesSettings } from "../model/WorkspaceResources";
 import { fetchData, handleFetchError } from "../utils/fetchUtils";
 
 type OperationResult = "success" | "failed";
+
+export const useDatasetTableNamesApi = () => {
+	const { apiUrl } = useEnviroment();
+	return useCallback(
+		async (
+			info: DatasetSrcInfo,
+			jdbcValues: Record<string, string>,
+		): Promise<string[]> => {
+			if (!info.srcPath) {
+				return [];
+			}
+			const fetchParams = {
+				endpoint: `${apiUrl}dataset-setting/table-names`,
+				options: {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						srcType: info.srcType,
+						src: info.srcPath,
+						regTableInclude: info.regTableInclude,
+						regTableExclude: info.regTableExclude,
+						recursive: info.recursive === "true",
+						regInclude: info.regInclude,
+						regExclude: info.regExclude,
+						extension: info.extension,
+						xlsxSchema: info.xlsxSchema,
+						fixedLength: info.fixedLength,
+						regHeaderSplit: info.regHeaderSplit,
+						regDataSplit: info.regDataSplit,
+						encoding: info.encoding,
+						delimiter: info.delimiter,
+						ignoreQuoted: info.ignoreQuoted,
+						headerName: info.headerName,
+						startRow: info.startRow,
+						addFileInfo: info.addFileInfo,
+						jdbcUrl: jdbcValues.jdbcUrl ?? "",
+						jdbcUser: jdbcValues.jdbcUser ?? "",
+						jdbcPass: jdbcValues.jdbcPass ?? "",
+						jdbcProperties: jdbcValues.jdbcProperties ?? "",
+					}),
+				},
+			};
+			return fetchData(fetchParams)
+				.then((r) => r.json())
+				.catch(() => []);
+		},
+		[apiUrl],
+	);
+};
+
+export const useDatasetTableNames = (
+	srcInfo: DatasetSrcInfo | undefined,
+): string[] => {
+	const [tableNames, setTableNames] = useState<string[]>([]);
+	const { jdbcValues, connectionOk } = useJdbcConnectionState();
+	const loadTableNames = useDatasetTableNamesApi();
+
+	const srcPath = srcInfo?.srcPath ?? "";
+	const srcType = srcInfo?.srcType ?? "";
+	const sqlNotReady = srcType === "sql" && !connectionOk;
+
+	useEffect(() => {
+		if (!srcPath || !srcType || srcType === "none" || sqlNotReady) {
+			setTableNames([]);
+			return;
+		}
+		loadTableNames(srcInfo as DatasetSrcInfo, jdbcValues).then(setTableNames);
+	}, [srcPath, srcType, connectionOk, loadTableNames]);
+
+	return tableNames;
+};
 
 export const useDeleteDatasetSettings = () => {
 	const environment = useEnviroment();

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -64,8 +64,9 @@ export const useDatasetTableNamesApi = () => {
 
 export const useDatasetTableNames = (
 	srcInfo: DatasetSrcInfo | undefined,
-): string[] => {
+): { tableNames: string[]; loading: boolean } => {
 	const [tableNames, setTableNames] = useState<string[]>([]);
+	const [loading, setLoading] = useState(false);
 	const { jdbcValues, connectionOk } = useJdbcConnectionState();
 	const loadTableNames = useDatasetTableNamesApi();
 
@@ -76,12 +77,17 @@ export const useDatasetTableNames = (
 	useEffect(() => {
 		if (!srcPath || !srcType || srcType === "none" || sqlNotReady) {
 			setTableNames([]);
+			setLoading(false);
 			return;
 		}
-		loadTableNames(srcInfo as DatasetSrcInfo, jdbcValues).then(setTableNames);
+		setLoading(true);
+		loadTableNames(srcInfo as DatasetSrcInfo, jdbcValues).then((names) => {
+			setTableNames(names);
+			setLoading(false);
+		});
 	}, [srcPath, srcType, connectionOk, jdbcValues, loadTableNames]);
 
-	return tableNames;
+	return { tableNames, loading };
 };
 
 export const useDeleteDatasetSettings = () => {

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -316,3 +316,17 @@ export type SrcInfo = {
 	regExclude: string;
 	extension: string;
 };
+
+export type DatasetSrcInfo = SrcInfo & {
+	srcType: string;
+	xlsxSchema: string;
+	fixedLength: string;
+	regHeaderSplit: string;
+	regDataSplit: string;
+	encoding: string;
+	delimiter: string;
+	ignoreQuoted: boolean;
+	headerName: string;
+	startRow: string;
+	addFileInfo: boolean;
+};


### PR DESCRIPTION
## Summary
This PR adds a new feature to preview available table names from dataset sources before configuring dataset settings. Users can now see what tables are available from their data source (files, databases, etc.) through a preview dialog.

## Key Changes

### Backend (Java/Sidecar)
- **New DTO**: `DatasetTableNamesRequestDto` - Encapsulates all dataset configuration parameters needed to fetch table names
- **New API Endpoint**: `POST /dataset-setting/table-names` - Returns a JSON array of table names available from the specified data source
  - Converts request DTO to `DataSetLoadDto` and uses existing `ComparableDataSetLoader` to extract table names
  - Handles errors gracefully by returning empty array on failure

### Frontend (TypeScript/React)
- **New Hook**: `useDatasetTableNamesApi()` - Fetches table names from the backend API
- **New Hook**: `useDatasetTableNames()` - Manages table name state with automatic loading based on source configuration and JDBC connection status
- **New Component**: `DatasetTableNamesPreviewButton` - Displays a preview dialog showing available tables from the current dataset source
- **New Type**: `DatasetSrcInfo` - Extends `SrcInfo` with additional dataset-specific configuration fields (xlsx schema, fixed length, encoding, delimiter, etc.)
- **Integration Points**:
  - Added preview button to dataset setting dialogs
  - Passes `DatasetSrcInfo` through form elements and dialog components
  - Populates table name datalist in dataset settings when tables are available

## Implementation Details
- The preview feature respects JDBC connection status - SQL sources won't attempt to load tables until a valid connection is established
- Table names are automatically loaded when source path or type changes
- The feature gracefully handles missing or invalid sources by showing "No tables found"
- Reuses existing dataset loading infrastructure to ensure consistency with actual dataset operations

https://claude.ai/code/session_016ESJVvmeThC4sMgBBbgGcj