### PR TITLE
feat(tauri): CompareForm の setting 要素を targetType 別にレンダリング制御

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -76,6 +76,7 @@ export function buildDatasetSrcInfo(elements: CommandParam[]): DatasetSrcInfo {
 export default function CommandFormElements(
 	prop: {
 		handleTypeSelect: (selected: string) => Promise<void>;
+		hideDatasetSettingEdit?: boolean;
 	} & CommandParams,
 ) {
 	const [showOptional, setShowOptional] = useState(false);
@@ -161,6 +162,7 @@ export default function CommandFormElements(
 							element={element}
 							hidden={prop.optional?.(element.name) && !showOptional}
 							srcType={element.name === "src" ? srcType : undefined}
+							hideDatasetSettingEdit={prop.hideDatasetSettingEdit}
 						/>
 					</Fragment>
 				);
@@ -256,12 +258,13 @@ function Text(prop: Prop) {
 								hidden={prop.hidden}
 								srcType={srcType}
 								isValueInDatalist={isValueInDatalist}
+								hideDatasetSettingEdit={prop.hideDatasetSettingEdit}
 							/>
 						)}
 					</div>
 				</div>
 			</div>
-			{element.name === "setting" && datasetSrcInfo?.srcType && (
+			{element.name === "setting" && datasetSrcInfo?.srcType && !prop.hideDatasetSettingEdit && (
 				<div className="mt-2 flex items-center gap-3">
 					<DatasetTableNamesPreviewButton title="Preview Before Settings" />
 					{path && (
@@ -284,9 +287,11 @@ function TextDropDownMenu({
 	hidden,
 	srcType,
 	isValueInDatalist,
+	hideDatasetSettingEdit,
 }: FileProp & {
 	srcType?: string;
 	isValueInDatalist?: boolean;
+	hideDatasetSettingEdit?: boolean;
 }) {
 	const { connectionOk } = useJdbcConnectionState();
 
@@ -294,7 +299,7 @@ function TextDropDownMenu({
 		<DropDownMenu>
 			{(closeMenu) => (
 				<>
-					{element.name === "setting" && !hidden && (
+					{element.name === "setting" && !hidden && !hideDatasetSettingEdit && (
 						<li>
 							<DatasetSettingEditButton
 								path={path}

--- a/tauri/src/app/form/CompareForm.tsx
+++ b/tauri/src/app/form/CompareForm.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
+import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
 import type { CompareParams } from "../../model/CommandParam";
-import CommandFormElements from "./CommandFormElement";
+import CommandFormElements, { buildDatasetSrcInfo } from "./CommandFormElement";
 import { DatasetLoadForm } from "./DatasetLoadForm";
 
 export function CompareForm(prop: {
@@ -12,6 +14,26 @@ export function CompareForm(prop: {
 	const oldData = prop.compare.oldData;
 	const expectData = prop.compare.expectData;
 	const convertResult = prop.compare.convertResult;
+
+	const targetType =
+		prop.compare.elements.find((e) => e.name === "targetType")?.value ?? "data";
+	const settingIndex = prop.compare.elements.findIndex(
+		(e) => e.name === "setting",
+	);
+	const settingElement =
+		settingIndex >= 0 ? prop.compare.elements[settingIndex] : null;
+	const elementsBeforeSetting =
+		settingIndex >= 0
+			? prop.compare.elements.slice(0, settingIndex)
+			: prop.compare.elements;
+	const elementsAfterSetting =
+		settingIndex >= 0 ? prop.compare.elements.slice(settingIndex + 1) : [];
+
+	const oldDataInitialInfo = useMemo(
+		() => buildDatasetSrcInfo(oldData.elements),
+		[oldData.elements],
+	);
+
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
@@ -20,7 +42,35 @@ export function CompareForm(prop: {
 					handleTypeSelect={prop.handleTypeSelect}
 					name={prop.name}
 					prefix=""
-					elements={prop.compare.elements}
+					elements={elementsBeforeSetting}
+				/>
+				{settingElement &&
+					(targetType === "data" ? (
+						<DatasetSrcInfoProvider
+							key={prop.name + "compare-setting"}
+							initialValue={oldDataInitialInfo}
+						>
+							<CommandFormElements
+								handleTypeSelect={prop.handleTypeSelect}
+								name={prop.name}
+								prefix=""
+								elements={[settingElement]}
+							/>
+						</DatasetSrcInfoProvider>
+					) : (
+						<CommandFormElements
+							handleTypeSelect={prop.handleTypeSelect}
+							name={prop.name}
+							prefix=""
+							elements={[settingElement]}
+							hideDatasetSettingEdit={true}
+						/>
+					))}
+				<CommandFormElements
+					handleTypeSelect={prop.handleTypeSelect}
+					name={prop.name}
+					prefix=""
+					elements={elementsAfterSetting}
 				/>
 				{prop.compare.imageOption && (
 					<CommandFormElements

--- a/tauri/src/app/form/FormElementProp.ts
+++ b/tauri/src/app/form/FormElementProp.ts
@@ -6,6 +6,7 @@ export type Prop = {
 	element: CommandParam;
 	hidden?: boolean;
 	srcType?: string;
+	hideDatasetSettingEdit?: boolean;
 };
 export type FileProp = Prop & {
 	path: string;


### PR DESCRIPTION
- data: DatasetSrcInfoProvider（oldData 初期値）内で DatasetSettingEditButton / DatasetTableNamesPreviewButton を有効化
- pdf / image: hideDatasetSettingEdit フラグで DatasetSettingEditButton を非表示にし、ドロップダウンを open / delete / file のみに制限

https://claude.ai/code/session_01VTyarwDL66qPDp1Wn6SDSe