### PR TITLE
Start Maven proxy before JDK download and switch to Oracle JDK

### DIFF
--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -31,10 +31,10 @@ if [ -z "$CURRENT_JAVA_MAJOR" ] || [ "$CURRENT_JAVA_MAJOR" -lt "$REQUIRED_JAVA_V
     JDK25_READY=true
   else
     echo "Installing JDK 25..."
-    ADOPTIUM_URL="https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jdk/hotspot/normal/eclipse"
+    ORACLE_URL="https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.tar.gz"
     TMP_JDK=$(mktemp /tmp/jdk25-XXXXXX.tar.gz)
     rm -rf "$JDK25_DIR" && mkdir -p "$JDK25_DIR"
-    if curl -sL --proxy http://127.0.0.1:3128 "$ADOPTIUM_URL" -o "$TMP_JDK" && tar -xz -C "$JDK25_DIR" --strip-components=1 -f "$TMP_JDK"; then
+    if curl -sL --proxy http://127.0.0.1:3128 "$ORACLE_URL" -o "$TMP_JDK" && tar -xz -C "$JDK25_DIR" --strip-components=1 -f "$TMP_JDK"; then
       echo "JDK 25 installed at $JDK25_DIR"
       JDK25_READY=true
     else

--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -4,6 +4,19 @@ if ! echo "${JAVA_TOOL_OPTIONS:-}" | grep -q "jwt_"; then
   exit 0
 fi
 
+# ローカルプロキシを先に起動（JDK ダウンロードで使用するため）
+nohup python3 /home/user/dbunitcli/.claude/maven-proxy.py >> /tmp/maven-proxy.log 2>&1 &
+PROXY_PID=$!
+echo "Maven proxy setup complete (PID: $PROXY_PID)"
+
+# ポートが利用可能になるまで待機（最大5秒）
+for i in $(seq 1 10); do
+  if nc -z 127.0.0.1 3128 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+
 # JDK 25 のインストール（現在のバージョンが 25 未満の場合）
 REQUIRED_JAVA_VERSION=25
 JDK25_DIR="$HOME/jdk-25"
@@ -21,7 +34,7 @@ if [ -z "$CURRENT_JAVA_MAJOR" ] || [ "$CURRENT_JAVA_MAJOR" -lt "$REQUIRED_JAVA_V
     ADOPTIUM_URL="https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jdk/hotspot/normal/eclipse"
     TMP_JDK=$(mktemp /tmp/jdk25-XXXXXX.tar.gz)
     rm -rf "$JDK25_DIR" && mkdir -p "$JDK25_DIR"
-    if curl -sL "$ADOPTIUM_URL" -o "$TMP_JDK" && tar -xz -C "$JDK25_DIR" --strip-components=1 -f "$TMP_JDK"; then
+    if curl -sL --proxy http://127.0.0.1:3128 "$ADOPTIUM_URL" -o "$TMP_JDK" && tar -xz -C "$JDK25_DIR" --strip-components=1 -f "$TMP_JDK"; then
       echo "JDK 25 installed at $JDK25_DIR"
       JDK25_READY=true
     else
@@ -48,9 +61,6 @@ EOF
 else
   echo "Java $CURRENT_JAVA_MAJOR >= $REQUIRED_JAVA_VERSION, no installation needed"
 fi
-
-nohup python3 /home/user/dbunitcli/.claude/maven-proxy.py >> /tmp/maven-proxy.log 2>&1 &
-echo "Maven proxy setup complete (PID: $!)"
 
 # Create ~/.mavenrc to override JAVA_TOOL_OPTIONS proxy settings
 # MAVEN_OPTS flags are appended to JVM command line, overriding JAVA_TOOL_OPTIONS


### PR DESCRIPTION
## Summary
Refactored the JDK installation process to start the local Maven proxy server before attempting to download JDK, and switched from Adoptium to Oracle's official JDK distribution.

## Key Changes
- **Moved proxy startup earlier**: The Maven proxy server is now started at the beginning of the script before JDK installation, ensuring it's available when needed for downloads
- **Added proxy readiness check**: Implemented a polling mechanism (up to 5 seconds) to wait for the proxy port (3128) to become available before proceeding with JDK download
- **Switched JDK source**: Changed from Adoptium's API endpoint to Oracle's official JDK 25 download URL
- **Added proxy configuration to curl**: Updated the JDK download curl command to use the local proxy (`--proxy http://127.0.0.1:3128`)

## Implementation Details
- The proxy startup is now performed unconditionally at the script start (after the initial JWT check)
- Uses `nc` (netcat) to verify port availability with a 0.5-second retry interval
- The proxy process runs in the background with output redirected to `/tmp/maven-proxy.log`
- Maintains the same error handling and logging patterns as the original implementation

https://claude.ai/code/session_01TVzDhqDo3WDXYbAvjELvwG