### PR TITLE
Use OS default charset for BAT file generation on Windows

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -18,7 +18,7 @@ import yo.dbunitcli.sidecar.dto.WorkspaceDto;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -144,7 +144,7 @@ public class Workspace {
         template.add("name", name);
         final String content = template.render();
         final File scriptFile = new File(launchDir.toFile(), commandType.name() + "_" + name + ".bat");
-        Files.writeString(scriptFile.toPath(), content, StandardCharsets.UTF_8);
+        Files.writeString(scriptFile.toPath(), content, Charset.defaultCharset());
         return scriptFile.getAbsolutePath();
     }
 

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -144,6 +144,7 @@ public class Workspace {
         template.add("name", name);
         final String content = template.render();
         final File scriptFile = new File(launchDir.toFile(), commandType.name() + "_" + name + ".bat");
+        // BATファイルはWindowsのOSデフォルト文字コードで保存する必要がある
         Files.writeString(scriptFile.toPath(), content, Charset.defaultCharset());
         return scriptFile.getAbsolutePath();
     }


### PR DESCRIPTION
## Summary
Changed the character encoding used when writing BAT script files from UTF-8 to the OS default charset to ensure compatibility with Windows batch file execution.

## Key Changes
- Updated import statement from `StandardCharsets` to `Charset` in `Workspace.java`
- Modified `saveShell()` method to use `Charset.defaultCharset()` instead of `StandardCharsets.UTF_8` when writing BAT files
- Added explanatory comment in Japanese indicating that BAT files must be saved using the Windows OS default character encoding

## Implementation Details
The change addresses a compatibility issue where BAT files generated with UTF-8 encoding may not execute properly on Windows systems. By using the OS default charset (typically Windows-1252 or similar on Windows), the generated batch scripts will be properly recognized and executed by the Windows command interpreter.

https://claude.ai/code/session_01JrxBS66pNHRRJJGJ7esx9n