### PR TITLE
Remove strict image heap validation from GraalVM native build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
                                     --initialize-at-run-time=sun.font.SunFontManager
                                     --initialize-at-run-time=sun.font.FontManagerFactory
                                     --initialize-at-run-time=sun.font.PlatformFontInfo
-                                    --strict-image-heap
                                 </buildArgs>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
## Summary
Removed the `--strict-image-heap` flag from the GraalVM native image build configuration in the Maven POM file.

## Changes
- Removed `--strict-image-heap` build argument from the native-image plugin configuration

## Details
The `--strict-image-heap` flag enforces strict validation of the image heap during GraalVM native image compilation. Removing this flag relaxes the heap validation constraints, which may be necessary to resolve build issues or allow certain runtime behaviors that would otherwise be rejected by strict validation.

https://claude.ai/code/session_01KQD1Mfnzqvbh45FLhsxG3G