### PR TITLE
Remove dbunitcli test class exclusions from access filters

### DIFF
--- a/core/access-filter.json
+++ b/core/access-filter.json
@@ -14,12 +14,6 @@
     },
     {
       "excludeClasses": "mockit.**"
-    },
-    {
-      "excludeClasses": "yo.dbunitcli.**Test"
-    },
-    {
-      "excludeClasses": "yo.dbunitcli.**Test$*"
     }
   ]
 }

--- a/sidecar/access-filter.json
+++ b/sidecar/access-filter.json
@@ -14,12 +14,6 @@
     },
     {
       "excludeClasses": "mockit.**"
-    },
-    {
-      "excludeClasses": "yo.dbunitcli.sidecar.**Test"
-    },
-    {
-      "excludeClasses": "yo.dbunitcli.sidecar.**Test$*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Removed test class exclusion patterns from both core and sidecar access filter configurations. These exclusions were preventing test classes from being processed by the access control system.

## Changes
- **core/access-filter.json**: Removed exclusion rules for `yo.dbunitcli.**Test` and `yo.dbunitcli.**Test$*` classes
- **sidecar/access-filter.json**: Removed exclusion rules for `yo.dbunitcli.sidecar.**Test` and `yo.dbunitcli.sidecar.**Test$*` classes

## Details
The removal of these test class exclusions allows test classes in the dbunitcli packages to be subject to the same access control filtering as production code, which may be necessary for proper test execution or access control validation.

https://claude.ai/code/session_014wCeeePkwGhbppZYuyECQs