### PR TITLE
Refactor GraalVM native-image configuration to parent POM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,32 +40,7 @@
                         <configuration>
                             <mainClass>yo.dbunitcli.application.command.Parameterize</mainClass>
                             <imageName>dbunit-cli</imageName>
-                            <fallback>false</fallback>
-                            <buildArgs>
-                                -J-Dfile.encoding=MS932
-                                -H:+AddAllCharsets
-                                -H:+UnlockExperimentalVMOptions
-                                -H:ReflectionConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/reflect-config.json
-                                -H:ResourceConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/resource-config.json
-                                -H:JNIConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/jni-config.json
-                                -H:SerializationConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/serialization-config.json
-                                --initialize-at-build-time=oracle.sql.converter.I18CharacterConvertersWrapper
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetWithConverter
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverter1Byte
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetAL16UTF16
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetAL32UTF8
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetUTF
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetUTFE
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGB18030
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGBK
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterJAEUC
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterShift
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterZHTEUC
-                                --initialize-at-run-time=sun.font.SunFontManager
-                                --initialize-at-run-time=sun.font.FontManagerFactory
-                                --initialize-at-run-time=sun.font.PlatformFontInfo
-                                --strict-image-heap
-                            </buildArgs>
+                            <buildArgs combine.children="append"/>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,6 @@
                                 -H:JNIConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/jni-config.json
                                 -H:SerializationConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/serialization-config.json
                                 --initialize-at-build-time=oracle.sql.converter.I18CharacterConvertersWrapper
-                                --initialize-at-build-time=oracle.sql.converter.I18CharacterConvertersWrapper
                                 --initialize-at-build-time=oracle.i18n.text.OraCharsetWithConverter
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverter1Byte
                                 --initialize-at-build-time=oracle.i18n.text.OraCharsetAL16UTF16
@@ -62,6 +61,9 @@
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterJAEUC
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterShift
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterZHTEUC
+                                --initialize-at-run-time=sun.font.SunFontManager
+                                --initialize-at-run-time=sun.font.FontManagerFactory
+                                --initialize-at-run-time=sun.font.PlatformFontInfo
                                 --strict-image-heap
                             </buildArgs>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,44 @@
             <properties>
                 <jdbc.dependencies.scope>compile</jdbc.dependencies.scope>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.graalvm.buildtools</groupId>
+                            <artifactId>native-maven-plugin</artifactId>
+                            <configuration>
+                                <fallback>false</fallback>
+                                <buildArgs>
+                                    -J-Dfile.encoding=MS932
+                                    -H:+AddAllCharsets
+                                    -H:+UnlockExperimentalVMOptions
+                                    -H:ReflectionConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/reflect-config.json
+                                    -H:ResourceConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/resource-config.json
+                                    -H:JNIConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/jni-config.json
+                                    -H:SerializationConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/serialization-config.json
+                                    --initialize-at-build-time=oracle.sql.converter.I18CharacterConvertersWrapper
+                                    --initialize-at-build-time=oracle.i18n.text.OraCharsetWithConverter
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverter1Byte
+                                    --initialize-at-build-time=oracle.i18n.text.OraCharsetAL16UTF16
+                                    --initialize-at-build-time=oracle.i18n.text.OraCharsetAL32UTF8
+                                    --initialize-at-build-time=oracle.i18n.text.OraCharsetUTF
+                                    --initialize-at-build-time=oracle.i18n.text.OraCharsetUTFE
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGB18030
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGBK
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterJAEUC
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterShift
+                                    --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterZHTEUC
+                                    --initialize-at-run-time=sun.font.SunFontManager
+                                    --initialize-at-run-time=sun.font.FontManagerFactory
+                                    --initialize-at-run-time=sun.font.PlatformFontInfo
+                                    --strict-image-heap
+                                </buildArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
     </profiles>
     <dependencies>

--- a/sidecar/pom.xml
+++ b/sidecar/pom.xml
@@ -104,6 +104,9 @@
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterJAEUC
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterShift
                                 --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterZHTEUC
+                                --initialize-at-run-time=sun.font.SunFontManager
+                                --initialize-at-run-time=sun.font.FontManagerFactory
+                                --initialize-at-run-time=sun.font.PlatformFontInfo
                                 --strict-image-heap
                             </buildArgs>
                         </configuration>

--- a/sidecar/pom.xml
+++ b/sidecar/pom.xml
@@ -83,32 +83,7 @@
                         <configuration>
                             <mainClass>${exec.mainClass}</mainClass>
                             <imageName>dbunit-cli-sidecar</imageName>
-                            <fallback>false</fallback>
-                            <buildArgs>
-                                -J-Dfile.encoding=MS932
-                                -H:+AddAllCharsets
-                                -H:+UnlockExperimentalVMOptions
-                                -H:ReflectionConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/reflect-config.json
-                                -H:ResourceConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/resource-config.json
-                                -H:JNIConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/jni-config.json
-                                -H:SerializationConfigurationFiles=${project.resources[0].directory}/META-INF/native-image/${project.groupId}/${project.artifactId}/serialization-config.json
-                                --initialize-at-build-time=oracle.sql.converter.I18CharacterConvertersWrapper
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetWithConverter
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverter1Byte
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetAL16UTF16
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetAL32UTF8
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetUTF
-                                --initialize-at-build-time=oracle.i18n.text.OraCharsetUTFE
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGB18030
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterGBK
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterJAEUC
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterShift
-                                --initialize-at-build-time=oracle.i18n.text.converter.CharacterConverterZHTEUC
-                                --initialize-at-run-time=sun.font.SunFontManager
-                                --initialize-at-run-time=sun.font.FontManagerFactory
-                                --initialize-at-run-time=sun.font.PlatformFontInfo
-                                --strict-image-heap
-                            </buildArgs>
+                            <buildArgs combine.children="append"/>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary
Consolidate duplicate GraalVM native-image build configurations from child modules into the parent POM's profile, reducing duplication and improving maintainability.

## Key Changes
- Moved native-maven-plugin configuration from `core/pom.xml` and `sidecar/pom.xml` into the parent `pom.xml` profile's `pluginManagement` section
- Removed 27 lines of duplicated `buildArgs` configuration from both child modules
- Updated child modules to use `combine.children="append"` to inherit and extend parent configuration
- Centralized GraalVM build arguments including:
  - File encoding (MS932) and charset settings
  - Reflection, resource, JNI, and serialization configuration file paths
  - Oracle character converter initialization settings
  - Font manager runtime initialization settings

## Implementation Details
- The parent POM now defines the complete native-image plugin configuration with all build arguments
- Child modules retain only module-specific configuration (mainClass, imageName) while inheriting common settings
- This follows Maven best practices for managing shared plugin configurations across multi-module projects
- Reduces maintenance burden by having a single source of truth for native-image build settings

https://claude.ai/code/session_019ZKPcJC5weM9BLRp4myZ3n