### PR TITLE
Upgrade Java version to 25 and refactor compiler configuration

### DIFF
--- a/sidecar/pom.xml
+++ b/sidecar/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>dbunit-cli-sidecar</artifactId>
     <properties>
         <packaging>jar</packaging>
-        <jdk.version>21</jdk.version>
-        <release.version>21</release.version>
+        <jdk.version>25</jdk.version>
+        <release.version>25</release.version>
         <micronaut.version>4.8.9</micronaut.version>
         <micronaut.aot.enabled>false</micronaut.aot.enabled>
         <micronaut.aot.packageName>yo.dbunitcli.sidecar.generated</micronaut.aot.packageName>
@@ -202,9 +202,9 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>25</source>
-                    <target>25</target>
-                    <release>25</release>
+                    <source>${release.version}</source>
+                    <target>${release.version}</target>
+                    <release>${release.version}</release>
                     <encoding>UTF-8</encoding>
                     <annotationProcessorPaths combine.children="append">
                         <path>
@@ -280,7 +280,7 @@
                 <configuration>
                     <rules combine.children="append">
                         <requireJavaVersion>
-                            <version>21</version>
+                            <version>${release.version}</version>
                         </requireJavaVersion>
                         <checkSnakeYaml/>
                     </rules>


### PR DESCRIPTION
## Summary
This PR upgrades the project's Java version from 21 to 25 and improves the Maven configuration by using property variables for version management instead of hardcoded values.

## Key Changes
- Updated `jdk.version` and `release.version` properties from 21 to 25
- Refactored maven-compiler-plugin configuration to use `${release.version}` property for source, target, and release settings instead of hardcoded "25" values
- Updated maven-enforcer-plugin's requireJavaVersion rule to use `${release.version}` property instead of hardcoded "21"

## Implementation Details
These changes improve maintainability by centralizing version management through Maven properties. All Java version references now point to the `release.version` property, making future version upgrades simpler and reducing the risk of inconsistent version specifications across the build configuration.

https://claude.ai/code/session_01TzMq1rrEHYJSSsT5GYSghA