### PR TITLE
Add refresh response fixtures and tests for CommandForm

### DIFF
--- a/tauri/src/tests/app/form/CommandForm.test.tsx
+++ b/tauri/src/tests/app/form/CommandForm.test.tsx
@@ -5,10 +5,14 @@ import CommandForm from "../../../app/form/CommandForm";
 import type { SelectParameter } from "../../../model/CommandParam";
 import {
 	compareLoadResponseFixture,
+	compareRefreshTargetTypeImageResponseFixture,
 	convertLoadResponseFixture,
+	convertRefreshSrcTypeXlsxResponseFixture,
 	generateLoadResponseFixture,
+	generateRefreshSrcTypeTableResponseFixture,
 	parameterizeLoadResponseFixture,
 	runLoadResponseFixture,
+	runRefreshScriptTypeSqlResponseFixture,
 } from "./fixtures";
 
 // モック関数をホイスト（mockReset: true により各テスト前にリセットされるため beforeEach で再設定する）
@@ -69,21 +73,39 @@ beforeEach(() => {
 	});
 });
 
-// 全コマンドの共通モック SelectParameter 値を生成
-function makeSelectParameter(command: string): SelectParameter {
+// 全コマンドの共通モック SelectParameter 値を生成（refreshOverrides で各フィクスチャを上書き可能）
+function makeSelectParameter(
+	command: string,
+	refreshOverrides?: {
+		convert?: typeof convertLoadResponseFixture;
+		compare?: typeof compareLoadResponseFixture;
+		generate?: typeof generateLoadResponseFixture;
+		run?: typeof runLoadResponseFixture;
+	},
+): SelectParameter {
 	return {
 		command,
 		name: "test-param",
-		convert: convertLoadResponseFixture,
-		compare: compareLoadResponseFixture,
-		generate: generateLoadResponseFixture,
-		run: runLoadResponseFixture,
+		convert: refreshOverrides?.convert ?? convertLoadResponseFixture,
+		compare: refreshOverrides?.compare ?? compareLoadResponseFixture,
+		generate: refreshOverrides?.generate ?? generateLoadResponseFixture,
+		run: refreshOverrides?.run ?? runLoadResponseFixture,
 		parameterize: parameterizeLoadResponseFixture,
 		currentParameter: () => undefined,
 	} as unknown as SelectParameter;
 }
 
 const mockFormValues = { key: "val" as FormDataEntryValue };
+
+// refreshレスポンスフィクスチャを使った SelectParameter を生成
+function makeSelectParameterWithRefresh(command: string): SelectParameter {
+	return makeSelectParameter(command, {
+		convert: convertRefreshSrcTypeXlsxResponseFixture,
+		compare: compareRefreshTargetTypeImageResponseFixture,
+		generate: generateRefreshSrcTypeTableResponseFixture,
+		run: runRefreshScriptTypeSqlResponseFixture,
+	});
+}
 
 describe("CommandFormのテスト", () => {
 	it.each([
@@ -121,4 +143,40 @@ describe("CommandFormのテスト", () => {
 		expect(mockFormData).toHaveBeenCalledWith(false);
 		expect(mockRefreshSelectFn).toHaveBeenCalledWith(mockFormValues);
 	});
+
+	it.each([
+		{ command: "convert" },
+		{ command: "compare" },
+		{ command: "generate" },
+		{ command: "run" },
+		{ command: "parameterize" },
+	])(
+		"command=$commandのとき、useRefreshSelectParameterが$commandで呼ばれる",
+		({ command }) => {
+			mockUseSelectParameter.mockReturnValue(makeSelectParameter(command));
+
+			render(<CommandForm formData={mockFormData} />);
+
+			expect(mockUseRefreshSelectParameter).toHaveBeenCalledWith(command);
+		},
+	);
+
+	it.each([
+		{ command: "convert", testId: "mock-convert-form" },
+		{ command: "compare", testId: "mock-compare-form" },
+		{ command: "generate", testId: "mock-generate-form" },
+		{ command: "run", testId: "mock-run-form" },
+		{ command: "parameterize", testId: "mock-parameterize-form" },
+	])(
+		"refreshレスポンスのパラメータでcommand=$commandのとき、対応するフォームが表示される",
+		({ command, testId }) => {
+			mockUseSelectParameter.mockReturnValue(
+				makeSelectParameterWithRefresh(command),
+			);
+
+			render(<CommandForm formData={mockFormData} />);
+
+			expect(screen.getByTestId(testId)).toBeInTheDocument();
+		},
+	);
 });

--- a/tauri/src/tests/app/form/ConvertForm.test.tsx
+++ b/tauri/src/tests/app/form/ConvertForm.test.tsx
@@ -1,0 +1,277 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConvertForm } from "../../../app/form/ConvertForm";
+import { SelectParameter } from "../../../model/CommandParam";
+import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import {
+	convertLoadResponseFixture,
+	convertRefreshResultTypeXlsxResponseFixture,
+	convertRefreshSrcTypeTableResponseFixture,
+	convertRefreshSrcTypeXlsxResponseFixture,
+} from "./fixtures";
+
+// Tauri API モック（ファイル選択ダイアログ等の依存）
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ core: { invoke: vi.fn() } }));
+vi.mock("@tauri-apps/api/path", () => ({
+	isAbsolute: vi.fn().mockResolvedValue(false),
+	sep: vi.fn().mockReturnValue("/"),
+}));
+
+// コンテキストフックのモック
+vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
+	useWorkspaceContext: () => workspaceResourcesFixture.context,
+	useResourcesSettings: () => workspaceResourcesFixture.resources,
+}));
+vi.mock("../../../context/EnviromentProvider", () => ({
+	useEnviroment: () => enviromentFixture,
+}));
+
+// JDBC API フックのモック（クリック時のみ API を呼ぶ）
+vi.mock("../../../hooks/useJdbc", () => ({
+	useJdbcConnectionTest: () => vi.fn(),
+	useJdbcSaveProperties: () => vi.fn(),
+	useDeleteJdbcProperties: () => vi.fn(),
+}));
+
+// フィクスチャから ConvertForm の props を生成する
+// SelectParameter コンストラクタで srcData を DatasetSourceImpl にラップし、
+// srcElements() / srcTypeSettings() / settingElements() メソッドを有効化する
+function makeConvertProps(fixture = convertLoadResponseFixture) {
+	const sp = new SelectParameter(
+		JSON.parse(JSON.stringify(fixture)),
+		"convert",
+		"test",
+	);
+	return {
+		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
+		name: "test",
+		convert: sp.convert,
+	};
+}
+
+describe("ConvertFormの描画テスト", () => {
+	describe("csvソース・xlsxResult（loadレスポンス）", () => {
+		it("srcとresultのセクションがこの順で表示される", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("src");
+			expect(legends[1]).toHaveTextContent("result");
+		});
+
+		it("srcセクションにsrcType・src・encodingが含まれる", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			expect(
+				document.querySelector('select[name="-src.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("traversal option要素（recursive・regInclude等）は初期状態でhiddenになっている", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-src.recursive"]',
+				),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.regInclude"]'),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.extension"]'),
+			).not.toBeVisible();
+		});
+
+		it("Show traversal optionはrecursiveの前のDOM位置に配置される", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			const captionEl = screen.getByText(/Show traversal option/);
+			const recursiveEl = document.querySelector(
+				'input[type="checkbox"][name="-src.recursive"]',
+			)!;
+			expect(
+				captionEl.compareDocumentPosition(recursiveEl) &
+					Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		it("Show traversal optionをクリックするとtraversal option要素が表示される", async () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			await userEvent.click(screen.getByText(/Show traversal option/));
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-src.recursive"]',
+				),
+			).toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.regInclude"]'),
+			).toBeVisible();
+		});
+
+		it("トグル後のボタンテキストがHide traversal optionになる", async () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			await userEvent.click(screen.getByText(/Show traversal option/));
+
+			expect(screen.getByText(/Hide traversal option/)).toBeInTheDocument();
+		});
+
+		it("csv option要素（headerName・delimiter等）は初期状態でhiddenになっている", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.headerName"]'),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.delimiter"]'),
+			).not.toBeVisible();
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-src.ignoreQuoted"]',
+				),
+			).not.toBeVisible();
+		});
+
+		it("Show csv optionはheaderNameの前のDOM位置に配置される", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			const captionEl = screen.getByText(/Show csv option/);
+			const headerNameEl = document.querySelector(
+				'input[type="text"][name="-src.headerName"]',
+			)!;
+			expect(
+				captionEl.compareDocumentPosition(headerNameEl) &
+					Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		it("resultセクションにexcelTableが含まれる", () => {
+			render(<ConvertForm {...makeConvertProps()} />);
+
+			expect(
+				document.querySelector(
+					'input[type="text"][name="-result.excelTable"]',
+				),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("xlsxソース（srcType=xlsxのrefreshレスポンス）", () => {
+		it("srcセクションにxlsxSchemaが含まれる", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.xlsxSchema"]'),
+			).toBeInTheDocument();
+		});
+
+		it("csvオプション（delimiter）は含まれない", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('[name="-src.delimiter"]'),
+			).not.toBeInTheDocument();
+		});
+
+		it("Show xlsx optionが表示される", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(screen.getByText(/Show xlsx option/)).toBeInTheDocument();
+		});
+
+		it("resultセクションにoutputEncodingが含まれる（csv result）", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="text"][name="-result.outputEncoding"]',
+				),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("tableソース（srcType=tableのrefreshレスポンス）", () => {
+		it("srcセクションにJDBC要素（jdbcUrl・jdbcUser・jdbcPass）が含まれる", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcUrl"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcUser"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcPass"]'),
+			).toBeInTheDocument();
+		});
+
+		it("Show table optionが表示される", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(screen.getByText(/Show table option/)).toBeInTheDocument();
+		});
+	});
+
+	describe("xlsxResult（resultType=xlsxのrefreshレスポンス）", () => {
+		it("resultセクションにexcelTableが含まれる", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshResultTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="text"][name="-result.excelTable"]',
+				),
+			).toBeInTheDocument();
+		});
+
+		it("resultセクションにoutputEncodingは含まれない", () => {
+			render(
+				<ConvertForm
+					{...makeConvertProps(convertRefreshResultTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('[name="-result.outputEncoding"]'),
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/tauri/src/tests/app/form/ConvertForm.test.tsx
+++ b/tauri/src/tests/app/form/ConvertForm.test.tsx
@@ -38,6 +38,7 @@ vi.mock("../../../hooks/useJdbc", () => ({
 // フィクスチャから ConvertForm の props を生成する
 // SelectParameter コンストラクタで srcData を DatasetSourceImpl にラップし、
 // srcElements() / srcTypeSettings() / settingElements() メソッドを有効化する
+// ※ JSON.parse/JSON.stringify はコンストラクタがフィクスチャの srcData を直接書き換えるための深いコピー
 function makeConvertProps(fixture = convertLoadResponseFixture) {
 	const sp = new SelectParameter(
 		JSON.parse(JSON.stringify(fixture)),
@@ -49,6 +50,14 @@ function makeConvertProps(fixture = convertLoadResponseFixture) {
 		name: "test",
 		convert: sp.convert,
 	};
+}
+
+// DOM順序の検証: precedingEl が followingEl より前にあることを確認する
+function expectPrecedesInDom(precedingEl: Element, followingEl: Element) {
+	expect(
+		precedingEl.compareDocumentPosition(followingEl) &
+			Node.DOCUMENT_POSITION_FOLLOWING,
+	).toBeTruthy();
 }
 
 describe("ConvertFormの描画テスト", () => {
@@ -94,14 +103,12 @@ describe("ConvertFormの描画テスト", () => {
 		it("Show traversal optionはrecursiveの前のDOM位置に配置される", () => {
 			render(<ConvertForm {...makeConvertProps()} />);
 
-			const captionEl = screen.getByText(/Show traversal option/);
-			const recursiveEl = document.querySelector(
-				'input[type="checkbox"][name="-src.recursive"]',
-			)!;
-			expect(
-				captionEl.compareDocumentPosition(recursiveEl) &
-					Node.DOCUMENT_POSITION_FOLLOWING,
-			).toBeTruthy();
+			expectPrecedesInDom(
+				screen.getByText(/Show traversal option/),
+				document.querySelector(
+					'input[type="checkbox"][name="-src.recursive"]',
+				)!,
+			);
 		});
 
 		it("Show traversal optionをクリックするとtraversal option要素が表示される", async () => {
@@ -146,14 +153,12 @@ describe("ConvertFormの描画テスト", () => {
 		it("Show csv optionはheaderNameの前のDOM位置に配置される", () => {
 			render(<ConvertForm {...makeConvertProps()} />);
 
-			const captionEl = screen.getByText(/Show csv option/);
-			const headerNameEl = document.querySelector(
-				'input[type="text"][name="-src.headerName"]',
-			)!;
-			expect(
-				captionEl.compareDocumentPosition(headerNameEl) &
-					Node.DOCUMENT_POSITION_FOLLOWING,
-			).toBeTruthy();
+			expectPrecedesInDom(
+				screen.getByText(/Show csv option/),
+				document.querySelector(
+					'input[type="text"][name="-src.headerName"]',
+				)!,
+			);
 		});
 
 		it("resultセクションにexcelTableが含まれる", () => {

--- a/tauri/src/tests/app/form/fixtures.ts
+++ b/tauri/src/tests/app/form/fixtures.ts
@@ -32,6 +32,122 @@ const templateOptionElements: CommandParam[] = [
 	makeElement("templateVarStop", "TEXT", "$", "WORKSPACE", false),
 ];
 
+// xlsx/xls型のsrcData要素（xlsxSchemaあり、CSV系フィールドなし）
+function makeXlsxSrcDataElements(): CommandParam[] {
+	return [
+		makeElement("srcType", "ENUM", "xlsx", "WORKSPACE", false, [
+			"table",
+			"sql",
+			"file",
+			"dir",
+			"csv",
+			"csvq",
+			"reg",
+			"fixed",
+			"xls",
+			"xlsx",
+		]),
+		makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+		makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+		makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("extension", "TEXT", "", "WORKSPACE", false),
+		makeElement("headerName", "TEXT", "", "WORKSPACE", false),
+		makeElement("startRow", "TEXT", "1", "WORKSPACE", false),
+		makeElement("addFileInfo", "FLG", "false", "WORKSPACE", false),
+		makeElement("xlsxSchema", "FILE", "", "XLSX_SCHEMA", false),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("loadData", "FLG", "true", "WORKSPACE", false),
+		makeElement("includeMetaData", "FLG", "false", "WORKSPACE", false),
+	];
+}
+
+// table型のsrcData要素（JDBCフィールド・テンプレートフィールドあり、CSV系フィールドなし）
+function makeTableSrcDataElements(): CommandParam[] {
+	return [
+		makeElement("srcType", "ENUM", "table", "WORKSPACE", false, [
+			"table",
+			"sql",
+			"file",
+			"dir",
+			"csv",
+			"csvq",
+			"reg",
+			"fixed",
+			"xls",
+			"xlsx",
+		]),
+		makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+		makeElement("encoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+		makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("extension", "TEXT", "", "WORKSPACE", false),
+		makeElement("headerName", "TEXT", "", "WORKSPACE", false),
+		makeElement("addFileInfo", "FLG", "false", "WORKSPACE", false),
+		makeElement("jdbcProperties", "FILE", "", "JDBC", false),
+		makeElement("jdbcUrl", "TEXT", "", "WORKSPACE", false),
+		makeElement("jdbcUser", "TEXT", "", "WORKSPACE", false),
+		makeElement("jdbcPass", "TEXT", "", "WORKSPACE", false),
+		makeElement("useJdbcMetaData", "FLG", "false", "WORKSPACE", false),
+		makeElement("templateGroup", "FILE", "", "TEMPLATE", false),
+		makeElement(
+			"templateParameterAttribute",
+			"TEXT",
+			"param",
+			"WORKSPACE",
+			false,
+		),
+		makeElement("templateVarStart", "TEXT", "$", "WORKSPACE", false),
+		makeElement("templateVarStop", "TEXT", "$", "WORKSPACE", false),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("loadData", "FLG", "true", "WORKSPACE", false),
+		makeElement("includeMetaData", "FLG", "false", "WORKSPACE", false),
+	];
+}
+
+// xlsx resultType のresult要素（excelTableあり）
+function makeXlsxResultElements(): CommandParam[] {
+	return [
+		makeElement("resultType", "ENUM", "xlsx", "WORKSPACE", false, [
+			"csv",
+			"xls",
+			"xlsx",
+			"table",
+		]),
+		makeElement("result", "DIR", "", "RESULT", false),
+		makeElement("resultPath", "TEXT", "", "WORKSPACE", false),
+		makeElement("exportEmptyTable", "FLG", "true", "WORKSPACE", false),
+		makeElement("exportHeader", "FLG", "true", "WORKSPACE", false),
+		makeElement("excelTable", "TEXT", "SHEET", "WORKSPACE", false),
+	];
+}
+
+// csv resultType のresult要素（outputEncodingあり）
+function makeCsvResultElements(required = false): CommandParam[] {
+	return [
+		makeElement(
+			"resultType",
+			"ENUM",
+			"csv",
+			"WORKSPACE",
+			required,
+			required ? ["csv", "xls", "xlsx"] : ["csv", "xls", "xlsx", "table"],
+		),
+		makeElement("result", "DIR", "", "RESULT", false),
+		makeElement("resultPath", "TEXT", "", "WORKSPACE", false),
+		makeElement("exportEmptyTable", "FLG", "true", "WORKSPACE", false),
+		makeElement("exportHeader", "FLG", "true", "WORKSPACE", false),
+		makeElement("outputEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	];
+}
+
 // convert / compare / generate / parameterize srcData の共通 CSV 要素
 function makeCsvSrcDataElements(src: string): CommandParam[] {
 	return [
@@ -250,5 +366,342 @@ export const parameterizeLoadResponseFixture = {
 	templateOption: {
 		prefix: "template",
 		elements: templateOptionElements,
+	},
+};
+
+// --- refresh レスポンスフィクスチャ ---
+
+// convert-refresh-srcType-xlsx-response.json をもとにしたフィクスチャ
+export const convertRefreshSrcTypeXlsxResponseFixture = {
+	prefix: "",
+	elements: [] as CommandParam[],
+	srcData: {
+		prefix: "src",
+		elements: makeXlsxSrcDataElements(),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeCsvResultElements(),
+	},
+};
+
+// convert-refresh-srcType-table-response.json をもとにしたフィクスチャ
+export const convertRefreshSrcTypeTableResponseFixture = {
+	prefix: "",
+	elements: [] as CommandParam[],
+	srcData: {
+		prefix: "src",
+		elements: makeTableSrcDataElements(),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeCsvResultElements(),
+	},
+};
+
+// convert-refresh-resultType-xlsx-response.json をもとにしたフィクスチャ
+export const convertRefreshResultTypeXlsxResponseFixture = {
+	prefix: "",
+	elements: [] as CommandParam[],
+	srcData: {
+		prefix: "src",
+		elements: makeCsvSrcDataElements(""),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeXlsxResultElements(),
+	},
+};
+
+// image/pdf targetType 時の file 型 srcData 要素（新旧データ共通）
+function makeImageFileSrcDataElements(): CommandParam[] {
+	return [
+		makeElement("srcType", "ENUM", "file", "WORKSPACE", true, ["file"]),
+		makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+		makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+		makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("extension", "TEXT", "png", "WORKSPACE", false),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+		makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		makeElement("loadData", "FLG", "true", "WORKSPACE", false),
+		makeElement("includeMetaData", "FLG", "false", "WORKSPACE", false),
+	];
+}
+
+// compare-refresh-targetType-image-response.json をもとにしたフィクスチャ
+export const compareRefreshTargetTypeImageResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("targetType", "ENUM", "image", "WORKSPACE", false, [
+			"data",
+			"image",
+			"pdf",
+		]),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	imageOption: {
+		prefix: "image",
+		elements: [
+			makeElement("threshold", "TEXT", "", "WORKSPACE", false),
+			makeElement("pixelToleranceLevel", "TEXT", "", "WORKSPACE", false),
+			makeElement(
+				"allowingPercentOfDifferentPixels",
+				"TEXT",
+				"",
+				"WORKSPACE",
+				false,
+			),
+			makeElement("rectangleLineWidth", "TEXT", "", "WORKSPACE", false),
+			makeElement("minimalRectangleSize", "TEXT", "", "WORKSPACE", false),
+			makeElement("maximalRectangleCount", "TEXT", "", "WORKSPACE", false),
+			makeElement("excludedAreas", "TEXT", "", "WORKSPACE", false),
+			makeElement("drawExcludedRectangles", "FLG", "true", "WORKSPACE", false),
+			makeElement("fillExcludedRectangles", "FLG", "false", "WORKSPACE", false),
+			makeElement(
+				"percentOpacityExcludedRectangles",
+				"TEXT",
+				"",
+				"WORKSPACE",
+				false,
+			),
+			makeElement("excludedRectangleColor", "TEXT", "", "WORKSPACE", false),
+			makeElement(
+				"fillDifferenceRectangles",
+				"FLG",
+				"false",
+				"WORKSPACE",
+				false,
+			),
+			makeElement(
+				"percentOpacityDifferenceRectangles",
+				"TEXT",
+				"",
+				"WORKSPACE",
+				false,
+			),
+			makeElement("differenceRectangleColor", "TEXT", "", "WORKSPACE", false),
+		],
+	},
+	newData: {
+		prefix: "new",
+		elements: makeImageFileSrcDataElements(),
+	},
+	oldData: {
+		prefix: "old",
+		elements: makeImageFileSrcDataElements(),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeCsvResultElements(true),
+	},
+	expectData: {
+		prefix: "expect",
+		elements: [
+			makeElement("srcType", "ENUM", "none", "WORKSPACE", false, [
+				"none",
+				"sql",
+				"csv",
+				"csvq",
+				"xls",
+				"xlsx",
+			]),
+		],
+	},
+};
+
+// compare-refresh-newSrcType-table-response.json をもとにしたフィクスチャ
+export const compareRefreshNewSrcTypeTableResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("targetType", "ENUM", "data", "WORKSPACE", false, [
+			"data",
+			"image",
+			"pdf",
+		]),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	newData: {
+		prefix: "new",
+		elements: makeTableSrcDataElements(),
+	},
+	oldData: {
+		prefix: "old",
+		elements: makeCsvSrcDataElements(""),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeCsvResultElements(true),
+	},
+	expectData: {
+		prefix: "expect",
+		elements: [
+			makeElement("srcType", "ENUM", "none", "WORKSPACE", false, [
+				"none",
+				"sql",
+				"csv",
+				"csvq",
+				"xls",
+				"xlsx",
+			]),
+		],
+	},
+};
+
+// compare-refresh-expectSrcType-csv-response.json をもとにしたフィクスチャ
+export const compareRefreshExpectSrcTypeCsvResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("targetType", "ENUM", "data", "WORKSPACE", false, [
+			"data",
+			"image",
+			"pdf",
+		]),
+		makeElement("setting", "FILE", "", "SETTING", false),
+		makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	newData: {
+		prefix: "new",
+		elements: makeCsvSrcDataElements(""),
+	},
+	oldData: {
+		prefix: "old",
+		elements: makeCsvSrcDataElements(""),
+	},
+	convertResult: {
+		prefix: "result",
+		elements: makeCsvResultElements(true),
+	},
+	expectData: {
+		prefix: "expect",
+		elements: [
+			makeElement("srcType", "ENUM", "csv", "WORKSPACE", false, [
+				"none",
+				"sql",
+				"csv",
+				"csvq",
+				"xls",
+				"xlsx",
+			]),
+			makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+			makeElement("encoding", "TEXT", "UTF-8", "WORKSPACE", false),
+			makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+			makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("extension", "TEXT", "", "WORKSPACE", false),
+			makeElement("headerName", "TEXT", "", "WORKSPACE", false),
+			makeElement("startRow", "TEXT", "1", "WORKSPACE", false),
+			makeElement("addFileInfo", "FLG", "false", "WORKSPACE", false),
+			makeElement("delimiter", "TEXT", ",", "WORKSPACE", false),
+			makeElement("ignoreQuoted", "FLG", "false", "WORKSPACE", false),
+			makeElement("setting", "FILE", "", "SETTING", false),
+			makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+			makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("loadData", "FLG", "true", "WORKSPACE", false),
+			makeElement("includeMetaData", "FLG", "false", "WORKSPACE", false),
+		],
+	},
+};
+
+// generate-refresh-srcType-table-response.json をもとにしたフィクスチャ
+export const generateRefreshSrcTypeTableResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("generateType", "ENUM", "txt", "WORKSPACE", false, [
+			"txt",
+			"xlsx",
+			"xls",
+			"settings",
+			"sql",
+			"xlsxTemplate",
+		]),
+		makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
+			"record",
+			"table",
+			"dataset",
+		]),
+		makeElement("template", "FILE", "", "TEMPLATE", true),
+		makeElement("result", "DIR", "", "RESULT", false),
+		makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
+		makeElement("outputEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+	],
+	srcData: {
+		prefix: "src",
+		elements: makeTableSrcDataElements(),
+	},
+	templateOption: {
+		prefix: "template",
+		elements: templateOptionElements,
+	},
+};
+
+// run-refresh-scriptType-cmd-response.json をもとにしたフィクスチャ
+export const runRefreshScriptTypeCmdResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("scriptType", "ENUM", "cmd", "WORKSPACE", false, [
+			"cmd",
+			"bat",
+			"sql",
+			"ant",
+		]),
+		makeElement("baseDir", "TEXT", "", "WORKSPACE", false),
+	],
+	srcData: {
+		prefix: "src",
+		elements: [
+			makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+			makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+			makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("setting", "FILE", "", "SETTING", false),
+			makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+			makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		],
+	},
+};
+
+// run-refresh-scriptType-sql-response.json をもとにしたフィクスチャ
+export const runRefreshScriptTypeSqlResponseFixture = {
+	prefix: "",
+	elements: [
+		makeElement("scriptType", "ENUM", "sql", "WORKSPACE", false, [
+			"cmd",
+			"bat",
+			"sql",
+			"ant",
+		]),
+	],
+	srcData: {
+		prefix: "src",
+		elements: [
+			makeElement("src", "FILE_OR_DIR", "", "DATASET", true),
+			makeElement("recursive", "FLG", "false", "WORKSPACE", false),
+			makeElement("regInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regExclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("setting", "FILE", "", "SETTING", false),
+			makeElement("settingEncoding", "TEXT", "UTF-8", "WORKSPACE", false),
+			makeElement("regTableInclude", "TEXT", "", "WORKSPACE", false),
+			makeElement("regTableExclude", "TEXT", "", "WORKSPACE", false),
+		],
+	},
+	templateOption: {
+		prefix: "template",
+		elements: templateOptionElements,
+	},
+	jdbcOption: {
+		prefix: "jdbc",
+		elements: [
+			makeElement("jdbcProperties", "FILE", "", "JDBC", false),
+			makeElement("jdbcUrl", "TEXT", "", "WORKSPACE", false),
+			makeElement("jdbcUser", "TEXT", "", "WORKSPACE", false),
+			makeElement("jdbcPass", "TEXT", "", "WORKSPACE", false),
+		],
 	},
 };


### PR DESCRIPTION
## Summary
This PR adds comprehensive test fixtures and test cases for handling refresh responses in the CommandForm component. It introduces fixture data for various command types (convert, compare, generate, run) with different parameter configurations, and adds test coverage to verify that the form correctly renders with refreshed parameters.

## Key Changes

- **New fixture functions** in `fixtures.ts`:
  - `makeXlsxSrcDataElements()` - XLSX/XLS source data configuration
  - `makeTableSrcDataElements()` - Table type source data with JDBC and template fields
  - `makeXlsxResultElements()` - XLSX result type configuration
  - `makeCsvResultElements()` - CSV result type configuration with optional required flag
  - `makeImageFileSrcDataElements()` - Image/PDF file source data configuration

- **New response fixtures** for refresh scenarios:
  - `convertRefreshSrcTypeXlsxResponseFixture` - Convert command with XLSX source
  - `convertRefreshSrcTypeTableResponseFixture` - Convert command with table source
  - `convertRefreshResultTypeXlsxResponseFixture` - Convert command with XLSX result
  - `compareRefreshTargetTypeImageResponseFixture` - Compare command with image target type
  - `compareRefreshNewSrcTypeTableResponseFixture` - Compare command with table source
  - `compareRefreshExpectSrcTypeCsvResponseFixture` - Compare command with CSV expectation
  - `generateRefreshSrcTypeTableResponseFixture` - Generate command with table source
  - `runRefreshScriptTypeCmdResponseFixture` - Run command with cmd script type
  - `runRefreshScriptTypeSqlResponseFixture` - Run command with SQL script type

- **Enhanced test utilities**:
  - Modified `makeSelectParameter()` to accept optional `refreshOverrides` for fixture customization
  - Added `makeSelectParameterWithRefresh()` helper to create SelectParameter with refresh fixtures

- **New test cases** in `CommandForm.test.tsx`:
  - Test that `useRefreshSelectParameter` is called with the correct command
  - Test that CommandForm correctly renders with refresh response parameters for all command types

## Implementation Details
The fixtures follow the existing pattern of using `makeElement()` to construct parameter configurations. The refresh fixtures mirror the structure of actual API responses, allowing tests to verify that the form properly handles dynamic parameter updates from refresh operations.

https://claude.ai/code/session_01Y42j6CUnNFUovoLiMgpJL4