### PR TITLE
Add refresh endpoint tests for dynamic form field updates

### DIFF
--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
@@ -149,6 +149,16 @@ class CompareControllerTest {
         assertRefresh("{\"-expect.srcType\":\"xlsx\"}", "compare-refresh-expectSrcType-xlsx-response.json");
     }
 
+    @Test
+    public void testRefresh_targetTypeImage_imageOptionが追加されsrcTypeがfileに制限される() throws IOException {
+        assertRefresh("{\"-targetType\":\"image\"}", "compare-refresh-targetType-image-response.json");
+    }
+
+    @Test
+    public void testRefresh_targetTypePdf_imageOptionが追加されsrcTypeがfileに制限される() throws IOException {
+        assertRefresh("{\"-targetType\":\"pdf\"}", "compare-refresh-targetType-pdf-response.json");
+    }
+
     private void assertRefresh(final String requestJson, final String expectedFile) throws IOException {
         final String jsonResponse = this.client.toBlocking().retrieve(
                 HttpRequest.POST("dbunit-cli/compare/refresh", requestJson));

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
@@ -126,42 +126,34 @@ class CompareControllerTest {
 
     @Test
     public void testRefresh_newSrcTypeXlsx_newDataにxlsxSchema要素が追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-new.srcType\":\"xlsx\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-xlsx-response.json"), jsonResponse);
+        assertRefresh("{\"-new.srcType\":\"xlsx\"}", "compare-refresh-newSrcType-xlsx-response.json");
     }
 
     @Test
     public void testRefresh_newSrcTypeTable_newDataにJDBC要素が追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-new.srcType\":\"table\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-table-response.json"), jsonResponse);
+        assertRefresh("{\"-new.srcType\":\"table\"}", "compare-refresh-newSrcType-table-response.json");
     }
 
     @Test
     public void testRefresh_oldSrcTypeXlsx_oldDataにxlsxSchema要素が追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-old.srcType\":\"xlsx\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-oldSrcType-xlsx-response.json"), jsonResponse);
+        assertRefresh("{\"-old.srcType\":\"xlsx\"}", "compare-refresh-oldSrcType-xlsx-response.json");
     }
 
     @Test
     public void testRefresh_expectSrcTypeCsv_expectDataにCSV要素が追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-expect.srcType\":\"csv\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-csv-response.json"), jsonResponse);
+        assertRefresh("{\"-expect.srcType\":\"csv\"}", "compare-refresh-expectSrcType-csv-response.json");
     }
 
     @Test
     public void testRefresh_expectSrcTypeXlsx_expectDataにxlsxSchema要素が追加される() throws IOException {
+        assertRefresh("{\"-expect.srcType\":\"xlsx\"}", "compare-refresh-expectSrcType-xlsx-response.json");
+    }
+
+    private void assertRefresh(final String requestJson, final String expectedFile) throws IOException {
         final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-expect.srcType\":\"xlsx\"}"));
+                HttpRequest.POST("dbunit-cli/compare/refresh", requestJson));
         System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-xlsx-response.json"), jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/" + expectedFile), jsonResponse);
     }
 
     private void tryDelete(final String name) {

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java
@@ -124,6 +124,46 @@ class CompareControllerTest {
         JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-reset-response.json"), jsonResponse);
     }
 
+    @Test
+    public void testRefresh_newSrcTypeXlsx_newDataにxlsxSchema要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-new.srcType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-xlsx-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_newSrcTypeTable_newDataにJDBC要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-new.srcType\":\"table\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-table-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_oldSrcTypeXlsx_oldDataにxlsxSchema要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-old.srcType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-oldSrcType-xlsx-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_expectSrcTypeCsv_expectDataにCSV要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-expect.srcType\":\"csv\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-csv-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_expectSrcTypeXlsx_expectDataにxlsxSchema要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/compare/refresh", "{\"-expect.srcType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-xlsx-response.json"), jsonResponse);
+    }
+
     private void tryDelete(final String name) {
         this.tryDeleteCommand("compare", name);
     }

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java
@@ -123,6 +123,86 @@ class ConvertControllerTest {
         JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-reset-response.json"), jsonResponse);
     }
 
