### PR TITLE
Add skill and rule for application package change impact checks

### DIFF
--- a/.claude/rules/application-change-impact.md
+++ b/.claude/rules/application-change-impact.md
@@ -1,0 +1,58 @@
+# coreアプリケーションパッケージ変更時の影響確認
+
+`core/src/main/java/yo/dbunitcli/application/` 配下を変更したとき、以下の手順で影響範囲を確認すること。
+
+## 対象となる変更
+
+- `command/` 配下のコマンドクラス（`Compare.java`, `Convert.java`, `Generate.java`, `Run.java`, `Parameterize.java`）
+- `command/` 配下のDTOクラス（`CompareDto.java`, `ConvertDto.java` 等）
+- `command/` 配下のOptionクラス（`CompareOption.java`, `ConvertOption.java` 等）
+- `option/` 配下の共通オプションクラス（`DataSetLoadOption.java` 等）
+- `Option.java`, `Command.java`, `CommandDto.java`, `CommandLineOption.java` 等の基底クラス・インターフェース
+
+## 1. sidecar: JUnitコントローラーテストで影響を確認する
+
+変更したクラスに対応するコントローラーテストを実行し、レスポンスが壊れていないことを確認する。
+
+### テストファイルの対応表
+
+| 変更クラス（command/） | テストファイル |
+|---|---|
+| `Compare` / `CompareDto` / `CompareOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java` |
+| `Convert` / `ConvertDto` / `ConvertOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java` |
+| `Generate` / `GenerateDto` / `GenerateOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java` |
+| `Run` / `RunDto` / `RunOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java` |
+| `Parameterize` / `ParameterizeDto` / `ParameterizeOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ParameterizeControllerTest.java` |
+
+- `option/` 配下の共通クラスや基底クラス・インターフェースを変更した場合は、上記すべてのコントローラーテストを確認する
+- テストが失敗した場合は、`sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/` 配下の期待値JSONを実際のレスポンスに合わせて更新する
+
+## 2. tauri: フォームテストのフィクスチャを更新する
+
+コントローラーのレスポンス構造（フィールド名・型・デフォルト値・selectOption）が変わった場合、Tauriのフォームテスト用フィクスチャを更新する。
+
+### 更新対象ファイル
+
+- `tauri/src/tests/app/form/fixtures.ts`
+
+### 確認手順
+
+1. 対応するフィクスチャ定数（`compareLoadResponseFixture`, `convertLoadResponseFixture` 等）を確認する
+2. フィールド名・型・デフォルト値・`selectOption` 配列がコントローラーのレスポンスJSONと一致しているか検証する
+3. 変更があれば `fixtures.ts` を更新し、以下のテストが通ることを確認する
+   - `tauri/src/tests/app/form/CommandForm.test.tsx`
+   - `tauri/src/tests/app/form/ConvertForm.test.tsx`
+
+## 3. GUI: 影響箇所をコードレビューで確認する
+
+GUIモジュールにはテストがないため、以下のファイルをコードレビューで確認する。
+
+### 確認対象ファイル
+
+- `gui/src/main/java/yo/dbunitcli/javafx/view/main/MainPresenter.java`
+
+### 確認観点
+
+- `Option` インターフェースや `ParamType` 列挙値を変更した場合、フィールド生成ロジック（`setInputFields` 等）が正しく動作するか確認する
+- DTOのフィールド追加・削除・名称変更をした場合、GUI上のフォーム項目の表示が正しいことを目視確認する
+- `CommandLineOption` や `Command` の基底クラスシグネチャを変更した場合は、コンパイルエラーがないことを確認する

--- a/.claude/rules/application-change-impact.md
+++ b/.claude/rules/application-change-impact.md
@@ -1,25 +1,3 @@
 # core/application パッケージ変更時の影響確認
 
