### PR TITLE
Add column header to ArraysText component

### DIFF
--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -257,38 +257,39 @@ export function ArraysText(props: {
 	const handleBlur = (newVal: React.FocusEvent<HTMLInputElement>) =>
 		props.handleChange(newVal.target.value, props.index);
 	const handleRemove = () => props.handleRemove(props.index);
+	const showLabel = !props.ignoreLabel && props.index === 0;
 	return (
 		<>
-			{!props.ignoreLabel && props.index === 0 && (
+			{showLabel && (
 				<div className="grid grid-cols-5 pb-1">
 					<span className="col-start-2 text-xs text-gray-500">column</span>
 				</div>
 			)}
 			<div className="grid grid-cols-5 pb-2">
-			{!props.ignoreLabel && props.index === 0 && (
-				<InputLabel
+				{showLabel && (
+					<InputLabel
+						id={props.name}
+						text={props.name}
+						required={false}
+						wStyle="p-2.5 w=1/5"
+					/>
+				)}
+				<ControllTextBox
+					name={props.name}
 					id={props.name}
-					text={props.name}
-					required={false}
-					wStyle="p-2.5 w=1/5"
+					required={true}
+					wStyle="col-start-2"
+					value={text}
+					handleChange={(ev) => setText(ev.target.value)}
+					handleBlur={handleBlur}
+					list={props.list}
 				/>
-			)}
-			<ControllTextBox
-				name={props.name}
-				id={props.name}
-				required={true}
-				wStyle="col-start-2"
-				value={text}
-				handleChange={(ev) => setText(ev.target.value)}
-				handleBlur={handleBlur}
-				list={props.list}
-			/>
-			{props.index > 0 && (
-				<div className="col-start-3">
-					<RemoveButton handleClick={handleRemove} />
-				</div>
-			)}
-		</div>
+				{props.index > 0 && (
+					<div className="col-start-3">
+						<RemoveButton handleClick={handleRemove} />
+					</div>
+				)}
+			</div>
 		</>
 	);
 }

--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -258,7 +258,13 @@ export function ArraysText(props: {
 		props.handleChange(newVal.target.value, props.index);
 	const handleRemove = () => props.handleRemove(props.index);
 	return (
-		<div className="grid grid-cols-5 pb-2">
+		<>
+			{!props.ignoreLabel && props.index === 0 && (
+				<div className="grid grid-cols-5 pb-1">
+					<span className="col-start-2 text-xs text-gray-500">column</span>
+				</div>
+			)}
+			<div className="grid grid-cols-5 pb-2">
 			{!props.ignoreLabel && props.index === 0 && (
 				<InputLabel
 					id={props.name}
@@ -283,6 +289,7 @@ export function ArraysText(props: {
 				</div>
 			)}
 		</div>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary
Enhanced the `ArraysText` component in the SettingDialog to display a column header above the input field, improving UI clarity for array input fields.

## Key Changes
- Extracted the label visibility logic into a `showLabel` constant for better readability
- Added a new header row that displays "column" text when the first array item is rendered
- Restructured the component to use a fragment wrapper containing two separate grid sections:
  - Header row (only shown for the first item)
  - Input row (shown for all items)
- Updated the conditional rendering to use the `showLabel` variable consistently throughout the component

## Implementation Details
- The header row uses the same grid layout (`grid-cols-5`) as the input row for alignment
- The "column" label is styled with `text-xs text-gray-500` for subtle visual hierarchy
- The header is only rendered when `!props.ignoreLabel && props.index === 0`, ensuring it appears once per array field
- The component now uses a React Fragment (`<>...</>`) to avoid adding unnecessary DOM wrapper elements

https://claude.ai/code/session_01FgngLJ4nhwp8qXP2C4no1h