+    @Test
+    public void testRefresh_srcTypeXlsx_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xlsx-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeXls_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"xls\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xls-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeReg_regDataSplitとregHeaderSplitが追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"reg\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-reg-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeFixed_fixedLength要素が追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"fixed\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-fixed-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeTable_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"table\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-table-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeSql_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"sql\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-sql-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeFile_最小限の要素のみになる() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"file\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-file-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeDir_トラバース要素のみになる() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"dir\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-dir-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_resultTypeXlsx_excelTable要素が追加されoutputEncodingが削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-resultType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xlsx-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_resultTypeXls_excelTable要素が追加されoutputEncodingが削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-resultType\":\"xls\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xls-response.json"), jsonResponse);
+    }
+
     private void tryDelete(final String name) {
         this.tryDeleteCommand("convert", name);
     }

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java
@@ -125,82 +125,59 @@ class ConvertControllerTest {
 
     @Test
     public void testRefresh_srcTypeXlsx_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"xlsx\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xlsx-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"xlsx\"}", "convert-refresh-srcType-xlsx-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeXls_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"xls\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xls-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"xls\"}", "convert-refresh-srcType-xls-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeReg_regDataSplitとregHeaderSplitが追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"reg\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-reg-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"reg\"}", "convert-refresh-srcType-reg-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeFixed_fixedLength要素が追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"fixed\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-fixed-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"fixed\"}", "convert-refresh-srcType-fixed-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeTable_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"table\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-table-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"table\"}", "convert-refresh-srcType-table-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeSql_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"sql\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-sql-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"sql\"}", "convert-refresh-srcType-sql-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeFile_最小限の要素のみになる() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"file\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-file-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"file\"}", "convert-refresh-srcType-file-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeDir_トラバース要素のみになる() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-srcType\":\"dir\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-dir-response.json"), jsonResponse);
+        assertRefresh("{\"-srcType\":\"dir\"}", "convert-refresh-srcType-dir-response.json");
     }
 
     @Test
     public void testRefresh_resultTypeXlsx_excelTable要素が追加されoutputEncodingが削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-resultType\":\"xlsx\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xlsx-response.json"), jsonResponse);
+        assertRefresh("{\"-resultType\":\"xlsx\"}", "convert-refresh-resultType-xlsx-response.json");
     }
 
     @Test
     public void testRefresh_resultTypeXls_excelTable要素が追加されoutputEncodingが削除される() throws IOException {
+        assertRefresh("{\"-resultType\":\"xls\"}", "convert-refresh-resultType-xls-response.json");
+    }
+
+    private void assertRefresh(final String requestJson, final String expectedFile) throws IOException {
         final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/convert/refresh", "{\"-resultType\":\"xls\"}"));
+                HttpRequest.POST("dbunit-cli/convert/refresh", requestJson));
         System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xls-response.json"), jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/" + expectedFile), jsonResponse);
     }
 
     private void tryDelete(final String name) {

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java
@@ -122,6 +122,38 @@ class GenerateControllerTest {
         JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-reset-response.json"), jsonResponse);
     }
 
+    @Test
+    public void testRefresh_srcTypeXlsx_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"xlsx\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-xlsx-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeReg_regDataSplitとregHeaderSplitが追加される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"reg\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-reg-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeTable_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"table\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-table-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_srcTypeFile_最小限の要素のみになる() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"file\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-file-response.json"), jsonResponse);
+    }
+
     private void tryDelete(final String name) {
         this.tryDeleteCommand("generate", name);
     }

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java
@@ -124,34 +124,29 @@ class GenerateControllerTest {
 
     @Test
     public void testRefresh_srcTypeXlsx_xlsxSchema要素が追加されdelimiterIgnoreQuotedが削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"xlsx\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-xlsx-response.json"), jsonResponse);
