### PR TITLE
Add Maven proxy setup for Claude web environment

### DIFF
--- a/.claude/maven-proxy.py
+++ b/.claude/maven-proxy.py
@@ -33,21 +33,44 @@ def handle(client):
             resp += upstream.recv(4096)
         if b'200' in resp.split(b'\r\n')[0]:
             client.send(b'HTTP/1.1 200 Connection Established\r\n\r\n')
-            for s in [client, upstream]:
-                s.setblocking(False)
+            peer = {client: upstream, upstream: client}
+            # Keep sockets BLOCKING for sendall - non-blocking sendall loses data
+            # Use select only to detect readability
+            half_closed = set()
             while True:
-                r, _, _ = select.select([client, upstream], [], [], 30)
+                active = [s for s in [client, upstream] if s not in half_closed]
+                if not active:
+                    break
+                r, _, _ = select.select(active, [], [], 60)
                 if not r:
                     break
                 for s in r:
-                    data = s.recv(8192)
+                    try:
+                        data = s.recv(65536)
+                    except OSError:
+                        half_closed.add(s)
+                        half_closed.add(peer[s])
+                        continue
                     if not data:
-                        return
-                    (upstream if s is client else client).sendall(data)
+                        half_closed.add(s)
+                        try:
+                            peer[s].shutdown(socket.SHUT_WR)
+                        except OSError:
+                            half_closed.add(peer[s])
+                    else:
+                        try:
+                            peer[s].sendall(data)
+                        except OSError:
+                            half_closed.add(s)
+                            half_closed.add(peer[s])
     except:
         pass
     finally:
-        client.close()
+        for s in [client]:
+            try:
+                s.close()
+            except OSError:
+                pass
 
 if __name__ == '__main__':
     srv = socket.socket()