-`core/src/main/java/yo/dbunitcli/application/` 変更時に必ず実施する。
-
-## 1. sidecar コントローラーテスト実行
-
-テストパス: `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/`
-
-| 変更 | テストクラス |
-|---|---|
-| Compare系 | `CompareControllerTest` |
-| Convert系 | `ConvertControllerTest` |
-| Generate系 | `GenerateControllerTest` |
-| Run系 | `RunControllerTest` |
-| Parameterize系 | `ParameterizeControllerTest` |
-
-共通クラス・基底インターフェース変更時は全テスト対象。失敗時は `sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/` の期待値JSONを更新する。
-
-## 2. tauri フィクスチャ更新
-
-レスポンス構造変更時、`tauri/src/tests/app/form/fixtures.ts` を更新し `CommandForm.test.tsx` / `ConvertForm.test.tsx` が通ることを確認する。
-
-## 3. GUI コードレビュー
-
-`gui/src/main/java/yo/dbunitcli/javafx/view/main/MainPresenter.java` を確認する。Option・ParamType・DTO変更時はフォーム表示を目視確認する。
+`core/src/main/java/yo/dbunitcli/application/` 変更時に **Claude 自身が** `/check-application-impact` を呼び出すこと。

--- a/.claude/rules/application-change-impact.md
+++ b/.claude/rules/application-change-impact.md
@@ -1,58 +1,25 @@
-# coreアプリケーションパッケージ変更時の影響確認
+# core/application パッケージ変更時の影響確認
 
-`core/src/main/java/yo/dbunitcli/application/` 配下を変更したとき、以下の手順で影響範囲を確認すること。
+`core/src/main/java/yo/dbunitcli/application/` 変更時に必ず実施する。
 
-## 対象となる変更
+## 1. sidecar コントローラーテスト実行
 
-- `command/` 配下のコマンドクラス（`Compare.java`, `Convert.java`, `Generate.java`, `Run.java`, `Parameterize.java`）
-- `command/` 配下のDTOクラス（`CompareDto.java`, `ConvertDto.java` 等）
-- `command/` 配下のOptionクラス（`CompareOption.java`, `ConvertOption.java` 等）
-- `option/` 配下の共通オプションクラス（`DataSetLoadOption.java` 等）
-- `Option.java`, `Command.java`, `CommandDto.java`, `CommandLineOption.java` 等の基底クラス・インターフェース
+テストパス: `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/`
 
-## 1. sidecar: JUnitコントローラーテストで影響を確認する
-
-変更したクラスに対応するコントローラーテストを実行し、レスポンスが壊れていないことを確認する。
-
-### テストファイルの対応表
-
-| 変更クラス（command/） | テストファイル |
+| 変更 | テストクラス |
 |---|---|
-| `Compare` / `CompareDto` / `CompareOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/CompareControllerTest.java` |
-| `Convert` / `ConvertDto` / `ConvertOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ConvertControllerTest.java` |
-| `Generate` / `GenerateDto` / `GenerateOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/GenerateControllerTest.java` |
-| `Run` / `RunDto` / `RunOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/RunControllerTest.java` |
-| `Parameterize` / `ParameterizeDto` / `ParameterizeOption` | `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/ParameterizeControllerTest.java` |
+| Compare系 | `CompareControllerTest` |
+| Convert系 | `ConvertControllerTest` |
+| Generate系 | `GenerateControllerTest` |
+| Run系 | `RunControllerTest` |
+| Parameterize系 | `ParameterizeControllerTest` |
 
-- `option/` 配下の共通クラスや基底クラス・インターフェースを変更した場合は、上記すべてのコントローラーテストを確認する
-- テストが失敗した場合は、`sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/` 配下の期待値JSONを実際のレスポンスに合わせて更新する
+共通クラス・基底インターフェース変更時は全テスト対象。失敗時は `sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/` の期待値JSONを更新する。
 
-## 2. tauri: フォームテストのフィクスチャを更新する
+## 2. tauri フィクスチャ更新
 
-コントローラーのレスポンス構造（フィールド名・型・デフォルト値・selectOption）が変わった場合、Tauriのフォームテスト用フィクスチャを更新する。
+レスポンス構造変更時、`tauri/src/tests/app/form/fixtures.ts` を更新し `CommandForm.test.tsx` / `ConvertForm.test.tsx` が通ることを確認する。
 
-### 更新対象ファイル
+## 3. GUI コードレビュー
 
