### PR TITLE
Refactor dataset source info management to use React Context

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -8,6 +8,11 @@ import {
 	ResourceDatalist,
 	SelectBox,
 } from "../../components/element/Input";
+import {
+	DatasetSrcInfoProvider,
+	useDatasetSrcInfo,
+	useSetDatasetSrcInfo,
+} from "../../context/DatasetSrcInfoProvider";
 import { useJdbcConnectionState } from "../../context/JdbcConnectionProvider";
 import { useResourcesSettings } from "../../context/WorkspaceResourcesProvider";
 import type {
@@ -123,7 +128,10 @@ export default function CommandFormElements(
 		: undefined;
 
 	return (
-		<>
+		<DatasetSrcInfoProvider
+			key={prop.name + prop.prefix}
+			initialValue={datasetSrcInfo}
+		>
 			{prop.elements.map((element) => {
 				if (isJdbcFieldName(element.name)) {
 					return null;
@@ -188,9 +196,6 @@ export default function CommandFormElements(
 							hidden={prop.optional?.(element.name) && !showOptional}
 							srcType={element.name === "src" ? srcType : undefined}
 							srcInfo={element.name === "xlsxSchema" ? srcInfo : undefined}
-							datasetSrcInfo={
-								element.name === "setting" ? datasetSrcInfo : undefined
-							}
 						/>
 					</Fragment>
 				);
@@ -198,12 +203,14 @@ export default function CommandFormElements(
 			{jdbcElements.length > 0 && (
 				<JdbcFormSection prefix={prop.prefix} elements={jdbcElements} />
 			)}
-		</>
+		</DatasetSrcInfoProvider>
 	);
 }
 function Text(prop: Prop) {
 	const [path, setPath] = useState(prop.element.value);
-	const { element, srcType, srcInfo, datasetSrcInfo } = prop;
+	const { element, srcType, srcInfo } = prop;
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const setDatasetSrcInfo = useSetDatasetSrcInfo();
 	const datasetSrcInfoWithSetting = useMemo(
 		() => (datasetSrcInfo ? { ...datasetSrcInfo, setting: path } : undefined),
 		[datasetSrcInfo, path],
@@ -229,6 +236,22 @@ function Text(prop: Prop) {
 		element.attribute.type.includes("DIR") ||
 		showDatalist;
 	const isValueInDatalist = resourceFiles?.includes(path) || false;
+
+	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+		const newValue = ev.target.value;
+		setPath(newValue);
+		if (datasetSrcInfo) {
+			const fieldName =
+				element.name === "src" ? "srcPath" : element.name;
+			if (fieldName in datasetSrcInfo) {
+				setDatasetSrcInfo({
+					...datasetSrcInfo,
+					[fieldName]: newValue,
+				} as DatasetSrcInfo);
+			}
+		}
+	};
+
 	return (
 		<>
 			<div>
@@ -253,7 +276,7 @@ function Text(prop: Prop) {
 							hidden={prop.hidden}
 							required={prop.element.attribute.required}
 							value={path}
-							handleChange={(ev) => setPath(ev.target.value)}
+							handleChange={handleChange}
 						/>
 						{showDatalist && !prop.hidden && (
 							<ResourceDatalist
@@ -272,7 +295,6 @@ function Text(prop: Prop) {
 								hidden={prop.hidden}
 								srcType={srcType}
 								srcInfo={srcInfo}
-								datasetSrcInfo={datasetSrcInfo}
 								isValueInDatalist={isValueInDatalist}
 							/>
 						)}
@@ -305,13 +327,13 @@ function TextDropDownMenu({
 	hidden,
 	srcType,
 	srcInfo,
-	datasetSrcInfo,
 	isValueInDatalist,
 }: FileProp & {
 	srcType?: string;
 	isValueInDatalist?: boolean;
 }) {
 	const { connectionOk } = useJdbcConnectionState();
+	const datasetSrcInfo = useDatasetSrcInfo();
 
 	return (
 		<DropDownMenu>
@@ -429,6 +451,18 @@ function TextDropDownMenu({
 	);
 }
 function Check(prop: Prop) {
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const setDatasetSrcInfo = useSetDatasetSrcInfo();
+
+	const handleOnChange = (checked: boolean) => {
+		if (datasetSrcInfo && prop.element.name in datasetSrcInfo) {
+			setDatasetSrcInfo({
+				...datasetSrcInfo,
+				[prop.element.name]: checked,
+			} as DatasetSrcInfo);
+		}
+	};
+
 	return (
 		<div>
 			<InputLabel
@@ -450,11 +484,22 @@ function Check(prop: Prop) {
 				id={`${prop.prefix}_${prop.element.name}`}
 				hidden={prop.hidden}
 				defaultValue={prop.element.value}
+				handleOnChange={handleOnChange}
 			/>
 		</div>
 	);
 }
 function Select(prop: SelectProp) {
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const setDatasetSrcInfo = useSetDatasetSrcInfo();
+
+	const handleTypeSelect = async (selected: string) => {
+		await prop.handleTypeSelect(selected);
+		if (prop.element.name === "srcType" && datasetSrcInfo) {
+			setDatasetSrcInfo({ ...datasetSrcInfo, srcType: selected });
+		}
+	};
+
 	return (
 		<div>
 			<InputLabel
@@ -476,7 +521,7 @@ function Select(prop: SelectProp) {
 				id={`${prop.prefix}_${prop.element.name}`}
 				required={true}
 				hidden={prop.hidden}
-				handleOnChange={prop.handleTypeSelect}
+				handleOnChange={handleTypeSelect}
 				defaultValue={prop.element.value}
 			>
 				{prop.element.attribute.selectOption.map((value) => {

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -9,13 +9,13 @@ import {
 	SelectBox,
 } from "../../components/element/Input";
 import {
-	DatasetSrcInfoProvider,
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
 } from "../../context/DatasetSrcInfoProvider";
 import { useJdbcConnectionState } from "../../context/JdbcConnectionProvider";
 import { useResourcesSettings } from "../../context/WorkspaceResourcesProvider";
 import type {
+	CommandParam,
 	CommandParams,
 	DatasetSrcInfo,
 	SrcInfo,
@@ -41,6 +41,33 @@ import XlsxSchemaEditButton, {
 import { DirectoryChooser, FileChooser, OpenInOS } from "./Chooser";
 import type { FileProp, Prop, SelectProp } from "./FormElementProp";
 import JdbcFormSection, { JDBC_FIELD_NAMES } from "./JdbcFormSection";
+
+export function buildDatasetSrcInfo(elements: CommandParam[]): DatasetSrcInfo {
+	const find = (name: string) => elements.find((e) => e.name === name);
+	const srcInfo: SrcInfo = {
+		srcPath: find("src")?.value ?? "",
+		regTableInclude: find("regTableInclude")?.value ?? "",
+		regTableExclude: find("regTableExclude")?.value ?? "",
+		recursive: find("recursive")?.value ?? "",
+		regInclude: find("regInclude")?.value ?? "",
+		regExclude: find("regExclude")?.value ?? "",
+		extension: find("extension")?.value ?? "",
+	};
+	return {
+		...srcInfo,
+		srcType: find("srcType")?.value ?? "",
+		xlsxSchema: find("xlsxSchema")?.value ?? "",
+		fixedLength: find("fixedLength")?.value ?? "",
+		regHeaderSplit: find("regHeaderSplit")?.value ?? "",
+		regDataSplit: find("regDataSplit")?.value ?? "",
+		encoding: find("encoding")?.value ?? "",
+		delimiter: find("delimiter")?.value ?? "",
+		ignoreQuoted: find("ignoreQuoted")?.value === "true",
+		headerName: find("headerName")?.value ?? "",
+		startRow: find("startRow")?.value ?? "",
+		addFileInfo: find("addFileInfo")?.value === "true",
+	};
+}
 
 export default function CommandFormElements(
 	prop: {
@@ -80,40 +107,6 @@ export default function CommandFormElements(
 		regExclude: regExcludeElement?.value ?? "",
 		extension: extensionElement?.value ?? "",
 	};
-	const xlsxSchemaElement = prop.elements.find((e) => e.name === "xlsxSchema");
-	const fixedLengthElement = prop.elements.find(
-		(e) => e.name === "fixedLength",
-	);
-	const regHeaderSplitElement = prop.elements.find(
-		(e) => e.name === "regHeaderSplit",
-	);
-	const regDataSplitElement = prop.elements.find(
-		(e) => e.name === "regDataSplit",
-	);
-	const encodingElement = prop.elements.find((e) => e.name === "encoding");
-	const delimiterElement = prop.elements.find((e) => e.name === "delimiter");
-	const ignoreQuotedElement = prop.elements.find(
-		(e) => e.name === "ignoreQuoted",
-	);
-	const headerNameElement = prop.elements.find((e) => e.name === "headerName");
-	const startRowElement = prop.elements.find((e) => e.name === "startRow");
-	const addFileInfoElement = prop.elements.find(
-		(e) => e.name === "addFileInfo",
-	);
-	const datasetSrcInfo: DatasetSrcInfo = {
-		...srcInfo,
-		srcType,
-		xlsxSchema: xlsxSchemaElement?.value ?? "",
-		fixedLength: fixedLengthElement?.value ?? "",
-		regHeaderSplit: regHeaderSplitElement?.value ?? "",
-		regDataSplit: regDataSplitElement?.value ?? "",
-		encoding: encodingElement?.value ?? "",
-		delimiter: delimiterElement?.value ?? "",
-		ignoreQuoted: ignoreQuotedElement?.value === "true",
-		headerName: headerNameElement?.value ?? "",
-		startRow: startRowElement?.value ?? "",
-		addFileInfo: addFileInfoElement?.value === "true",
-	};
 	const toggleOptional = () => setShowOptional(!showOptional);
 
 	const isJdbcFieldName = (name: string) =>
@@ -128,10 +121,7 @@ export default function CommandFormElements(
 		: undefined;
 
 	return (
-		<DatasetSrcInfoProvider
-			key={prop.name + prop.prefix}
-			initialValue={datasetSrcInfo}
-		>
+		<>
 			{prop.elements.map((element) => {
 				if (isJdbcFieldName(element.name)) {
 					return null;
@@ -203,7 +193,7 @@ export default function CommandFormElements(
 			{jdbcElements.length > 0 && (
 				<JdbcFormSection prefix={prop.prefix} elements={jdbcElements} />
 			)}
-		</DatasetSrcInfoProvider>
+		</>
 	);
 }
 function Text(prop: Prop) {

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useState } from "react";
 import { ExpandButton } from "../../components/element/ButtonIcon";
 import DropDownMenu from "../../components/element/DropDownMenu";
 import {
@@ -83,7 +83,6 @@ export default function CommandFormElements(
 		(element) => element.name === "srcType",
 	);
 	const srcType = srcTypeElement ? srcTypeElement.value : "";
-	const srcInfo = buildSrcInfo(prop.elements);
 	const toggleOptional = () => setShowOptional(!showOptional);
 
 	const isJdbcFieldName = (name: string) =>
@@ -162,7 +161,6 @@ export default function CommandFormElements(
 							element={element}
 							hidden={prop.optional?.(element.name) && !showOptional}
 							srcType={element.name === "src" ? srcType : undefined}
-							srcInfo={element.name === "xlsxSchema" ? srcInfo : undefined}
 						/>
 					</Fragment>
 				);
@@ -175,13 +173,9 @@ export default function CommandFormElements(
 }
 function Text(prop: Prop) {
 	const [path, setPath] = useState(prop.element.value);
-	const { element, srcType, srcInfo } = prop;
+	const { element, srcType } = prop;
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
-	const datasetSrcInfoWithSetting = useMemo(
-		() => (datasetSrcInfo ? { ...datasetSrcInfo, setting: path } : undefined),
-		[datasetSrcInfo, path],
-	);
 	const settings = useResourcesSettings();
 	let resourceFiles: string[] = [];
 	if (element.name === "src" && isSqlRelatedType(srcType ?? "")) {
@@ -261,7 +255,6 @@ function Text(prop: Prop) {
 								setPath={setPath}
 								hidden={prop.hidden}
 								srcType={srcType}
-								srcInfo={srcInfo}
 								isValueInDatalist={isValueInDatalist}
 							/>
 						)}
@@ -270,14 +263,11 @@ function Text(prop: Prop) {
 			</div>
 			{element.name === "setting" && datasetSrcInfo?.srcType && (
 				<div className="mt-2 flex items-center gap-3">
-					<DatasetTableNamesPreviewButton
-						title="Preview Before Settings"
-						datasetSrcInfo={datasetSrcInfo}
-					/>
-					{datasetSrcInfoWithSetting && path && (
+					<DatasetTableNamesPreviewButton title="Preview Before Settings" />
+					{path && (
 						<DatasetTableNamesPreviewButton
 							title="Preview Aply Settings"
-							datasetSrcInfo={datasetSrcInfoWithSetting}
+							setting={path}
 						/>
 					)}
 				</div>
@@ -293,14 +283,12 @@ function TextDropDownMenu({
 	setPath,
 	hidden,
 	srcType,
-	srcInfo,
 	isValueInDatalist,
 }: FileProp & {
 	srcType?: string;
 	isValueInDatalist?: boolean;
 }) {
 	const { connectionOk } = useJdbcConnectionState();
-	const datasetSrcInfo = useDatasetSrcInfo();
 
 	return (
 		<DropDownMenu>
@@ -311,7 +299,6 @@ function TextDropDownMenu({
 							<DatasetSettingEditButton
 								path={path}
 								setPath={setPath}
-								datasetSrcInfo={datasetSrcInfo}
 							/>
 						</li>
 					)}
@@ -320,7 +307,6 @@ function TextDropDownMenu({
 							<XlsxSchemaEditButton
 								path={path}
 								setPath={setPath}
-								srcInfo={srcInfo}
 							/>
 						</li>
 					)}

--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -42,9 +42,9 @@ import { DirectoryChooser, FileChooser, OpenInOS } from "./Chooser";
 import type { FileProp, Prop, SelectProp } from "./FormElementProp";
 import JdbcFormSection, { JDBC_FIELD_NAMES } from "./JdbcFormSection";
 
-export function buildDatasetSrcInfo(elements: CommandParam[]): DatasetSrcInfo {
+export function buildSrcInfo(elements: CommandParam[]): SrcInfo {
 	const find = (name: string) => elements.find((e) => e.name === name);
-	const srcInfo: SrcInfo = {
+	return {
 		srcPath: find("src")?.value ?? "",
 		regTableInclude: find("regTableInclude")?.value ?? "",
 		regTableExclude: find("regTableExclude")?.value ?? "",
@@ -53,8 +53,12 @@ export function buildDatasetSrcInfo(elements: CommandParam[]): DatasetSrcInfo {
 		regExclude: find("regExclude")?.value ?? "",
 		extension: find("extension")?.value ?? "",
 	};
+}
+
+export function buildDatasetSrcInfo(elements: CommandParam[]): DatasetSrcInfo {
+	const find = (name: string) => elements.find((e) => e.name === name);
 	return {
-		...srcInfo,
+		...buildSrcInfo(elements),
 		srcType: find("srcType")?.value ?? "",
 		xlsxSchema: find("xlsxSchema")?.value ?? "",
 		fixedLength: find("fixedLength")?.value ?? "",
@@ -79,34 +83,7 @@ export default function CommandFormElements(
 		(element) => element.name === "srcType",
 	);
 	const srcType = srcTypeElement ? srcTypeElement.value : "";
-	const srcElement = prop.elements.find((element) => element.name === "src");
-	const regTableIncludeElement = prop.elements.find(
-		(element) => element.name === "regTableInclude",
-	);
-	const regTableExcludeElement = prop.elements.find(
-		(element) => element.name === "regTableExclude",
-	);
-	const recursiveElement = prop.elements.find(
-		(element) => element.name === "recursive",
-	);
-	const regIncludeElement = prop.elements.find(
-		(element) => element.name === "regInclude",
-	);
-	const regExcludeElement = prop.elements.find(
-		(element) => element.name === "regExclude",
-	);
-	const extensionElement = prop.elements.find(
-		(element) => element.name === "extension",
-	);
-	const srcInfo: SrcInfo = {
-		srcPath: srcElement?.value ?? "",
-		regTableInclude: regTableIncludeElement?.value ?? "",
-		regTableExclude: regTableExcludeElement?.value ?? "",
-		recursive: recursiveElement?.value ?? "",
-		regInclude: regIncludeElement?.value ?? "",
-		regExclude: regExcludeElement?.value ?? "",
-		extension: extensionElement?.value ?? "",
-	};
+	const srcInfo = buildSrcInfo(prop.elements);
 	const toggleOptional = () => setShowOptional(!showOptional);
 
 	const isJdbcFieldName = (name: string) =>

--- a/tauri/src/app/form/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/DatasetLoadForm.tsx
@@ -1,6 +1,7 @@
+import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
 import { JdbcConnectionProvider } from "../../context/JdbcConnectionProvider";
 import type { DatasetSource } from "../../model/CommandParam";
-import CommandFormElements from "./CommandFormElement";
+import CommandFormElements, { buildDatasetSrcInfo } from "./CommandFormElement";
 
 export function DatasetLoadForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -12,33 +13,38 @@ export function DatasetLoadForm(prop: {
 	const settingElements = prop.srcData.settingElements();
 	return (
 		<JdbcConnectionProvider>
-			<fieldset className="border border-gray-200 p-3">
-				<legend>{prop.srcData.prefix}</legend>
-				<CommandFormElements
-					handleTypeSelect={prop.handleTypeSelect}
-					prefix={src.prefix}
-					name={prop.name}
-					elements={src.elements}
-					optionCaption={src.optionCaption}
-					optional={src.optional}
-				/>
-				<CommandFormElements
-					handleTypeSelect={prop.handleTypeSelect}
-					prefix={srcTypeSettings.prefix}
-					name={prop.name}
-					elements={srcTypeSettings.elements}
-					optionCaption={srcTypeSettings.optionCaption}
-					optional={srcTypeSettings.optional}
-				/>
-				<CommandFormElements
-					handleTypeSelect={prop.handleTypeSelect}
-					prefix={settingElements.prefix}
-					name={prop.name}
-					elements={settingElements.elements}
-					optionCaption={settingElements.optionCaption}
-					optional={settingElements.optional}
-				/>
-			</fieldset>
+			<DatasetSrcInfoProvider
+				key={prop.name + prop.srcData.prefix}
+				initialValue={buildDatasetSrcInfo(prop.srcData.elements)}
+			>
+				<fieldset className="border border-gray-200 p-3">
+					<legend>{prop.srcData.prefix}</legend>
+					<CommandFormElements
+						handleTypeSelect={prop.handleTypeSelect}
+						prefix={src.prefix}
+						name={prop.name}
+						elements={src.elements}
+						optionCaption={src.optionCaption}
+						optional={src.optional}
+					/>
+					<CommandFormElements
+						handleTypeSelect={prop.handleTypeSelect}
+						prefix={srcTypeSettings.prefix}
+						name={prop.name}
+						elements={srcTypeSettings.elements}
+						optionCaption={srcTypeSettings.optionCaption}
+						optional={srcTypeSettings.optional}
+					/>
+					<CommandFormElements
+						handleTypeSelect={prop.handleTypeSelect}
+						prefix={settingElements.prefix}
+						name={prop.name}
+						elements={settingElements.elements}
+						optionCaption={settingElements.optionCaption}
+						optional={settingElements.optional}
+					/>
+				</fieldset>
+			</DatasetSrcInfoProvider>
 		</JdbcConnectionProvider>
 	);
 }

--- a/tauri/src/app/form/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/DatasetLoadForm.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
 import { JdbcConnectionProvider } from "../../context/JdbcConnectionProvider";
 import type { DatasetSource } from "../../model/CommandParam";
@@ -11,11 +12,15 @@ export function DatasetLoadForm(prop: {
 	const src = prop.srcData.srcElements();
 	const srcTypeSettings = prop.srcData.srcTypeSettings();
 	const settingElements = prop.srcData.settingElements();
+	const initialDatasetSrcInfo = useMemo(
+		() => buildDatasetSrcInfo(prop.srcData.elements),
+		[prop.srcData.elements],
+	);
 	return (
 		<JdbcConnectionProvider>
 			<DatasetSrcInfoProvider
 				key={prop.name + prop.srcData.prefix}
-				initialValue={buildDatasetSrcInfo(prop.srcData.elements)}
+				initialValue={initialDatasetSrcInfo}
 			>
 				<fieldset className="border border-gray-200 p-3">
 					<legend>{prop.srcData.prefix}</legend>

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -1,19 +1,17 @@
 import type { Dispatch, SetStateAction } from "react";
-import type { CommandParam, SrcInfo } from "../../model/CommandParam";
+import type { CommandParam } from "../../model/CommandParam";
 
 export type Prop = {
 	prefix: string;
 	element: CommandParam;
 	hidden?: boolean;
 	srcType?: string;
-	srcInfo?: SrcInfo;
 };
 export type FileProp = Prop & {
 	path: string;
 	setPath: Dispatch<SetStateAction<string>>;
 	onSelect?: () => void;
 	srcType?: string;
-	srcInfo?: SrcInfo;
 };
 export type SelectProp = Prop & {
 	handleTypeSelect: (selected: string) => Promise<void>;

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -1,9 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import type {
-	CommandParam,
-	DatasetSrcInfo,
-	SrcInfo,
-} from "../../model/CommandParam";
+import type { CommandParam, SrcInfo } from "../../model/CommandParam";
 
 export type Prop = {
 	prefix: string;
@@ -11,7 +7,6 @@ export type Prop = {
 	hidden?: boolean;
 	srcType?: string;
 	srcInfo?: SrcInfo;
-	datasetSrcInfo?: DatasetSrcInfo;
 };
 export type FileProp = Prop & {
 	path: string;
@@ -19,7 +14,6 @@ export type FileProp = Prop & {
 	onSelect?: () => void;
 	srcType?: string;
 	srcInfo?: SrcInfo;
-	datasetSrcInfo?: DatasetSrcInfo;
 };
 export type SelectProp = Prop & {
 	handleTypeSelect: (selected: string) => Promise<void>;

--- a/tauri/src/app/settings/DatasetSettingDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingDialog.tsx
@@ -11,22 +11,22 @@ import {
 } from "../../components/dialog";
 import { ExpandButton } from "../../components/element/ButtonIcon";
 import { ResourceDatalist } from "../../components/element/Input";
+import { useDatasetSrcInfo } from "../../context/DatasetSrcInfoProvider";
 import { useDatasetTableNames } from "../../hooks/useDatasetSettings";
-import type { DatasetSrcInfo } from "../../model/CommandParam";
 import type { DatasetSetting } from "../../model/DatasetSettings";
 
 export default function DatasetSettingDialog(props: {
 	setting: DatasetSetting;
 	handleDialogClose: () => void;
 	handleCommit: (newSettings: DatasetSetting) => void;
-	datasetSrcInfo?: DatasetSrcInfo;
 }) {
 	const [target, setTarget] = useState(props.setting);
 	const handleTargetChange = async (select: string) =>
 		setTarget((current) => current.replace(select));
 	const [showOptional, setShowOptional] = useState(false);
 	const toggleOptional = () => setShowOptional(!showOptional);
-	const { tableNames } = useDatasetTableNames(props.datasetSrcInfo);
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const { tableNames } = useDatasetTableNames(datasetSrcInfo);
 	const tableList = tableNames.length > 0 ? "tableName_list" : undefined;
 
 	return (

--- a/tauri/src/app/settings/DatasetSettingEditButton.tsx
+++ b/tauri/src/app/settings/DatasetSettingEditButton.tsx
@@ -1,20 +1,14 @@
 import { useDeleteDatasetSettings } from "../../hooks/useDatasetSettings";
-import type { DatasetSrcInfo } from "../../model/CommandParam";
 import DatasetSettingsDialog from "./DatasetSettingsDialog";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,
 } from "./ResourceEditButton";
 
-type DatasetSettingEditButtonProp = ResourceEditButtonProp & {
-	datasetSrcInfo?: DatasetSrcInfo;
-};
-
 export default function DatasetSettingEditButton({
 	path,
 	setPath,
-	datasetSrcInfo,
-}: DatasetSettingEditButtonProp) {
+}: ResourceEditButtonProp) {
 	const renderDialog = (open: boolean, closeDialog: () => void) => {
 		if (!open) {
 			return null;
@@ -27,7 +21,6 @@ export default function DatasetSettingEditButton({
 					setPath(newPath);
 					closeDialog();
 				}}
-				datasetSrcInfo={datasetSrcInfo}
 			/>
 		);
 	};

--- a/tauri/src/app/settings/DatasetSettingsDialog.tsx
+++ b/tauri/src/app/settings/DatasetSettingsDialog.tsx
@@ -4,7 +4,6 @@ import {
 	useLoadDatasetSettings,
 	useSaveDatasetSettings,
 } from "../../hooks/useDatasetSettings";
-import type { DatasetSrcInfo } from "../../model/CommandParam";
 import type { DatasetSetting } from "../../model/DatasetSettings";
 import {
 	DatasetSettings,
@@ -17,7 +16,6 @@ export default function DatasetSettingsDialog(props: {
 	fileName: string;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
-	datasetSrcInfo?: DatasetSrcInfo;
 }) {
 	const loadSettings = useLoadDatasetSettings();
 	return (
@@ -27,7 +25,6 @@ export default function DatasetSettingsDialog(props: {
 				fileName={props.fileName}
 				handleDialogClose={props.handleDialogClose}
 				handleSave={props.handleSave}
-				datasetSrcInfo={props.datasetSrcInfo}
 			/>
 		</Suspense>
 	);
@@ -37,7 +34,6 @@ function Dialog(props: {
 	fileName: string;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
-	datasetSrcInfo?: DatasetSrcInfo;
 }) {
 	const saveSettings = useSaveDatasetSettings();
 	const dataSettingsData = use(props.promise);
@@ -73,7 +69,6 @@ function Dialog(props: {
 						setting={setting}
 						handleDialogClose={handleDialogClose}
 						handleCommit={handleCommit}
-						datasetSrcInfo={props.datasetSrcInfo}
 					/>
 				)}
 				newSetting={newDatasetSetting}
@@ -98,7 +93,6 @@ function Dialog(props: {
 						setting={setting}
 						handleDialogClose={handleDialogClose}
 						handleCommit={handleCommit}
-						datasetSrcInfo={props.datasetSrcInfo}
 					/>
 				)}
 				newSetting={newDatasetSetting}

--- a/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
+++ b/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
@@ -1,22 +1,28 @@
 import { useEffect, useRef, useState } from "react";
 import { BlueButton, WhiteButton } from "../../components/element/Button";
+import { useDatasetSrcInfo } from "../../context/DatasetSrcInfoProvider";
 import { useDatasetTableNames } from "../../hooks/useDatasetSettings";
 import type { DatasetSrcInfo } from "../../model/CommandParam";
 
 export default function DatasetTableNamesPreviewButton({
 	title,
-	datasetSrcInfo,
+	setting,
 }: {
 	title: string;
-	datasetSrcInfo: DatasetSrcInfo;
+	setting?: string;
 }) {
 	const [showDialog, setShowDialog] = useState(false);
+	const datasetSrcInfo = useDatasetSrcInfo();
 	return (
 		<>
 			<BlueButton title={title} handleClick={() => setShowDialog(true)} />
-			{showDialog && (
+			{showDialog && datasetSrcInfo && (
 				<DatasetTableNamesPreviewDialog
-					datasetSrcInfo={datasetSrcInfo}
+					datasetSrcInfo={
+						setting !== undefined
+							? { ...datasetSrcInfo, setting }
+							: datasetSrcInfo
+					}
 					handleDialogClose={() => setShowDialog(false)}
 				/>
 			)}

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -7,18 +7,17 @@ import {
 	Text,
 } from "../../components/dialog";
 import { ResourceDatalist } from "../../components/element/Input";
+import { useDatasetSrcInfo } from "../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
-import type { SrcInfo } from "../../model/CommandParam";
 import type { CellSetting } from "../../model/XlsxSchema";
 
 export default function XlsxCellSettingDialog(props: {
 	setting: CellSetting;
-	srcInfo?: SrcInfo;
 	handleDialogClose: () => void;
 	handleCommit: (newSettings: CellSetting) => void;
 }) {
 	const [target, setTarget] = useState(props.setting);
-	const sheetNames = useSrcInfoSheets(props.srcInfo);
+	const sheetNames = useSrcInfoSheets(useDatasetSrcInfo());
 
 	return (
 		<SettingDialog

--- a/tauri/src/app/settings/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxCellSettingDialog.tsx
@@ -17,7 +17,8 @@ export default function XlsxCellSettingDialog(props: {
 	handleCommit: (newSettings: CellSetting) => void;
 }) {
 	const [target, setTarget] = useState(props.setting);
-	const sheetNames = useSrcInfoSheets(useDatasetSrcInfo());
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const sheetNames = useSrcInfoSheets(datasetSrcInfo);
 
 	return (
 		<SettingDialog

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -1,18 +1,17 @@
 import { useState } from "react";
 import { Check, Fieldset, SettingDialog, Text } from "../../components/dialog";
 import { ResourceDatalist } from "../../components/element/Input";
+import { useDatasetSrcInfo } from "../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../hooks/useXlsxSchema";
-import type { SrcInfo } from "../../model/CommandParam";
 import type { RowSetting } from "../../model/XlsxSchema";
 
 export default function XlsxRowSettingDialog(props: {
 	setting: RowSetting;
-	srcInfo?: SrcInfo;
 	handleDialogClose: () => void;
 	handleCommit: (newSettings: RowSetting) => void;
 }) {
 	const [target, setTarget] = useState(props.setting);
-	const sheetNames = useSrcInfoSheets(props.srcInfo);
+	const sheetNames = useSrcInfoSheets(useDatasetSrcInfo());
 
 	return (
 		<SettingDialog

--- a/tauri/src/app/settings/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/settings/XlsxRowSettingDialog.tsx
@@ -11,7 +11,8 @@ export default function XlsxRowSettingDialog(props: {
 	handleCommit: (newSettings: RowSetting) => void;
 }) {
 	const [target, setTarget] = useState(props.setting);
-	const sheetNames = useSrcInfoSheets(useDatasetSrcInfo());
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const sheetNames = useSrcInfoSheets(datasetSrcInfo);
 
 	return (
 		<SettingDialog

--- a/tauri/src/app/settings/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/settings/XlsxSchemaDialog.tsx
@@ -4,7 +4,6 @@ import {
 	useLoadXlsxSchema,
 	useSaveXlsxSchema,
 } from "../../hooks/useXlsxSchema";
-import type { SrcInfo } from "../../model/CommandParam";
 import {
 	type CellSetting,
 	createCellSetting,
@@ -18,7 +17,6 @@ import XlsxRowSettingDialog from "./XlsxRowSettingDialog";
 
 export default function XlsxSchemaDialog(props: {
 	fileName: string;
-	srcInfo?: SrcInfo;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
 }) {
@@ -28,7 +26,6 @@ export default function XlsxSchemaDialog(props: {
 			<Dialog
 				promise={loadXlsxSchema(props.fileName)}
 				fileName={props.fileName}
-				srcInfo={props.srcInfo}
 				handleDialogClose={props.handleDialogClose}
 				handleSave={props.handleSave}
 			/>
@@ -38,7 +35,6 @@ export default function XlsxSchemaDialog(props: {
 function Dialog(props: {
 	promise: Promise<XlsxSchema>;
 	fileName: string;
-	srcInfo?: SrcInfo;
 	handleDialogClose: () => void;
 	handleSave: (path: string) => void;
 }) {
@@ -76,7 +72,6 @@ function Dialog(props: {
 						setting={setting}
 						handleDialogClose={handleDialogClose}
 						handleCommit={handleCommit}
-						srcInfo={props.srcInfo}
 					/>
 				)}
 				newSetting={createRowSetting}
@@ -101,7 +96,6 @@ function Dialog(props: {
 						setting={setting}
 						handleDialogClose={handleDialogClose}
 						handleCommit={handleCommit}
-						srcInfo={props.srcInfo}
 					/>
 				)}
 				newSetting={createCellSetting}

--- a/tauri/src/app/settings/XlsxSchemaEditButton.tsx
+++ b/tauri/src/app/settings/XlsxSchemaEditButton.tsx
@@ -1,20 +1,14 @@
 import { useDeleteXlsxSchema } from "../../hooks/useXlsxSchema";
-import type { SrcInfo } from "../../model/CommandParam";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,
 } from "./ResourceEditButton";
 import XlsxSchemaDialog from "./XlsxSchemaDialog";
 
-type XlsxSchemaEditButtonProp = ResourceEditButtonProp & {
-	srcInfo?: SrcInfo;
-};
-
 export default function XlsxSchemaEditButton({
 	path,
 	setPath,
-	srcInfo,
-}: XlsxSchemaEditButtonProp) {
+}: ResourceEditButtonProp) {
 	const renderDialog = (open: boolean, closeDialog: () => void) => {
 		if (!open) {
 			return null;
@@ -22,7 +16,6 @@ export default function XlsxSchemaEditButton({
 		return (
 			<XlsxSchemaDialog
 				fileName={path}
-				srcInfo={srcInfo}
 				handleDialogClose={closeDialog}
 				handleSave={(newPath: string) => {
 					setPath(newPath);

--- a/tauri/src/context/DatasetSrcInfoProvider.tsx
+++ b/tauri/src/context/DatasetSrcInfoProvider.tsx
@@ -3,7 +3,7 @@ import type { DatasetSrcInfo } from "../model/CommandParam";
 
 type DatasetSrcInfoContextValue = {
 	state: DatasetSrcInfo | undefined;
-	setState: (state: DatasetSrcInfo | undefined) => void;
+	setState: (state: DatasetSrcInfo) => void;
 };
 
 const DatasetSrcInfoContext = createContext<DatasetSrcInfoContextValue>({
@@ -18,7 +18,7 @@ export function DatasetSrcInfoProvider({
 	children: React.ReactNode;
 	initialValue: DatasetSrcInfo;
 }) {
-	const [state, setState] = useState<DatasetSrcInfo | undefined>(initialValue);
+	const [state, setState] = useState<DatasetSrcInfo>(initialValue);
 
 	return (
 		<DatasetSrcInfoContext.Provider value={{ state, setState }}>
@@ -31,8 +31,6 @@ export function useDatasetSrcInfo(): DatasetSrcInfo | undefined {
 	return useContext(DatasetSrcInfoContext).state;
 }
 
-export function useSetDatasetSrcInfo(): (
-	state: DatasetSrcInfo | undefined,
-) => void {
+export function useSetDatasetSrcInfo(): (state: DatasetSrcInfo) => void {
 	return useContext(DatasetSrcInfoContext).setState;
 }

--- a/tauri/src/context/DatasetSrcInfoProvider.tsx
+++ b/tauri/src/context/DatasetSrcInfoProvider.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useState } from "react";
+import type { DatasetSrcInfo } from "../model/CommandParam";
+
+type DatasetSrcInfoContextValue = {
+	state: DatasetSrcInfo | undefined;
+	setState: (state: DatasetSrcInfo | undefined) => void;
+};
+
+const DatasetSrcInfoContext = createContext<DatasetSrcInfoContextValue>({
+	state: undefined,
+	setState: () => {},
+});
+
+export function DatasetSrcInfoProvider({
+	children,
+	initialValue,
+}: {
+	children: React.ReactNode;
+	initialValue: DatasetSrcInfo;
+}) {
+	const [state, setState] = useState<DatasetSrcInfo | undefined>(initialValue);
+
+	return (
+		<DatasetSrcInfoContext.Provider value={{ state, setState }}>
+			{children}
+		</DatasetSrcInfoContext.Provider>
+	);
+}
+
+export function useDatasetSrcInfo(): DatasetSrcInfo | undefined {
+	return useContext(DatasetSrcInfoContext).state;
+}
+
+export function useSetDatasetSrcInfo(): (
+	state: DatasetSrcInfo | undefined,
+) => void {
+	return useContext(DatasetSrcInfoContext).setState;
+}


### PR DESCRIPTION
## Summary
This PR refactors the dataset source information management from prop drilling to a React Context-based approach. The changes improve code maintainability by centralizing state management and reducing the complexity of passing data through multiple component layers.

## Key Changes

- **Created `DatasetSrcInfoProvider` context**: New context provider (`DatasetSrcInfoProvider.tsx`) manages `DatasetSrcInfo` state globally within the dataset load form scope, with hooks `useDatasetSrcInfo()` and `useSetDatasetSrcInfo()` for accessing and updating the state.

- **Extracted builder functions**: Added `buildSrcInfo()` and `buildDatasetSrcInfo()` helper functions in `CommandFormElement.tsx` to construct source info objects from command parameters, eliminating repetitive element lookups.

- **Removed prop drilling**: Eliminated `srcInfo` and `datasetSrcInfo` props from multiple components:
  - `CommandFormElement.tsx`: Removed from `Prop` and `FileProp` type definitions
  - `DatasetSettingEditButton.tsx`, `XlsxSchemaEditButton.tsx`: Removed from component props
  - `DatasetSettingDialog.tsx`, `DatasetSettingsDialog.tsx`, `XlsxSchemaDialog.tsx`: Removed from dialog components
  - `XlsxCellSettingDialog.tsx`, `XlsxRowSettingDialog.tsx`: Removed from dialog components

- **Updated form element handlers**: Modified `Text`, `Check`, and `Select` components to use context hooks and update `DatasetSrcInfo` directly when form values change, ensuring state synchronization across the form.

- **Refactored `DatasetTableNamesPreviewButton`**: Now uses context to access `DatasetSrcInfo` and accepts an optional `setting` parameter to override the setting value for preview purposes.

- **Wrapped form in provider**: `DatasetLoadForm.tsx` now wraps all form sections with `DatasetSrcInfoProvider`, initialized with the current form state.

## Implementation Details

- The context is scoped to each dataset load form instance using a `key` prop to ensure proper state isolation when multiple forms are present.
- Form field changes automatically update the context state, maintaining consistency across all components that consume the context.
- The `buildDatasetSrcInfo()` function is memoized in `DatasetLoadForm` to prevent unnecessary recalculations.

https://claude.ai/code/session_01VTyarwDL66qPDp1Wn6SDSe