### PR TITLE
Resolve file paths in command parameters and display default paths in UI

### DIFF
--- a/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
+++ b/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
@@ -42,10 +42,10 @@ public record CommandParameters(CommandType type, String[] args) {
         boolean changed = false;
         final List<String> newArgs = new ArrayList<>();
         for (final String key : params.keySet()) {
-            if (!params.hasValue(key)) {
+            final Option.Arg arg = params.getArg(key);
+            if (arg == null || arg.value().isEmpty()) {
                 continue;
             }
-            final Option.Arg arg = params.getArg(key);
             final String value = arg.value();
             final String resolved = resolver.apply(arg.attribute().defaultPath(), value);
             if (!resolved.equals(value)) {

--- a/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
+++ b/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
@@ -6,7 +6,10 @@ import yo.dbunitcli.common.Parameter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 public record CommandParameters(CommandType type, String[] args) {
 
@@ -32,6 +35,25 @@ public record CommandParameters(CommandType type, String[] args) {
 
     public Option.Parameters toOptionParameters() {
         return this.type().getCommand().parseOption(this.args).toParameters();
+    }
+
+    public CommandParameters resolveFilePaths(final BiFunction<Option.BaseDir, String, String> resolver) {
+        final Option.Parameters params = this.toOptionParameters();
+        boolean changed = false;
+        final List<String> newArgs = new ArrayList<>();
+        for (final String key : params.keySet()) {
+            if (!params.hasValue(key)) {
+                continue;
+            }
+            final Option.Arg arg = params.getArg(key);
+            final String value = arg.value();
+            final String resolved = resolver.apply(arg.attribute().defaultPath(), value);
+            if (!resolved.equals(value)) {
+                changed = true;
+            }
+            newArgs.add(key + "=" + resolved);
+        }
+        return changed ? new CommandParameters(this.type, newArgs.toArray(new String[0])) : this;
     }
 
     public CommandParameters shrink() {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -221,7 +221,7 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
                     continue;
                 }
                 final String key = Strings.isNotEmpty(prefix) ? "-" + prefix + "." + name : "-" + name;
-                resolved.put(key, new File(WorkspaceController.getFieldBaseDir(defaultPath, null), value).getAbsolutePath());
+                resolved.put(key, new File(Workspace.resolveBaseDir(defaultPath, null), value).getAbsolutePath());
             }
         }
         for (final Map.Entry<String, Object> entry : serialized.entrySet()) {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -156,8 +156,8 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
             LOGGER.info(System.getProperty(FileResources.PROPERTY_WORKSPACE));
             final CommandParameters parameters = new CommandParameters(this.getCommandType(), body.getInput())
                     .resolveFilePaths((baseDir, value) ->
-                            SIDECAR_RESOLVE_BASEDIRS.contains(baseDir) && !value.isEmpty() && !new File(value).isAbsolute()
-                                    ? new File(Workspace.resolveBaseDir(baseDir.name(), null), value).getAbsolutePath()
+                            SIDECAR_RESOLVE_BASEDIRS.contains(baseDir) && !new File(value).isAbsolute()
+                                    ? new File(Workspace.resolveBaseDir(baseDir, null), value).getAbsolutePath()
                                     : value);
             try {
                 parameters.exec(body.getName());

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -221,7 +221,7 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
                     continue;
                 }
                 final String key = Strings.isNotEmpty(prefix) ? "-" + prefix + "." + name : "-" + name;
-                resolved.put(key, new File(baseDirFor(defaultPath), value).getAbsolutePath());
+                resolved.put(key, new File(WorkspaceController.getFieldBaseDir(defaultPath, null), value).getAbsolutePath());
             }
         }
         for (final Map.Entry<String, Object> entry : serialized.entrySet()) {
@@ -229,17 +229,6 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
                 applyResolvedPaths((Map<String, Object>) sub, resolved);
             }
         }
-    }
-
-    private static File baseDirFor(final String defaultPath) {
-        return switch (defaultPath) {
-            case "SETTING" -> FileResources.settingDir();
-            case "TEMPLATE" -> FileResources.templateFileDir();
-            case "JDBC" -> FileResources.jdbcPropDir();
-            case "XLSX_SCHEMA" -> FileResources.xlsxSchemaDir();
-            case "PARAMETERIZE_TEMPLATE" -> FileResources.parameterizeTemplateDir();
-            default -> FileResources.baseDir();
-        };
     }
 
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -7,9 +7,9 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.serde.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import yo.dbunitcli.Strings;
 import yo.dbunitcli.application.Command;
 import yo.dbunitcli.application.CommandParameters;
+import yo.dbunitcli.application.Option;
 import yo.dbunitcli.application.command.Type;
 import yo.dbunitcli.resource.FileResources;
 import yo.dbunitcli.sidecar.domain.project.Workspace;
@@ -18,17 +18,17 @@ import yo.dbunitcli.sidecar.dto.CommandRequestDto;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class AbstractCommandController implements ControllerExceptionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCommandController.class);
 