-- `tauri/src/tests/app/form/fixtures.ts`
-
-### 確認手順
-
-1. 対応するフィクスチャ定数（`compareLoadResponseFixture`, `convertLoadResponseFixture` 等）を確認する
-2. フィールド名・型・デフォルト値・`selectOption` 配列がコントローラーのレスポンスJSONと一致しているか検証する
-3. 変更があれば `fixtures.ts` を更新し、以下のテストが通ることを確認する
-   - `tauri/src/tests/app/form/CommandForm.test.tsx`
-   - `tauri/src/tests/app/form/ConvertForm.test.tsx`
-
-## 3. GUI: 影響箇所をコードレビューで確認する
-
-GUIモジュールにはテストがないため、以下のファイルをコードレビューで確認する。
-
-### 確認対象ファイル
-
-- `gui/src/main/java/yo/dbunitcli/javafx/view/main/MainPresenter.java`
-
-### 確認観点
-
-- `Option` インターフェースや `ParamType` 列挙値を変更した場合、フィールド生成ロジック（`setInputFields` 等）が正しく動作するか確認する
-- DTOのフィールド追加・削除・名称変更をした場合、GUI上のフォーム項目の表示が正しいことを目視確認する
-- `CommandLineOption` や `Command` の基底クラスシグネチャを変更した場合は、コンパイルエラーがないことを確認する
+`gui/src/main/java/yo/dbunitcli/javafx/view/main/MainPresenter.java` を確認する。Option・ParamType・DTO変更時はフォーム表示を目視確認する。

--- a/.claude/skills/check-application-impact/SKILL.md
+++ b/.claude/skills/check-application-impact/SKILL.md
@@ -1,0 +1,25 @@
+---
+description: core/application変更時のsidecar・tauri影響確認
+TRIGGER when: core/src/main/java/yo/dbunitcli/application/ 配下のファイル変更を含む実装タスクが完了したとき。
+DO NOT TRIGGER when: core/application以外のファイルのみの変更、またはファイルの読み取りのみの場合。
+---
+
+以下を順に実施すること。
+
+## 1. sidecar コントローラーテスト実行
+
+テストパス: `sidecar/src/test/java/yo/dbunitcli/sidecar/controller/`
+
+| 変更 | テストクラス |
+|---|---|
+| Compare系 | `CompareControllerTest` |
+| Convert系 | `ConvertControllerTest` |
+| Generate系 | `GenerateControllerTest` |
+| Run系 | `RunControllerTest` |
+| Parameterize系 | `ParameterizeControllerTest` |
+
+共通クラス・基底インターフェース変更時は全テスト対象。失敗時は `sidecar/src/test/resources/yo/dbunitcli/sidecar/controller/` の期待値JSONを更新する。
+
+## 2. tauri フィクスチャ更新
+
+レスポンス構造変更時、`tauri/src/tests/app/form/fixtures.ts` を更新し `CommandForm.test.tsx` / `ConvertForm.test.tsx` が通ることを確認する。


### PR DESCRIPTION
## Summary
This PR introduces automation guidelines for verifying the impact of changes to the core application package on dependent modules (sidecar and tauri).

## Key Changes
- **Added `.claude/skills/check-application-impact/SKILL.md`**: Defines a skill that outlines the verification process when `core/src/main/java/yo/dbunitcli/application/` is modified
  - Specifies trigger conditions (application package changes in completed implementation tasks)
  - Documents exclusion criteria (non-application changes or read-only operations)
  - Provides step-by-step instructions for running sidecar controller tests with a mapping table of change types to test classes
  - Includes guidance for updating tauri fixtures when response structures change

- **Added `.claude/rules/application-change-impact.md`**: Establishes a rule requiring Claude to automatically invoke the application impact check skill when application package modifications are detected

## Implementation Details
The skill provides a structured approach to validating downstream impacts:
1. Sidecar controller tests are mapped by operation type (Compare, Convert, Generate, Run, Parameterize)
2. Common class and base interface changes trigger all controller tests
3. Test fixture updates in tauri are required when response structures change
4. Expected value JSONs in sidecar test resources may need updates based on test failures

https://claude.ai/code/session_01AXHMuzXZbYnRFvBduJteWR