+        assertRefresh("{\"-src.srcType\":\"xlsx\"}", "generate-refresh-srcType-xlsx-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeReg_regDataSplitとregHeaderSplitが追加される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"reg\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-reg-response.json"), jsonResponse);
+        assertRefresh("{\"-src.srcType\":\"reg\"}", "generate-refresh-srcType-reg-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeTable_JDBC要素が追加されファイルトラバース要素が削除される() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"table\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-table-response.json"), jsonResponse);
+        assertRefresh("{\"-src.srcType\":\"table\"}", "generate-refresh-srcType-table-response.json");
     }
 
     @Test
     public void testRefresh_srcTypeFile_最小限の要素のみになる() throws IOException {
+        assertRefresh("{\"-src.srcType\":\"file\"}", "generate-refresh-srcType-file-response.json");
+    }
+
+    private void assertRefresh(final String requestJson, final String expectedFile) throws IOException {
         final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/generate/refresh", "{\"-src.srcType\":\"file\"}"));
+                HttpRequest.POST("dbunit-cli/generate/refresh", requestJson));
         System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-file-response.json"), jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/" + expectedFile), jsonResponse);
     }
 
     private void tryDelete(final String name) {

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java
@@ -126,18 +126,19 @@ class RunControllerTest {
 
     @Test
     public void testRefresh_scriptTypeSql_デフォルト構造が返る() throws IOException {
-        final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/run/refresh", "{\"-scriptType\":\"sql\"}"));
-        System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-sql-response.json"), jsonResponse);
+        assertRefresh("{\"-scriptType\":\"sql\"}", "run-refresh-scriptType-sql-response.json");
     }
 
     @Test
     public void testRefresh_scriptTypeCmd_構造が返る() throws IOException {
+        assertRefresh("{\"-scriptType\":\"cmd\"}", "run-refresh-scriptType-cmd-response.json");
+    }
+
+    private void assertRefresh(final String requestJson, final String expectedFile) throws IOException {
         final String jsonResponse = this.client.toBlocking().retrieve(
-                HttpRequest.POST("dbunit-cli/run/refresh", "{\"-scriptType\":\"cmd\"}"));
+                HttpRequest.POST("dbunit-cli/run/refresh", requestJson));
         System.out.println(jsonResponse);
-        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-cmd-response.json"), jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/" + expectedFile), jsonResponse);
     }
 
     private void tryDelete(final String name) {

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java
@@ -124,6 +124,22 @@ class RunControllerTest {
         JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/run-reset-response.json"), jsonResponse);
     }
 
+    @Test
+    public void testRefresh_scriptTypeSql_デフォルト構造が返る() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/run/refresh", "{\"-scriptType\":\"sql\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-sql-response.json"), jsonResponse);
+    }
+
+    @Test
+    public void testRefresh_scriptTypeCmd_構造が返る() throws IOException {
+        final String jsonResponse = this.client.toBlocking().retrieve(
+                HttpRequest.POST("dbunit-cli/run/refresh", "{\"-scriptType\":\"cmd\"}"));
+        System.out.println(jsonResponse);
+        JsonTestHelper.assertJsonEquals(Paths.get("src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-cmd-response.json"), jsonResponse);
+    }
+
     private void tryDelete(final String name) {
         this.tryDeleteCommand("run", name);
     }

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-csv-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-csv-response.json
@@ -1,0 +1,634 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "data"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-expectSrcType-xlsx-response.json
@@ -1,0 +1,616 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "data"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-table-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-table-response.json
@@ -1,0 +1,535 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "data"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "table"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "jdbcProperties",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "JDBC"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUrl",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUser",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcPass",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "useJdbcMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "none"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-newSrcType-xlsx-response.json
@@ -1,0 +1,463 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "data"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "none"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-oldSrcType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-oldSrcType-xlsx-response.json
@@ -1,0 +1,463 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "data"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "none"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-targetType-image-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-targetType-image-response.json
@@ -1,0 +1,486 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "image"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "imageOption": {
+    "prefix": "image",
+    "elements": [
+      {
+        "name": "threshold",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "pixelToleranceLevel",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "allowingPercentOfDifferentPixels",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "rectangleLineWidth",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "minimalRectangleSize",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "maximalRectangleCount",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "excludedAreas",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "drawExcludedRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "fillExcludedRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "percentOpacityExcludedRectangles",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "excludedRectangleColor",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "fillDifferenceRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "percentOpacityDifferenceRectangles",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "differenceRectangleColor",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      }
+    ]
+  },
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "file"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "png"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "file"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "png"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "none"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-targetType-pdf-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/compare-refresh-targetType-pdf-response.json
@@ -1,0 +1,486 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "targetType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "data",
+          "image",
+          "pdf"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "pdf"
+    },
+    {
+      "name": "setting",
+      "attribute": {
+        "type": "FILE",
+        "required": false,
+        "defaultPath": "SETTING"
+      },
+      "value": ""
+    },
+    {
+      "name": "settingEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "imageOption": {
+    "prefix": "image",
+    "elements": [
+      {
+        "name": "threshold",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "pixelToleranceLevel",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "allowingPercentOfDifferentPixels",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "rectangleLineWidth",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "minimalRectangleSize",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "maximalRectangleCount",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "excludedAreas",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "drawExcludedRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "fillExcludedRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "percentOpacityExcludedRectangles",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "excludedRectangleColor",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "fillDifferenceRectangles",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "percentOpacityDifferenceRectangles",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "differenceRectangleColor",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      }
+    ]
+  },
+  "newData": {
+    "prefix": "new",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "file"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "pdf"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "oldData": {
+    "prefix": "old",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "file"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "pdf"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx"
+          ],
+          "required": true,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  },
+  "expectData": {
+    "prefix": "expect",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "none",
+            "sql",
+            "csv",
+            "csvq",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "none"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xls-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xls-response.json
@@ -1,0 +1,248 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xls"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "excelTable",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "SHEET"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-resultType-xlsx-response.json
@@ -1,0 +1,248 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "delimiter",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ","
+      },
+      {
+        "name": "ignoreQuoted",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "excelTable",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "SHEET"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-dir-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-dir-response.json
@@ -1,0 +1,185 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "dir"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-file-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-file-response.json
@@ -1,0 +1,194 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-fixed-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-fixed-response.json
@@ -1,0 +1,239 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "fixed"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "fixedLength",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-reg-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-reg-response.json
@@ -1,0 +1,248 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "reg"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regDataSplit",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regHeaderSplit",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-sql-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-sql-response.json
@@ -1,0 +1,302 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "sql"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "jdbcProperties",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "JDBC"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUrl",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUser",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcPass",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "useJdbcMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-table-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-table-response.json
@@ -1,0 +1,302 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "table"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "jdbcProperties",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "JDBC"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUrl",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUser",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcPass",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "useJdbcMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xls-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xls-response.json
@@ -1,0 +1,230 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xls"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/convert-refresh-srcType-xlsx-response.json
@@ -1,0 +1,230 @@
+{
+  "prefix": "",
+  "elements": [],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "convertResult": {
+    "prefix": "result",
+    "elements": [
+      {
+        "name": "resultType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "csv",
+            "xls",
+            "xlsx",
+            "table"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "csv"
+      },
+      {
+        "name": "result",
+        "attribute": {
+          "type": "DIR",
+          "required": false,
+          "defaultPath": "RESULT"
+        },
+        "value": ""
+      },
+      {
+        "name": "resultPath",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "exportEmptyTable",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "exportHeader",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "outputEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-file-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-file-response.json
@@ -1,0 +1,247 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "generateType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "txt",
+          "xlsx",
+          "xls",
+          "settings",
+          "sql",
+          "xlsxTemplate"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "txt"
+    },
+    {
+      "name": "unit",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "record",
+          "table",
+          "dataset"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "record"
+    },
+    {
+      "name": "template",
+      "attribute": {
+        "type": "FILE",
+        "required": true,
+        "defaultPath": "TEMPLATE"
+      },
+      "value": ""
+    },
+    {
+      "name": "result",
+      "attribute": {
+        "type": "DIR",
+        "required": false,
+        "defaultPath": "RESULT"
+      },
+      "value": ""
+    },
+    {
+      "name": "resultPath",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "result"
+    },
+    {
+      "name": "outputEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "file"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "templateOption": {
+    "prefix": "template",
+    "elements": [
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-reg-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-reg-response.json
@@ -1,0 +1,301 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "generateType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "txt",
+          "xlsx",
+          "xls",
+          "settings",
+          "sql",
+          "xlsxTemplate"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "txt"
+    },
+    {
+      "name": "unit",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "record",
+          "table",
+          "dataset"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "record"
+    },
+    {
+      "name": "template",
+      "attribute": {
+        "type": "FILE",
+        "required": true,
+        "defaultPath": "TEMPLATE"
+      },
+      "value": ""
+    },
+    {
+      "name": "result",
+      "attribute": {
+        "type": "DIR",
+        "required": false,
+        "defaultPath": "RESULT"
+      },
+      "value": ""
+    },
+    {
+      "name": "resultPath",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "result"
+    },
+    {
+      "name": "outputEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "reg"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regDataSplit",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regHeaderSplit",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "templateOption": {
+    "prefix": "template",
+    "elements": [
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-table-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-table-response.json
@@ -1,0 +1,355 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "generateType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "txt",
+          "xlsx",
+          "xls",
+          "settings",
+          "sql",
+          "xlsxTemplate"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "txt"
+    },
+    {
+      "name": "unit",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "record",
+          "table",
+          "dataset"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "record"
+    },
+    {
+      "name": "template",
+      "attribute": {
+        "type": "FILE",
+        "required": true,
+        "defaultPath": "TEMPLATE"
+      },
+      "value": ""
+    },
+    {
+      "name": "result",
+      "attribute": {
+        "type": "DIR",
+        "required": false,
+        "defaultPath": "RESULT"
+      },
+      "value": ""
+    },
+    {
+      "name": "resultPath",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "result"
+    },
+    {
+      "name": "outputEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "table"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "jdbcProperties",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "JDBC"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUrl",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUser",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcPass",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "useJdbcMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "templateOption": {
+    "prefix": "template",
+    "elements": [
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-xlsx-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/generate-refresh-srcType-xlsx-response.json
@@ -1,0 +1,283 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "generateType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "txt",
+          "xlsx",
+          "xls",
+          "settings",
+          "sql",
+          "xlsxTemplate"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "txt"
+    },
+    {
+      "name": "unit",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "record",
+          "table",
+          "dataset"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "record"
+    },
+    {
+      "name": "template",
+      "attribute": {
+        "type": "FILE",
+        "required": true,
+        "defaultPath": "TEMPLATE"
+      },
+      "value": ""
+    },
+    {
+      "name": "result",
+      "attribute": {
+        "type": "DIR",
+        "required": false,
+        "defaultPath": "RESULT"
+      },
+      "value": ""
+    },
+    {
+      "name": "resultPath",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "result"
+    },
+    {
+      "name": "outputEncoding",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "UTF-8"
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "srcType",
+        "attribute": {
+          "type": "ENUM",
+          "selectOption": [
+            "table",
+            "sql",
+            "file",
+            "dir",
+            "csv",
+            "csvq",
+            "reg",
+            "fixed",
+            "xls",
+            "xlsx"
+          ],
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "xlsx"
+      },
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "extension",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "headerName",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "startRow",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "1"
+      },
+      {
+        "name": "addFileInfo",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "xlsxSchema",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "XLSX_SCHEMA"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "loadData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "true"
+      },
+      {
+        "name": "includeMetaData",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      }
+    ]
+  },
+  "templateOption": {
+    "prefix": "template",
+    "elements": [
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-cmd-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-cmd-response.json
@@ -1,0 +1,106 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "scriptType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "cmd",
+          "bat",
+          "sql",
+          "ant"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "cmd"
+    },
+    {
+      "name": "baseDir",
+      "attribute": {
+        "type": "TEXT",
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": ""
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      }
+    ]
+  }
+}

--- a/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-sql-response.json
+++ b/sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/run-refresh-scriptType-sql-response.json
@@ -1,0 +1,188 @@
+{
+  "prefix": "",
+  "elements": [
+    {
+      "name": "scriptType",
+      "attribute": {
+        "type": "ENUM",
+        "selectOption": [
+          "cmd",
+          "bat",
+          "sql",
+          "ant"
+        ],
+        "required": false,
+        "defaultPath": "WORKSPACE"
+      },
+      "value": "sql"
+    }
+  ],
+  "srcData": {
+    "prefix": "src",
+    "elements": [
+      {
+        "name": "src",
+        "attribute": {
+          "type": "FILE_OR_DIR",
+          "required": true,
+          "defaultPath": "DATASET"
+        },
+        "value": ""
+      },
+      {
+        "name": "recursive",
+        "attribute": {
+          "type": "FLG",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "false"
+      },
+      {
+        "name": "regInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "setting",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "SETTING"
+        },
+        "value": ""
+      },
+      {
+        "name": "settingEncoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "regTableInclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "regTableExclude",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      }
+    ]
+  },
+  "templateOption": {
+    "prefix": "template",
+    "elements": [
+      {
+        "name": "encoding",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "UTF-8"
+      },
+      {
+        "name": "templateGroup",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "TEMPLATE"
+        },
+        "value": ""
+      },
+      {
+        "name": "templateParameterAttribute",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "param"
+      },
+      {
+        "name": "templateVarStart",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      },
+      {
+        "name": "templateVarStop",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": "$"
+      }
+    ]
+  },
+  "jdbcOption": {
+    "prefix": "jdbc",
+    "elements": [
+      {
+        "name": "jdbcProperties",
+        "attribute": {
+          "type": "FILE",
+          "required": false,
+          "defaultPath": "JDBC"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUrl",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcUser",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      },
+      {
+        "name": "jdbcPass",
+        "attribute": {
+          "type": "TEXT",
+          "required": false,
+          "defaultPath": "WORKSPACE"
+        },
+        "value": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the refresh endpoint functionality across multiple controllers (Compare, Generate, Convert, and Run). The refresh endpoint dynamically updates form fields based on user selections, and these tests verify that the correct fields are returned for different parameter combinations.

## Key Changes
- Added `testRefresh_*` test methods to `CompareControllerTest`, `GenerateControllerTest`, `ConvertControllerTest`, and `RunControllerTest`
- Created 24 new JSON test fixture files containing expected API responses for various refresh scenarios:
  - **Compare controller**: Tests for `targetType` (image, pdf) and `srcType` (csv, xlsx) parameter changes
  - **Generate controller**: Tests for `srcType` parameter changes (table, file, reg, xlsx)
  - **Convert controller**: Tests for `srcType` and `resultType` parameter changes (various file formats)
  - **Run controller**: Tests for `scriptType` parameter changes (cmd, sql)
- Each fixture file contains the complete form structure with appropriate fields for the selected parameter value

## Implementation Details
- Tests follow the existing pattern of comparing actual API responses against pre-generated JSON fixtures using `JsonTestHelper.assertJsonEquals()`
- Fixtures demonstrate the dynamic nature of the forms - different parameter selections result in different available fields being returned
- For example, selecting "image" or "pdf" as `targetType` in Compare adds an `imageOption` section with image comparison settings
- The `srcType` parameter significantly affects available fields (e.g., "table" type includes JDBC properties, while "csv" includes delimiter and encoding options)

https://claude.ai/code/session_01RhW4arcD5uWo65yyx21m3t