### PR TITLE
Separate native image tests into dedicated workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -82,8 +82,6 @@ jobs:
           mkdir sidecar/target/lib
           copy -path "$env:GRAALVM_HOME/lib/font*" ./core/target/lib
           copy -path "$env:GRAALVM_HOME/lib/font*" ./sidecar/target/lib
-      - name: Run native-test
-        run: mvn test -Pnative --projects core,sidecar
       - uses: actions/upload-artifact@v4
         with:
           name: native-image

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -32,3 +32,10 @@ jobs:
           copy -path "$env:GRAALVM_HOME/lib/font*" ./sidecar/target/lib
       - name: Run native-test
         run: mvn test -Pnative --projects core,sidecar
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: native-test-results
+          path: |
+            ./core/target/surefire-reports/*.xml
+            ./sidecar/target/surefire-reports/*.xml

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -1,0 +1,34 @@
+name: Native-Test
+on:
+  workflow_dispatch:
+
+jobs:
+  native-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up graalvm
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          cache: 'maven'
+      - name: postgresql setup
+        uses: ikalnytskyi/action-setup-postgres@v4
+        with:
+          username: admin
+          password: admin
+          database: test
+          port: 5433
+        id: postgres
+      - name: Build native-image
+        run: |
+          mvn clean package -Pnative "-Dmaven.test.skip=true"
+          mkdir core/target/lib
+          mkdir sidecar/target/lib
+          copy -path "$env:GRAALVM_HOME/lib/font*" ./core/target/lib
+          copy -path "$env:GRAALVM_HOME/lib/font*" ./sidecar/target/lib
+      - name: Run native-test
+        run: mvn test -Pnative --projects core,sidecar

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdbc.dependencies.scope>test</jdbc.dependencies.scope>
+        <allure.scope>test</allure.scope>
         <aspectj.version>1.9.4</aspectj.version>
         <allure.version>2.25.0</allure.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
@@ -25,6 +26,7 @@
             <id>native</id>
             <properties>
                 <jdbc.dependencies.scope>compile</jdbc.dependencies.scope>
+                <allure.scope>provided</allure.scope>
             </properties>
             <build>
                 <pluginManagement>
@@ -325,7 +327,7 @@
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-junit5</artifactId>
             <version>${allure.version}</version>
-            <scope>test</scope>
+            <scope>${allure.scope}</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
## Summary
This PR refactors the native image testing strategy by extracting native tests from the main Maven workflow into a dedicated GitHub Actions workflow, while also adjusting the Allure dependency scope for native builds.

## Key Changes
- **New workflow**: Added `.github/workflows/native-test.yml` that runs native image tests on Windows with GraalVM, PostgreSQL, and proper artifact collection
- **Workflow separation**: Removed native test execution from `.github/workflows/maven.yml` to avoid running tests twice in the main build pipeline
- **Dependency scope management**: Updated `pom.xml` to make Allure dependency scope configurable:
  - Default scope remains `test` for standard builds
  - Native profile sets scope to `provided` to prevent test-scoped dependencies from being included in native images

## Implementation Details
- The new native-test workflow runs on `windows-latest` with GraalVM Java 25
- Includes PostgreSQL setup on port 5433 for integration testing
- Copies GraalVM font libraries to both core and sidecar target directories (Windows-specific requirement)
- Uploads test results as artifacts for both core and sidecar modules
- Uses Maven profiles (`-Pnative`) to control build behavior and dependency scoping

https://claude.ai/code/session_011SRTH17vNaQ4GpFRhsqDXd