-    private static final Set<String> SIDECAR_RESOLVE_PATHS = Set.of(
-            "SETTING", "TEMPLATE", "JDBC", "XLSX_SCHEMA", "PARAMETERIZE_TEMPLATE");
+    private static final EnumSet<Option.BaseDir> SIDECAR_RESOLVE_BASEDIRS = EnumSet.of(
+            Option.BaseDir.SETTING, Option.BaseDir.TEMPLATE, Option.BaseDir.JDBC,
+            Option.BaseDir.XLSX_SCHEMA, Option.BaseDir.PARAMETERIZE_TEMPLATE);
 
     private final Workspace workspace;
 
@@ -154,8 +154,11 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
     public String exec(@Body final CommandRequestDto body) {
         try {
             LOGGER.info(System.getProperty(FileResources.PROPERTY_WORKSPACE));
-            final Map<String, String> resolvedInput = this.resolveDefaultPaths(body.getInput());
-            final CommandParameters parameters = new CommandParameters(this.getCommandType(), resolvedInput);
+            final CommandParameters parameters = new CommandParameters(this.getCommandType(), body.getInput())
+                    .resolveFilePaths((baseDir, value) ->
+                            SIDECAR_RESOLVE_BASEDIRS.contains(baseDir) && !value.isEmpty() && !new File(value).isAbsolute()
+                                    ? new File(Workspace.resolveBaseDir(baseDir.name(), null), value).getAbsolutePath()
+                                    : value);
             try {
                 parameters.exec(body.getName());
             } catch (final Command.CommandFailException th) {
@@ -195,40 +198,6 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
 
     protected String toJson(final List<String> object) throws IOException {
         return ObjectMapper.getDefault().writeValueAsString(object);
-    }
-
-    private Map<String, String> resolveDefaultPaths(final Map<String, String> input) {
-        final Map<String, Object> serialized = new CommandParameters(this.getCommandType(), input).serialize();
-        final Map<String, String> resolved = new LinkedHashMap<>(input);
-        applyResolvedPaths(serialized, resolved);
-        return resolved;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void applyResolvedPaths(final Map<String, Object> serialized, final Map<String, String> resolved) {
-        final String prefix = (String) serialized.get("prefix");
-        final List<Map<String, Object>> elements = (List<Map<String, Object>>) serialized.get("elements");
-        if (elements != null) {
-            for (final Map<String, Object> element : elements) {
-                final String name = (String) element.get("name");
-                final String value = (String) element.get("value");
-                final Map<String, Object> attribute = (Map<String, Object>) element.get("attribute");
-                if (attribute == null || value == null || value.isEmpty()) {
-                    continue;
-                }
-                final String defaultPath = String.valueOf(attribute.get("defaultPath"));
-                if (!SIDECAR_RESOLVE_PATHS.contains(defaultPath) || new File(value).isAbsolute()) {
-                    continue;
-                }
-                final String key = Strings.isNotEmpty(prefix) ? "-" + prefix + "." + name : "-" + name;
-                resolved.put(key, new File(Workspace.resolveBaseDir(defaultPath, null), value).getAbsolutePath());
-            }
-        }
-        for (final Map.Entry<String, Object> entry : serialized.entrySet()) {
-            if (!Set.of("prefix", "elements").contains(entry.getKey()) && entry.getValue() instanceof Map<?, ?> sub) {
-                applyResolvedPaths((Map<String, Object>) sub, resolved);
-            }
-        }
     }
 
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -7,6 +7,7 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.serde.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import yo.dbunitcli.Strings;
 import yo.dbunitcli.application.Command;
 import yo.dbunitcli.application.CommandParameters;
 import yo.dbunitcli.application.command.Type;
@@ -14,14 +15,20 @@ import yo.dbunitcli.resource.FileResources;
 import yo.dbunitcli.sidecar.domain.project.Workspace;
 import yo.dbunitcli.sidecar.dto.CommandRequestDto;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class AbstractCommandController implements ControllerExceptionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCommandController.class);
+
+    private static final Set<String> SIDECAR_RESOLVE_PATHS = Set.of(
+            "SETTING", "TEMPLATE", "JDBC", "XLSX_SCHEMA", "PARAMETERIZE_TEMPLATE");
 
     private final Workspace workspace;
 
@@ -147,7 +154,8 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
     public String exec(@Body final CommandRequestDto body) {
         try {
             LOGGER.info(System.getProperty(FileResources.PROPERTY_WORKSPACE));
-            final CommandParameters parameters = new CommandParameters(this.getCommandType(), body.getInput());
+            final Map<String, String> resolvedInput = this.resolveDefaultPaths(body.getInput());
+            final CommandParameters parameters = new CommandParameters(this.getCommandType(), resolvedInput);
             try {
                 parameters.exec(body.getName());
             } catch (final Command.CommandFailException th) {
@@ -187,6 +195,51 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
 
     protected String toJson(final List<String> object) throws IOException {
         return ObjectMapper.getDefault().writeValueAsString(object);
+    }
+
+    private Map<String, String> resolveDefaultPaths(final Map<String, String> input) {
+        final Map<String, Object> serialized = new CommandParameters(this.getCommandType(), input).serialize();
+        final Map<String, String> resolved = new LinkedHashMap<>(input);
+        applyResolvedPaths(serialized, resolved);
+        return resolved;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyResolvedPaths(final Map<String, Object> serialized, final Map<String, String> resolved) {
+        final String prefix = (String) serialized.get("prefix");
+        final List<Map<String, Object>> elements = (List<Map<String, Object>>) serialized.get("elements");
+        if (elements != null) {
+            for (final Map<String, Object> element : elements) {
+                final String name = (String) element.get("name");
+                final String value = (String) element.get("value");
+                final Map<String, Object> attribute = (Map<String, Object>) element.get("attribute");
+                if (attribute == null || value == null || value.isEmpty()) {
+                    continue;
+                }
+                final String defaultPath = String.valueOf(attribute.get("defaultPath"));
+                if (!SIDECAR_RESOLVE_PATHS.contains(defaultPath) || new File(value).isAbsolute()) {
+                    continue;
+                }
+                final String key = Strings.isNotEmpty(prefix) ? "-" + prefix + "." + name : "-" + name;
+                resolved.put(key, new File(baseDirFor(defaultPath), value).getAbsolutePath());
+            }
+        }
+        for (final Map.Entry<String, Object> entry : serialized.entrySet()) {
+            if (!Set.of("prefix", "elements").contains(entry.getKey()) && entry.getValue() instanceof Map<?, ?> sub) {
+                applyResolvedPaths((Map<String, Object>) sub, resolved);
+            }
+        }
+    }
+
+    private static File baseDirFor(final String defaultPath) {
+        return switch (defaultPath) {
+            case "SETTING" -> FileResources.settingDir();
+            case "TEMPLATE" -> FileResources.templateFileDir();
+            case "JDBC" -> FileResources.jdbcPropDir();
+            case "XLSX_SCHEMA" -> FileResources.xlsxSchemaDir();
+            case "PARAMETERIZE_TEMPLATE" -> FileResources.parameterizeTemplateDir();
+            default -> FileResources.baseDir();
+        };
     }
 
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
@@ -58,7 +58,7 @@ public class WorkspaceController implements ControllerExceptionHandler {
                 return absolute.getAbsolutePath();
             }
             for (final File root : new File[]{
-                    getFieldBaseDir(request.getDefaultPath(), request.getSrcType()),
+                    Workspace.resolveBaseDir(request.getDefaultPath(), request.getSrcType()),
                     FileResources.baseDir(),
                     new File(System.getProperty("user.dir"))
             }) {
@@ -72,10 +72,6 @@ public class WorkspaceController implements ControllerExceptionHandler {
             LOGGER.error("cause:", th);
             throw new ApplicationException(th);
         }
-    }
-
-    private static File getFieldBaseDir(final String defaultPath, final String srcType) {
-        return Workspace.resolveBaseDir(defaultPath, srcType);
     }
 
     private String currentResources() throws IOException {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
@@ -74,7 +74,7 @@ public class WorkspaceController implements ControllerExceptionHandler {
         }
     }
 
-    private static File getFieldBaseDir(final String defaultPath, final String srcType) {
+    static File getFieldBaseDir(final String defaultPath, final String srcType) {
         return switch (defaultPath) {
             case "DATASET" -> srcType != null && !srcType.isEmpty()
                     ? new File(FileResources.datasetDir(), srcType)

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/WorkspaceController.java
@@ -74,19 +74,8 @@ public class WorkspaceController implements ControllerExceptionHandler {
         }
     }
 
-    static File getFieldBaseDir(final String defaultPath, final String srcType) {
-        return switch (defaultPath) {
-            case "DATASET" -> srcType != null && !srcType.isEmpty()
-                    ? new File(FileResources.datasetDir(), srcType)
-                    : FileResources.datasetDir();
-            case "RESULT" -> FileResources.resultDir();
-            case "SETTING" -> FileResources.settingDir();
-            case "TEMPLATE" -> FileResources.templateFileDir();
-            case "PARAMETERIZE_TEMPLATE" -> FileResources.parameterizeTemplateDir();
-            case "JDBC" -> FileResources.jdbcPropDir();
-            case "XLSX_SCHEMA" -> FileResources.xlsxSchemaDir();
-            default -> FileResources.baseDir();
-        };
+    private static File getFieldBaseDir(final String defaultPath, final String srcType) {
+        return Workspace.resolveBaseDir(defaultPath, srcType);
     }
 
     private String currentResources() throws IOException {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
@@ -7,8 +7,10 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.serde.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import yo.dbunitcli.Strings;
 import yo.dbunitcli.dataset.ComparableDataSetParam;
 import yo.dbunitcli.dataset.producer.ComparableXlsxDataSetProducer;
+import yo.dbunitcli.resource.FileResources;
 import yo.dbunitcli.sidecar.domain.project.ResourceFile;
 import yo.dbunitcli.sidecar.domain.project.Workspace;
 import yo.dbunitcli.sidecar.dto.JsonXlsxSchemaRequestDto;
@@ -16,7 +18,6 @@ import yo.dbunitcli.sidecar.dto.XlsxSheetsRequestDto;
 
 import java.io.File;
 import java.util.Arrays;
-import yo.dbunitcli.resource.FileResources;
 
 @Controller("xlsx-schema")
 public class XlsxSchemaController extends AbstractResourceFileController<JsonXlsxSchemaRequestDto> {
@@ -34,9 +35,9 @@ public class XlsxSchemaController extends AbstractResourceFileController<JsonXls
     @Post(uri = "sheets", produces = MediaType.APPLICATION_JSON)
     public String sheets(@Body final XlsxSheetsRequestDto request) {
         try {
-            final File src = request.getSrc() != null && !new File(request.getSrc()).isAbsolute()
+            final File src = Strings.isNotEmpty(request.getSrc())
                     ? FileResources.searchDatasetBase(request.getSrc())
-                    : new File(request.getSrc());
+                    : new File(".");
             final ComparableDataSetParam param = ComparableDataSetParam.builder()
                     .setSrc(src)
                     .setRegTableInclude(request.getRegTableInclude())

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/XlsxSchemaController.java
@@ -16,6 +16,7 @@ import yo.dbunitcli.sidecar.dto.XlsxSheetsRequestDto;
 
 import java.io.File;
 import java.util.Arrays;
+import yo.dbunitcli.resource.FileResources;
 
 @Controller("xlsx-schema")
 public class XlsxSchemaController extends AbstractResourceFileController<JsonXlsxSchemaRequestDto> {
@@ -33,8 +34,11 @@ public class XlsxSchemaController extends AbstractResourceFileController<JsonXls
     @Post(uri = "sheets", produces = MediaType.APPLICATION_JSON)
     public String sheets(@Body final XlsxSheetsRequestDto request) {
         try {
+            final File src = request.getSrc() != null && !new File(request.getSrc()).isAbsolute()
+                    ? FileResources.searchDatasetBase(request.getSrc())
+                    : new File(request.getSrc());
             final ComparableDataSetParam param = ComparableDataSetParam.builder()
-                    .setSrc(new File(request.getSrc()))
+                    .setSrc(src)
                     .setRegTableInclude(request.getRegTableInclude())
                     .setRegTableExclude(request.getRegTableExclude())
                     .setRecursive(request.isRecursive())

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -31,7 +31,7 @@ public class Workspace {
 
     public static File resolveBaseDir(final String defaultPath, final String srcType) {
         return switch (defaultPath) {
-            case "DATASET" -> srcType != null && !srcType.isEmpty()
+            case "DATASET" -> Strings.isNotEmpty(srcType)
                     ? new File(FileResources.datasetDir(), srcType)
                     : FileResources.datasetDir();
             case "RESULT" -> FileResources.resultDir();

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -29,6 +29,21 @@ import java.util.stream.Stream;
 public class Workspace {
     private static final Logger LOGGER = LoggerFactory.getLogger(Workspace.class);
 
+    public static File resolveBaseDir(final String defaultPath, final String srcType) {
+        return switch (defaultPath) {
+            case "DATASET" -> srcType != null && !srcType.isEmpty()
+                    ? new File(FileResources.datasetDir(), srcType)
+                    : FileResources.datasetDir();
+            case "RESULT" -> FileResources.resultDir();
+            case "SETTING" -> FileResources.settingDir();
+            case "TEMPLATE" -> FileResources.templateFileDir();
+            case "PARAMETERIZE_TEMPLATE" -> FileResources.parameterizeTemplateDir();
+            case "JDBC" -> FileResources.jdbcPropDir();
+            case "XLSX_SCHEMA" -> FileResources.xlsxSchemaDir();
+            default -> FileResources.baseDir();
+        };
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -29,6 +29,10 @@ import java.util.stream.Stream;
 public class Workspace {
     private static final Logger LOGGER = LoggerFactory.getLogger(Workspace.class);
 
+    public static File resolveBaseDir(final Option.BaseDir baseDir, final String srcType) {
+        return resolveBaseDir(baseDir.name(), srcType);
+    }
+
     public static File resolveBaseDir(final String defaultPath, final String srcType) {
         return switch (defaultPath) {
             case "DATASET" -> Strings.isNotEmpty(srcType)

--- a/tauri/src/app/form/section/Chooser.tsx
+++ b/tauri/src/app/form/section/Chooser.tsx
@@ -135,7 +135,7 @@ export function OpenInOS(prop: FileProp) {
 	return <OpenButton handleClick={handleOpen} />;
 }
 
-function getPath(
+export function getPath(
 	context: WorkspaceContext,
 	defaultPath: DefaultPath,
 	srcType: string | undefined,

--- a/tauri/src/app/form/section/FileText.tsx
+++ b/tauri/src/app/form/section/FileText.tsx
@@ -4,7 +4,9 @@ import {
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
 } from "../../../context/DatasetSrcInfoProvider";
+import { useWorkspaceContext } from "../../../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../../../model/CommandParam";
+import { getPath } from "./Chooser";
 import FileDropDownMenu from "./FileDropDownMenu";
 import type { Prop } from "./FormElementProp";
 import { getId, getName } from "./FormElementProp";
@@ -13,6 +15,8 @@ export default function FileText({ prefix, element, hidden, srcType }: Prop) {
 	const [path, setPath] = useState(element.value);
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
+	const context = useWorkspaceContext();
+	const defaultPath = getPath(context, element.attribute.defaultPath, srcType);
 	const id = getId(prefix, element.name);
 	const fieldName = getName(prefix, element.name);
 
@@ -45,6 +49,9 @@ export default function FileText({ prefix, element, hidden, srcType }: Prop) {
 						value={path}
 						handleChange={handleChange}
 					/>
+					{!hidden && defaultPath && (
+						<p className="text-xs text-gray-400 truncate">{defaultPath}</p>
+					)}
 				</div>
 				{!hidden && (
 					<FileDropDownMenu

--- a/tauri/src/app/form/section/ResourceText.tsx
+++ b/tauri/src/app/form/section/ResourceText.tsx
@@ -5,8 +5,10 @@ import {
 	InputLabel,
 	ResourceDatalist,
 } from "../../../components/element/Input";
+import { useWorkspaceContext } from "../../../context/WorkspaceResourcesProvider";
 import type { Prop } from "./FormElementProp";
 import { getId, getName } from "./FormElementProp";
+import { getPath } from "./Chooser";
 
 interface Props extends Prop {
 	resourceFiles: string[];
@@ -22,7 +24,7 @@ export default function ResourceText({
 	prefix,
 	element,
 	hidden,
-	srcType: _srcType,
+	srcType,
 	resourceFiles,
 	onValueChange,
 	children,
@@ -30,6 +32,8 @@ export default function ResourceText({
 	const [path, setPath] = useState(element.value);
 	const hasResources = resourceFiles.length > 0;
 	const isValueInDatalist = resourceFiles.includes(path);
+	const context = useWorkspaceContext();
+	const defaultPath = getPath(context, element.attribute.defaultPath, srcType);
 	const id = getId(prefix, element.name);
 	const fieldName = getName(prefix, element.name);
 
@@ -63,6 +67,9 @@ export default function ResourceText({
 							id={id}
 							resources={resourceFiles}
 						/>
+					)}
+					{!hidden && defaultPath && (
+						<p className="text-xs text-gray-400 truncate">{defaultPath}</p>
 					)}
 				</div>
 				{!hidden && children({ path, setPath, isValueInDatalist })}


### PR DESCRIPTION
## Summary
This PR refactors file path resolution logic to be more centralized and adds UI enhancements to display default base directories for file input fields. The changes improve code reusability by extracting path resolution into shared utility methods and enhance user experience by showing where files will be resolved from.

## Key Changes

- **Centralized path resolution logic**: Extracted `getFieldBaseDir()` from `WorkspaceController` into a new static method `Workspace.resolveBaseDir()` that can be reused across the application
- **Command parameter path resolution**: Added `CommandParameters.resolveFilePaths()` method that accepts a resolver function to transform file paths before command execution
- **Automatic path resolution in command execution**: Modified `AbstractCommandController.exec()` to automatically resolve relative file paths for specific base directories (SETTING, TEMPLATE, JDBC, XLSX_SCHEMA, PARAMETERIZE_TEMPLATE) to their absolute paths
- **UI enhancements**: Updated `ResourceText` and `FileText` components to display the resolved default base directory path below input fields, helping users understand where files will be resolved from
- **Exported utility function**: Made `getPath()` function in `Chooser.tsx` public for reuse in other components

## Implementation Details

- The `resolveFilePaths()` method uses a `BiFunction` to allow flexible path resolution strategies
- Only relative paths are resolved; absolute paths are left unchanged
- The UI displays default paths in small gray text to avoid cluttering the interface
- Path resolution is applied selectively only to specific base directory types that are managed by the sidecar workspace

https://claude.ai/code/session_01VNwJfzSZKJLh8NdXFBo7C1