### PR TITLE
Refactor resource text inputs into reusable component

### DIFF
--- a/tauri/src/app/form/section/ResourceText.tsx
+++ b/tauri/src/app/form/section/ResourceText.tsx
@@ -51,13 +51,13 @@ export default function ResourceText({
 					<ControllTextBox
 						name={fieldName}
 						id={id}
-						list={`${id}_list`}
+						list={resourceFiles.length > 0 ? `${id}_list` : undefined}
 						hidden={hidden}
 						required={element.attribute.required}
 						value={path}
 						handleChange={handleChange}
 					/>
-					{!hidden && (
+					{!hidden && resourceFiles.length > 0 && (
 						<ResourceDatalist
 							id={id}
 							resources={resourceFiles}

--- a/tauri/src/app/form/section/ResourceText.tsx
+++ b/tauri/src/app/form/section/ResourceText.tsx
@@ -1,0 +1,71 @@
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+import { useState } from "react";
+import {
+	ControllTextBox,
+	InputLabel,
+	ResourceDatalist,
+} from "../../../components/element/Input";
+import type { Prop } from "./FormElementProp";
+import { getId, getName } from "./FormElementProp";
+
+interface Props extends Prop {
+	resourceFiles: string[];
+	onValueChange?: (value: string) => void;
+	children: (args: {
+		path: string;
+		setPath: Dispatch<SetStateAction<string>>;
+		isValueInDatalist: boolean;
+	}) => ReactNode;
+}
+
+export default function ResourceText({
+	prefix,
+	element,
+	hidden,
+	srcType: _srcType,
+	resourceFiles,
+	onValueChange,
+	children,
+}: Props) {
+	const [path, setPath] = useState(element.value);
+	const isValueInDatalist = resourceFiles.includes(path);
+	const id = getId(prefix, element.name);
+	const fieldName = getName(prefix, element.name);
+
+	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+		const newValue = ev.target.value;
+		setPath(newValue);
+		onValueChange?.(newValue);
+	};
+
+	return (
+		<div>
+			<InputLabel
+				text={fieldName}
+				id={id}
+				required={element.attribute.required}
+				hidden={hidden}
+			/>
+			<div className="flex">
+				<div className="flex-1">
+					<ControllTextBox
+						name={fieldName}
+						id={id}
+						list={`${id}_list`}
+						hidden={hidden}
+						required={element.attribute.required}
+						value={path}
+						handleChange={handleChange}
+					/>
+					{!hidden && (
+						<ResourceDatalist
+							id={id}
+							resources={resourceFiles}
+						/>
+					)}
+				</div>
+				{!hidden && children({ path, setPath, isValueInDatalist })}
+			</div>
+		</div>
+	);
+}

--- a/tauri/src/app/form/section/SqlSrcText.tsx
+++ b/tauri/src/app/form/section/SqlSrcText.tsx
@@ -1,9 +1,3 @@
-import { useState } from "react";
-import {
-	ControllTextBox,
-	InputLabel,
-	ResourceDatalist,
-} from "../../../components/element/Input";
 import {
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
@@ -11,66 +5,42 @@ import {
 import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../../../model/CommandParam";
 import { isSqlRelatedType } from "../../../model/QueryDatasource";
-import SqlSrcDropDownMenu from "./SqlSrcDropDownMenu";
 import type { Prop } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import ResourceText from "./ResourceText";
+import SqlSrcDropDownMenu from "./SqlSrcDropDownMenu";
 
 export default function SqlSrcText({ prefix, element, hidden, srcType }: Prop) {
-	const [path, setPath] = useState(element.value);
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
 	const settings = useResourcesSettings();
 	const isSqlSrc = isSqlRelatedType(srcType ?? "");
 	const resourceFiles = isSqlSrc ? settings.querys(srcType) : [];
-	const isValueInDatalist = resourceFiles.includes(path);
-	const id = getId(prefix, element.name);
-	const fieldName = getName(prefix, element.name);
 
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = ev.target.value;
-		setPath(newValue);
+	const handleValueChange = (newValue: string) => {
 		if (datasetSrcInfo) {
 			setDatasetSrcInfo({ ...datasetSrcInfo, srcPath: newValue } as DatasetSrcInfo);
 		}
 	};
 
 	return (
-		<div>
-			<InputLabel
-				text={fieldName}
-				id={id}
-				required={element.attribute.required}
-				hidden={hidden}
-			/>
-			<div className="flex">
-				<div className="flex-1">
-					<ControllTextBox
-						name={fieldName}
-						id={id}
-						list={isSqlSrc ? `${id}_list` : undefined}
-						hidden={hidden}
-						required={element.attribute.required}
-						value={path}
-						handleChange={handleChange}
-					/>
-					{isSqlSrc && !hidden && (
-						<ResourceDatalist
-							id={id}
-							resources={resourceFiles}
-						/>
-					)}
-				</div>
-				{!hidden && (
-					<SqlSrcDropDownMenu
-						path={path}
-						setPath={setPath}
-						prefix={prefix}
-						element={element}
-						srcType={srcType}
-						isValueInDatalist={isValueInDatalist}
-					/>
-				)}
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={srcType}
+			resourceFiles={resourceFiles}
+			onValueChange={handleValueChange}
+		>
+			{({ path, setPath, isValueInDatalist }) => (
+				<SqlSrcDropDownMenu
+					path={path}
+					setPath={setPath}
+					prefix={prefix}
+					element={element}
+					srcType={srcType}
+					isValueInDatalist={isValueInDatalist}
+				/>
+			)}
+		</ResourceText>
 	);
 }

--- a/tauri/src/app/form/section/TemplateText.tsx
+++ b/tauri/src/app/form/section/TemplateText.tsx
@@ -1,13 +1,7 @@
-import { useState } from "react";
-import {
-	ControllTextBox,
-	InputLabel,
-	ResourceDatalist,
-} from "../../../components/element/Input";
 import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
-import TemplateDropDownMenu from "./TemplateDropDownMenu";
 import type { Prop } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import ResourceText from "./ResourceText";
+import TemplateDropDownMenu from "./TemplateDropDownMenu";
 
 export default function TemplateText({
 	prefix,
@@ -15,54 +9,26 @@ export default function TemplateText({
 	hidden,
 	srcType,
 }: Prop) {
-	const [path, setPath] = useState(element.value);
 	const settings = useResourcesSettings();
-	const resourceFiles = settings.templateFiles;
-	const isValueInDatalist = resourceFiles.includes(path);
-	const id = getId(prefix, element.name);
-	const fieldName = getName(prefix, element.name);
-
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-		setPath(ev.target.value);
-	};
 
 	return (
-		<div>
-			<InputLabel
-				text={fieldName}
-				id={id}
-				required={element.attribute.required}
-				hidden={hidden}
-			/>
-			<div className="flex">
-				<div className="flex-1">
-					<ControllTextBox
-						name={fieldName}
-						id={id}
-						list={`${id}_list`}
-						hidden={hidden}
-						required={element.attribute.required}
-						value={path}
-						handleChange={handleChange}
-					/>
-					{!hidden && (
-						<ResourceDatalist
-							id={id}
-							resources={resourceFiles}
-						/>
-					)}
-				</div>
-				{!hidden && (
-					<TemplateDropDownMenu
-						path={path}
-						setPath={setPath}
-						prefix={prefix}
-						element={element}
-						srcType={srcType}
-						isValueInDatalist={isValueInDatalist}
-					/>
-				)}
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={srcType}
+			resourceFiles={settings.templateFiles}
+		>
+			{({ path, setPath, isValueInDatalist }) => (
+				<TemplateDropDownMenu
+					path={path}
+					setPath={setPath}
+					prefix={prefix}
+					element={element}
+					srcType={srcType}
+					isValueInDatalist={isValueInDatalist}
+				/>
+			)}
+		</ResourceText>
 	);
 }

--- a/tauri/src/app/form/section/XlsxSchemaText.tsx
+++ b/tauri/src/app/form/section/XlsxSchemaText.tsx
@@ -1,18 +1,12 @@
-import { useState } from "react";
-import {
-	ControllTextBox,
-	InputLabel,
-	ResourceDatalist,
-} from "../../../components/element/Input";
 import {
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
 } from "../../../context/DatasetSrcInfoProvider";
 import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../../../model/CommandParam";
-import XlsxSchemaDropDownMenu from "./XlsxSchemaDropDownMenu";
 import type { Prop } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import ResourceText from "./ResourceText";
+import XlsxSchemaDropDownMenu from "./XlsxSchemaDropDownMenu";
 
 export default function XlsxSchemaText({
 	prefix,
@@ -20,60 +14,35 @@ export default function XlsxSchemaText({
 	hidden,
 	srcType,
 }: Prop) {
-	const [path, setPath] = useState(element.value);
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
 	const settings = useResourcesSettings();
-	const resourceFiles = settings.xlsxSchemas;
-	const isValueInDatalist = resourceFiles.includes(path);
-	const id = getId(prefix, element.name);
-	const fieldName = getName(prefix, element.name);
 
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = ev.target.value;
-		setPath(newValue);
+	const handleValueChange = (newValue: string) => {
 		if (datasetSrcInfo) {
 			setDatasetSrcInfo({ ...datasetSrcInfo, xlsxSchema: newValue } as DatasetSrcInfo);
 		}
 	};
 
 	return (
-		<div>
-			<InputLabel
-				text={fieldName}
-				id={id}
-				required={element.attribute.required}
-				hidden={hidden}
-			/>
-			<div className="flex">
-				<div className="flex-1">
-					<ControllTextBox
-						name={fieldName}
-						id={id}
-						list={`${id}_list`}
-						hidden={hidden}
-						required={element.attribute.required}
-						value={path}
-						handleChange={handleChange}
-					/>
-					{!hidden && (
-						<ResourceDatalist
-							id={id}
-							resources={resourceFiles}
-						/>
-					)}
-				</div>
-				{!hidden && (
-					<XlsxSchemaDropDownMenu
-						path={path}
-						setPath={setPath}
-						prefix={prefix}
-						element={element}
-						srcType={srcType}
-						isValueInDatalist={isValueInDatalist}
-					/>
-				)}
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={srcType}
+			resourceFiles={settings.xlsxSchemas}
+			onValueChange={handleValueChange}
+		>
+			{({ path, setPath, isValueInDatalist }) => (
+				<XlsxSchemaDropDownMenu
+					path={path}
+					setPath={setPath}
+					prefix={prefix}
+					element={element}
+					srcType={srcType}
+					isValueInDatalist={isValueInDatalist}
+				/>
+			)}
+		</ResourceText>
 	);
 }


### PR DESCRIPTION
## Summary
Extracted common resource text input logic into a new `ResourceText` component to reduce code duplication across three similar form field components.

## Key Changes
- **Created new `ResourceText` component** (`ResourceText.tsx`) that encapsulates shared functionality:
  - Text input with datalist support for resource files
  - State management for path value
  - Conditional rendering of datalist based on resource availability
  - Render prop pattern for dropdown menu customization

- **Refactored three components** to use the new `ResourceText` wrapper:
  - `XlsxSchemaText.tsx`: Removed 31 lines of duplicated UI logic
  - `SqlSrcText.tsx`: Removed 30 lines of duplicated UI logic
  - `TemplateText.tsx`: Removed 34 lines of duplicated UI logic

## Implementation Details
- The `ResourceText` component accepts a `children` render prop that receives `{ path, setPath, isValueInDatalist }` for dropdown menu integration
- Optional `onValueChange` callback allows parent components to react to value changes (used for dataset source info updates)
- Datalist is only rendered when `resourceFiles` array is non-empty, improving conditional rendering logic
- Maintains all original functionality while centralizing common patterns

https://claude.ai/code/session_019vZnAuJKP6si53fSXpqikq