--- a/.claude/maven-proxy.py
+++ b/.claude/maven-proxy.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Local proxy that adds auth when forwarding to upstream proxy."""
+import socket, threading, os, base64, select, sys
+from urllib.parse import urlparse
+
+LOCAL_PORT = 3128
+UPSTREAM = os.environ.get('https_proxy') or os.environ.get('HTTPS_PROXY')
+
+if not UPSTREAM:
+    sys.exit(0)
+
+def get_upstream():
+    p = urlparse(UPSTREAM)
+    return p.hostname, p.port, p.username or '', p.password or ''
+
+def handle(client):
+    try:
+        req = b''
+        while b'\r\n\r\n' not in req:
+            req += client.recv(4096)
+        target = req.split(b'\r\n')[0].split()[1].decode()
+        host, port = (target.split(':') + ['443'])[:2]
+        proxy_host, proxy_port, user, pwd = get_upstream()
+        auth = base64.b64encode(f"{user}:{pwd}".encode()).decode()
+        upstream = socket.socket()
+        upstream.connect((proxy_host, proxy_port))
+        upstream.send(
+            f"CONNECT {host}:{port} HTTP/1.1\r\n"
+            f"Proxy-Authorization: Basic {auth}\r\n\r\n".encode()
+        )
+        resp = b''
+        while b'\r\n\r\n' not in resp:
+            resp += upstream.recv(4096)
+        if b'200' in resp.split(b'\r\n')[0]:
+            client.send(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+            for s in [client, upstream]:
+                s.setblocking(False)
+            while True:
+                r, _, _ = select.select([client, upstream], [], [], 30)
+                if not r:
+                    break
+                for s in r:
+                    data = s.recv(8192)
+                    if not data:
+                        return
+                    (upstream if s is client else client).sendall(data)
+    except:
+        pass
+    finally:
+        client.close()
+
+if __name__ == '__main__':
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        srv.bind(('127.0.0.1', LOCAL_PORT))
+    except OSError:
+        sys.exit(0)  # Already running
+    srv.listen(10)
+    print(f"Local proxy on 127.0.0.1:{LOCAL_PORT}", flush=True)
+    while True:
+        c, _ = srv.accept()
+        threading.Thread(target=handle, args=(c,), daemon=True).start()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-settings.json",
 	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash /home/user/dbunitcli/.claude/start-maven-proxy.sh"
+					}
+				]
+			}
+		],
 		"PostToolUse": [
 			{
 				"matcher": "Write|Edit",

--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -3,6 +3,16 @@ if [ -z "$https_proxy" ] && [ -z "$HTTPS_PROXY" ]; then
   exit 0
 fi
 
+nohup python3 /home/user/dbunitcli/.claude/maven-proxy.py >> /tmp/maven-proxy.log 2>&1 &
+echo "Maven proxy setup complete (PID: $!)"
+
+# Create ~/.mavenrc to override JAVA_TOOL_OPTIONS proxy settings
+# MAVEN_OPTS flags are appended to JVM command line, overriding JAVA_TOOL_OPTIONS
+cat > "$HOME/.mavenrc" << 'EOF'
+MAVEN_OPTS="-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.nonProxyHosts= $MAVEN_OPTS"
+EOF
+echo "~/.mavenrc created"
+
 mkdir -p "$HOME/.m2"
 cat > "$HOME/.m2/settings.xml" << 'EOF'
 <settings>
@@ -17,6 +27,3 @@ cat > "$HOME/.m2/settings.xml" << 'EOF'
  </proxies>
 </settings>
 EOF
-
-nohup python3 /home/user/dbunitcli/.claude/maven-proxy.py >> /tmp/maven-proxy.log 2>&1 &
-echo "Maven proxy setup complete (PID: $!)"

--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+if [ -z "$https_proxy" ] && [ -z "$HTTPS_PROXY" ]; then
+  exit 0
+fi
+
+mkdir -p "$HOME/.m2"
+cat > "$HOME/.m2/settings.xml" << 'EOF'
+<settings>
+ <proxies>
+  <proxy>
+   <id>local</id>
+   <active>true</active>
+   <protocol>https</protocol>
+   <host>127.0.0.1</host>
+   <port>3128</port>
+  </proxy>
+ </proxies>
+</settings>
+EOF
+
+nohup python3 /home/user/dbunitcli/.claude/maven-proxy.py >> /tmp/maven-proxy.log 2>&1 &
+echo "Maven proxy setup complete (PID: $!)"

--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-if [ -z "$https_proxy" ] && [ -z "$HTTPS_PROXY" ]; then
+# Claude on the web 環境のみ実行（JAVA_TOOL_OPTIONS に JWT プロキシが設定されている場合）
+if ! echo "${JAVA_TOOL_OPTIONS:-}" | grep -q "jwt_"; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
Add a local HTTP proxy and setup scripts to handle Maven dependency resolution in Claude web environments that use JWT authentication proxies.

## Key Changes
- **maven-proxy.py**: New Python script that implements a local CONNECT proxy on port 3128. It intercepts HTTPS requests and forwards them to the upstream proxy with Basic authentication credentials extracted from environment variables.
- **start-maven-proxy.sh**: New bash script that:
  - Detects if running in Claude web environment (checks for JWT proxy in JAVA_TOOL_OPTIONS)
  - Starts the local proxy in the background
  - Configures Maven via `~/.mavenrc` to use the local proxy instead of JAVA_TOOL_OPTIONS settings
  - Creates `~/.m2/settings.xml` with proxy configuration for Maven
- **settings.json**: Updated to run the Maven proxy setup script on session start

## Implementation Details
- The proxy uses blocking sockets with `sendall()` for data integrity and `select()` only for detecting readability to avoid data loss
- Handles half-closed connections gracefully with proper socket shutdown
- Automatically exits if already running (port already bound) or if no upstream proxy is configured
- Only activates in Claude web environments to avoid interference in other contexts

https://claude.ai/code/session_01XguUHLCt2mc3X5VW9ZMgL2