### PR TITLE
Refactor JDBC form handling to separate concerns

### DIFF
--- a/tauri/src/app/form/CommandFormElement.tsx
+++ b/tauri/src/app/form/CommandFormElement.tsx
@@ -40,7 +40,7 @@ import XlsxSchemaEditButton, {
 } from "../settings/XlsxSchemaEditButton";
 import { DirectoryChooser, FileChooser, OpenInOS } from "./Chooser";
 import type { FileProp, Prop, SelectProp } from "./FormElementProp";
-import JdbcFormSection, { JDBC_FIELD_NAMES } from "./JdbcFormSection";
+import { isJdbcField } from "./JdbcFormSection";
 
 export function buildSrcInfo(elements: CommandParam[]): SrcInfo {
 	const find = (name: string) => elements.find((e) => e.name === name);
@@ -86,21 +86,16 @@ export default function CommandFormElements(
 	const srcType = srcTypeElement ? srcTypeElement.value : "";
 	const toggleOptional = () => setShowOptional(!showOptional);
 
-	const isJdbcFieldName = (name: string) =>
-		JDBC_FIELD_NAMES.includes(name as (typeof JDBC_FIELD_NAMES)[number]);
-
-	const jdbcElements = prop.elements.filter((e) => isJdbcFieldName(e.name));
-
 	const firstOptionalNonJdbcElementName = prop.optionCaption
 		? prop.elements.find(
-				(e) => !isJdbcFieldName(e.name) && prop.optional?.(e.name),
+				(e) => !isJdbcField(e.name) && prop.optional?.(e.name),
 			)?.name
 		: undefined;
 
 	return (
 		<>
 			{prop.elements.map((element) => {
-				if (isJdbcFieldName(element.name)) {
+				if (isJdbcField(element.name)) {
 					return null;
 				}
 				const showExpandButton =
@@ -167,9 +162,6 @@ export default function CommandFormElements(
 					</Fragment>
 				);
 			})}
-			{jdbcElements.length > 0 && (
-				<JdbcFormSection prefix={prop.prefix} elements={jdbcElements} />
-			)}
 		</>
 	);
 }

--- a/tauri/src/app/form/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/DatasetLoadForm.tsx
@@ -3,6 +3,7 @@ import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
 import { JdbcConnectionProvider } from "../../context/JdbcConnectionProvider";
 import type { DatasetSource } from "../../model/CommandParam";
 import CommandFormElements, { buildDatasetSrcInfo } from "./CommandFormElement";
+import JdbcFormSection, { isJdbcField } from "./JdbcFormSection";
 
 export function DatasetLoadForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -15,6 +16,13 @@ export function DatasetLoadForm(prop: {
 	const initialDatasetSrcInfo = useMemo(
 		() => buildDatasetSrcInfo(prop.srcData.elements),
 		[prop.srcData.elements],
+	);
+	const srcJdbc = src.elements.filter((e) => isJdbcField(e.name));
+	const srcTypeSettingsJdbc = srcTypeSettings.elements.filter((e) =>
+		isJdbcField(e.name),
+	);
+	const settingElementsJdbc = settingElements.elements.filter((e) =>
+		isJdbcField(e.name),
 	);
 	return (
 		<JdbcConnectionProvider>
@@ -32,6 +40,9 @@ export function DatasetLoadForm(prop: {
 						optionCaption={src.optionCaption}
 						optional={src.optional}
 					/>
+					{srcJdbc.length > 0 && (
+						<JdbcFormSection prefix={src.prefix} elements={srcJdbc} />
+					)}
 					<CommandFormElements
 						handleTypeSelect={prop.handleTypeSelect}
 						prefix={srcTypeSettings.prefix}
@@ -40,6 +51,12 @@ export function DatasetLoadForm(prop: {
 						optionCaption={srcTypeSettings.optionCaption}
 						optional={srcTypeSettings.optional}
 					/>
+					{srcTypeSettingsJdbc.length > 0 && (
+						<JdbcFormSection
+							prefix={srcTypeSettings.prefix}
+							elements={srcTypeSettingsJdbc}
+						/>
+					)}
 					<CommandFormElements
 						handleTypeSelect={prop.handleTypeSelect}
 						prefix={settingElements.prefix}
@@ -48,6 +65,12 @@ export function DatasetLoadForm(prop: {
 						optionCaption={settingElements.optionCaption}
 						optional={settingElements.optional}
 					/>
+					{settingElementsJdbc.length > 0 && (
+						<JdbcFormSection
+							prefix={settingElements.prefix}
+							elements={settingElementsJdbc}
+						/>
+					)}
 				</fieldset>
 			</DatasetSrcInfoProvider>
 		</JdbcConnectionProvider>

--- a/tauri/src/app/form/JdbcFormSection.tsx
+++ b/tauri/src/app/form/JdbcFormSection.tsx
@@ -36,6 +36,9 @@ export const JDBC_FIELD_NAMES = [
 	"jdbcProperties",
 ] as const;
 
+export const isJdbcField = (name: string): boolean =>
+	JDBC_FIELD_NAMES.includes(name as (typeof JDBC_FIELD_NAMES)[number]);
+
 export default function JdbcFormSection({
 	prefix,
 	elements,

--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -1,6 +1,8 @@
+import { JdbcConnectionProvider } from "../../context/JdbcConnectionProvider";
 import type { RunParams } from "../../model/CommandParam";
 import CommandFormElements from "./CommandFormElement";
 import { DatasetLoadForm } from "./DatasetLoadForm";
+import JdbcFormSection, { isJdbcField } from "./JdbcFormSection";
 
 export function RunForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -10,6 +12,8 @@ export function RunForm(prop: {
 	const srcData = prop.run.srcData;
 	const templateOption = prop.run.templateOption;
 	const jdbcOption = prop.run.jdbcOption;
+	const jdbcOptionElements =
+		jdbcOption?.elements.filter((e) => isJdbcField(e.name)) ?? [];
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
@@ -29,12 +33,20 @@ export function RunForm(prop: {
 					/>
 				)}
 				{prop.run.jdbcOption && (
-					<CommandFormElements
-						handleTypeSelect={prop.handleTypeSelect}
-						name={prop.name}
-						prefix={jdbcOption.prefix}
-						elements={jdbcOption.elements}
-					/>
+					<JdbcConnectionProvider>
+						<CommandFormElements
+							handleTypeSelect={prop.handleTypeSelect}
+							name={prop.name}
+							prefix={jdbcOption.prefix}
+							elements={jdbcOption.elements}
+						/>
+						{jdbcOptionElements.length > 0 && (
+							<JdbcFormSection
+								prefix={jdbcOption.prefix}
+								elements={jdbcOptionElements}
+							/>
+						)}
+					</JdbcConnectionProvider>
 				)}
 			</fieldset>
 			<DatasetLoadForm


### PR DESCRIPTION
## Summary
This PR refactors the JDBC form field handling to improve code organization and reusability. JDBC-specific form sections are now rendered separately from general command form elements, with a shared utility function for identifying JDBC fields.

## Key Changes
- **Extracted `isJdbcField()` utility function** in `JdbcFormSection.tsx` to centralize JDBC field identification logic, replacing inline checks throughout the codebase
- **Separated JDBC form rendering** from `CommandFormElements` - JDBC fields are now filtered out and rendered via dedicated `JdbcFormSection` components in parent components
- **Updated `RunForm.tsx`** to wrap JDBC options in `JdbcConnectionProvider` and render filtered JDBC fields through `JdbcFormSection`
- **Updated `DatasetLoadForm.tsx`** to render `JdbcFormSection` components for each dataset configuration section (source, type settings, and general settings) when JDBC fields are present
- **Removed JDBC rendering logic** from `CommandFormElements.tsx` - it now only handles non-JDBC fields and delegates JDBC field rendering to parent components

## Implementation Details
- The `isJdbcField()` function provides a single source of truth for determining if a field name is JDBC-related
- JDBC fields are filtered using `elements.filter((e) => isJdbcField(e.name))` before being passed to `JdbcFormSection`
- `JdbcConnectionProvider` context is properly scoped around JDBC form sections to ensure connection state is available
- Conditional rendering (`{jdbcElements.length > 0 && ...}`) prevents empty JDBC sections from being rendered

https://claude.ai/code/session_01UQdJCEUvcYwfP8GzuZzNyL