### PR TITLE
Preserve raw property values in workspace shell scripts

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -48,6 +48,14 @@ public class Workspace {
             return target.toString();
         }
     }
+
+    private static String rawOrRelative(final Path launchDir, final String propertyName, final Path expandedPath) {
+        final String raw = System.getProperty(propertyName);
+        if (raw != null && raw.contains("%")) {
+            return raw;
+        }
+        return toRelative(launchDir, expandedPath);
+    }
     private Options options;
     private Resources resources;
     private Path path;
@@ -125,11 +133,11 @@ public class Workspace {
         template.add("sidecarExe", toRelative(launchDir, backendDir.resolve("dbunit-cli-sidecar.exe")));
         template.add("backendDir", toRelative(launchDir, backendDir));
         template.add("workspaceProperty", FileResources.PROPERTY_WORKSPACE);
-        template.add("workspace", toRelative(launchDir, FileResources.baseDir().toPath().toAbsolutePath().normalize()));
+        template.add("workspace", rawOrRelative(launchDir, FileResources.PROPERTY_WORKSPACE, FileResources.baseDir().toPath().toAbsolutePath().normalize()));
         template.add("datasetBaseProperty", FileResources.PROPERTY_DATASET_BASE);
-        template.add("datasetBase", toRelative(launchDir, FileResources.datasetDir().toPath().toAbsolutePath().normalize()));
+        template.add("datasetBase", rawOrRelative(launchDir, FileResources.PROPERTY_DATASET_BASE, FileResources.datasetDir().toPath().toAbsolutePath().normalize()));
         template.add("resultBaseProperty", FileResources.PROPERTY_RESULT_BASE);
-        template.add("resultBase", toRelative(launchDir, FileResources.resultDir().toPath().toAbsolutePath().normalize()));
+        template.add("resultBase", rawOrRelative(launchDir, FileResources.PROPERTY_RESULT_BASE, FileResources.resultDir().toPath().toAbsolutePath().normalize()));
         template.add("commandType", commandType.name());
         template.add("name", name);
         final String content = template.render();

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class Workspace {
@@ -49,13 +50,14 @@ public class Workspace {
         }
     }
 
-    private static String rawOrRelative(final Path launchDir, final String propertyName, final Path expandedPath) {
+    private static String rawOrRelative(final Path launchDir, final String propertyName, final Supplier<Path> expandedPath) {
         final String raw = System.getProperty(propertyName);
         if (raw != null && raw.contains("%")) {
             return raw;
         }
-        return toRelative(launchDir, expandedPath);
+        return toRelative(launchDir, expandedPath.get());
     }
+
     private Options options;
     private Resources resources;
     private Path path;
@@ -133,11 +135,11 @@ public class Workspace {
         template.add("sidecarExe", toRelative(launchDir, backendDir.resolve("dbunit-cli-sidecar.exe")));
         template.add("backendDir", toRelative(launchDir, backendDir));
         template.add("workspaceProperty", FileResources.PROPERTY_WORKSPACE);
-        template.add("workspace", rawOrRelative(launchDir, FileResources.PROPERTY_WORKSPACE, FileResources.baseDir().toPath().toAbsolutePath().normalize()));
+        template.add("workspace", rawOrRelative(launchDir, FileResources.PROPERTY_WORKSPACE, () -> FileResources.baseDir().toPath().toAbsolutePath().normalize()));
         template.add("datasetBaseProperty", FileResources.PROPERTY_DATASET_BASE);
-        template.add("datasetBase", rawOrRelative(launchDir, FileResources.PROPERTY_DATASET_BASE, FileResources.datasetDir().toPath().toAbsolutePath().normalize()));
+        template.add("datasetBase", rawOrRelative(launchDir, FileResources.PROPERTY_DATASET_BASE, () -> FileResources.datasetDir().toPath().toAbsolutePath().normalize()));
         template.add("resultBaseProperty", FileResources.PROPERTY_RESULT_BASE);
-        template.add("resultBase", rawOrRelative(launchDir, FileResources.PROPERTY_RESULT_BASE, FileResources.resultDir().toPath().toAbsolutePath().normalize()));
+        template.add("resultBase", rawOrRelative(launchDir, FileResources.PROPERTY_RESULT_BASE, () -> FileResources.resultDir().toPath().toAbsolutePath().normalize()));
         template.add("commandType", commandType.name());
         template.add("name", name);
         final String content = template.render();

--- a/tauri/src/hooks/useWorkspaceResources.ts
+++ b/tauri/src/hooks/useWorkspaceResources.ts
@@ -25,17 +25,9 @@ export const useWorkspaceUpdate = () => {
 		await fetchData(fetchParams)
 			.then((response) => response.json())
 			.then((resources: WorkspaceResources) => {
-				const ctx = WorkspaceContext.from(resources.context);
-				setContext(new WorkspaceContext(
-					workspace,
-					datasetBase,
-					resultBase,
-					ctx.settingBase,
-					ctx.templateBase,
-					ctx.parameterizeTemplateBase,
-					ctx.jdbcBase,
-					ctx.xlsxSchemaBase,
-				));
+				setContext(
+					WorkspaceContext.from(resources.context).with({ workspace, datasetBase, resultBase }),
+				);
 				setParameterList(ParameterList.from(resources.parameterList));
 				setResourcesSettings(new ResourcesSettings(resources.resources));
 			})

--- a/tauri/src/hooks/useWorkspaceResources.ts
+++ b/tauri/src/hooks/useWorkspaceResources.ts
@@ -25,7 +25,17 @@ export const useWorkspaceUpdate = () => {
 		await fetchData(fetchParams)
 			.then((response) => response.json())
 			.then((resources: WorkspaceResources) => {
-				setContext(WorkspaceContext.from(resources.context));
+				const ctx = WorkspaceContext.from(resources.context);
+				setContext(new WorkspaceContext(
+					workspace,
+					datasetBase,
+					resultBase,
+					ctx.settingBase,
+					ctx.templateBase,
+					ctx.parameterizeTemplateBase,
+					ctx.jdbcBase,
+					ctx.xlsxSchemaBase,
+				));
 				setParameterList(ParameterList.from(resources.parameterList));
 				setResourcesSettings(new ResourcesSettings(resources.resources));
 			})

--- a/tauri/src/model/WorkspaceResources.ts
+++ b/tauri/src/model/WorkspaceResources.ts
@@ -56,6 +56,18 @@ export class WorkspaceContext {
 		this.jdbcBase = jdbcBase;
 		this.xlsxSchemaBase = xlsxSchemaBase;
 	}
+	with(overrides: Partial<WorkspaceContextBuilder>): WorkspaceContext {
+		return new WorkspaceContext(
+			overrides.workspace ?? this.workspace,
+			overrides.datasetBase ?? this.datasetBase,
+			overrides.resultBase ?? this.resultBase,
+			overrides.settingBase ?? this.settingBase,
+			overrides.templateBase ?? this.templateBase,
+			overrides.parameterizeTemplateBase ?? this.parameterizeTemplateBase,
+			overrides.jdbcBase ?? this.jdbcBase,
+			overrides.xlsxSchemaBase ?? this.xlsxSchemaBase,
+		);
+	}
 }
 export type ParameterListBuilder = {
 	convert: string[];


### PR DESCRIPTION
## Summary
This change adds support for preserving raw system property values (containing environment variable placeholders like `%VAR%`) in generated shell scripts, while maintaining relative path resolution for computed values.

## Key Changes

- **Java (Workspace.java)**
  - Added new `rawOrRelative()` helper method that checks if a system property contains `%` characters and returns the raw value if present, otherwise computes and returns a relative path
  - Updated three template variable assignments (`workspace`, `datasetBase`, `resultBase`) to use `rawOrRelative()` instead of always computing relative paths
  - This allows environment variable placeholders in system properties to be preserved in shell script generation

- **TypeScript (WorkspaceResources.ts)**
  - Added `with()` method to `WorkspaceContext` class for creating modified copies with partial overrides
  - Enables fluent-style updates to workspace context objects

- **TypeScript (useWorkspaceResources.ts)**
  - Updated `useWorkspaceUpdate()` hook to preserve user-provided workspace paths (`workspace`, `datasetBase`, `resultBase`) when updating context from fetched resources
  - Uses the new `with()` method to merge fetched context with user overrides

## Implementation Details
The `rawOrRelative()` method uses lazy evaluation via `Supplier<Path>` to avoid unnecessary path computations when a raw property value is available. This ensures that environment variable placeholders in system properties are not expanded prematurely and are passed through to shell scripts as-is.

https://claude.ai/code/session_01U6qw3MoZF8nwLTvMy3Fvkd