### PR TITLE
Add native image testing and improve GraalVM configuration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,9 @@
         </profile>
         <profile>
             <id>native</id>
+            <properties>
+                <exclude.testcase>IntegrationTest,jvmTest</exclude.testcase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -29,6 +32,16 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <excludedGroups>IntegrationTest,jvmTest</excludedGroups>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>build-native</id>
                                 <goals>
@@ -41,6 +54,13 @@
                             <mainClass>yo.dbunitcli.application.command.Parameterize</mainClass>
                             <imageName>dbunit-cli</imageName>
                             <buildArgs combine.children="append"/>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,9 +22,6 @@
         </profile>
         <profile>
             <id>native</id>
-            <properties>
-                <exclude.testcase>IntegrationTest,jvmTest</exclude.testcase>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/core/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli/jni-config.json
+++ b/core/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli/jni-config.json
@@ -186,7 +186,7 @@
 },
 {
   "name":"sun.font.Font2D",
-  "methods":[{"name":"canDisplay","parameterTypes":["char"] }, {"name":"charToGlyph","parameterTypes":["int"] }, {"name":"charToVariationGlyph","parameterTypes":["int","int"] }, {"name":"getMapper","parameterTypes":[] }, {"name":"getTableBytes","parameterTypes":["int"] }]
+  "methods":[{"name":"canDisplay","parameterTypes":["char"] }, {"name":"charToGlyph","parameterTypes":["int"] }, {"name":"charToGlyphRaw","parameterTypes":["int"] }, {"name":"charToVariationGlyph","parameterTypes":["int","int"] }, {"name":"getMapper","parameterTypes":[] }, {"name":"getTableBytes","parameterTypes":["int"] }]
 },
 {
   "name":"sun.font.FontStrike",

--- a/core/src/test/java/yo/dbunitcli/application/command/CompareTest.java
+++ b/core/src/test/java/yo/dbunitcli/application/command/CompareTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
+@Tag("jvmTest")
 public class CompareTest {
 
     private static final Project PROJECT = new Project();

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
             <version>1.49</version>

--- a/sidecar/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli-sidecar/jni-config.json
+++ b/sidecar/src/main/resources/META-INF/native-image/com.github.yonodera/dbunit-cli-sidecar/jni-config.json
@@ -186,7 +186,7 @@
 },
 {
   "name":"sun.font.Font2D",
-  "methods":[{"name":"canDisplay","parameterTypes":["char"] }, {"name":"charToGlyph","parameterTypes":["int"] }, {"name":"charToVariationGlyph","parameterTypes":["int","int"] }, {"name":"getMapper","parameterTypes":[] }, {"name":"getTableBytes","parameterTypes":["int"] }]
+  "methods":[{"name":"canDisplay","parameterTypes":["char"] }, {"name":"charToGlyph","parameterTypes":["int"] }, {"name":"charToGlyphRaw","parameterTypes":["int"] }, {"name":"charToVariationGlyph","parameterTypes":["int","int"] }, {"name":"getMapper","parameterTypes":[] }, {"name":"getTableBytes","parameterTypes":["int"] }]
 },
 {
   "name":"sun.font.FontStrike",


### PR DESCRIPTION
## Summary
This PR enhances the native image build process by adding dedicated native testing capabilities and updating GraalVM JNI configurations to support additional font rendering methods.

## Key Changes
- **Native Testing**: Added a new `test-native` execution phase to the native-maven-plugin that runs native image tests while excluding integration and JVM tests
- **Surefire Configuration**: Configured maven-surefire-plugin to skip standard JVM tests during native builds to avoid duplicate test execution
- **Test Classification**: Tagged `CompareTest` with `@Tag("jvmTest")` to properly categorize it as a JVM-only test
- **JUnit Platform Launcher**: Added `junit-platform-launcher` dependency to support test discovery and execution in native images
- **GraalVM JNI Config**: Updated JNI configurations in both core and sidecar modules to include `charToGlyphRaw` method in `sun.font.Font2D` class, enabling proper glyph rendering in native images

## Implementation Details
The changes establish a clear separation between JVM and native image testing:
- Native tests run through the native-maven-plugin with excluded groups filtering
- Standard JVM tests are skipped during native builds to prevent redundant execution
- Test categorization via JUnit tags allows fine-grained control over which tests run in each environment
- Enhanced font rendering support in native images through updated reflection configuration

https://claude.ai/code/session_01Nig9vAm3oNYqFguHU3Y62M