### PR TITLE
Add Node.js LTS installation to Maven proxy setup script

### DIFF
--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -84,3 +84,55 @@ cat > "$HOME/.m2/settings.xml" << 'EOF'
  </proxies>
 </settings>
 EOF
+
+# Node.js のインストール（バージョンが 20 未満の場合）
+REQUIRED_NODE_VERSION=20
+NODE_LATEST_DIR="$HOME/node-latest"
+NODE_READY=false
+
+if command -v node &>/dev/null; then
+  CURRENT_NODE_MAJOR=$(node --version 2>&1 | grep -oP '(?<=v)[0-9]+' | head -1)
+else
+  CURRENT_NODE_MAJOR=0
+fi
+echo "Current Node.js major version: ${CURRENT_NODE_MAJOR:-unknown}"
+
+if [ -z "$CURRENT_NODE_MAJOR" ] || [ "$CURRENT_NODE_MAJOR" -lt "$REQUIRED_NODE_VERSION" ]; then
+  if [ -f "$NODE_LATEST_DIR/bin/node" ]; then
+    echo "Node.js already installed at $NODE_LATEST_DIR"
+    NODE_READY=true
+  else
+    echo "Installing latest Node.js LTS..."
+    NODE_VERSION=$(curl -sL --proxy http://127.0.0.1:3128 "https://nodejs.org/dist/latest-lts/SHASUMS256.txt" \
+      | grep -oP 'node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-x64)' | head -1)
+    if [ -z "$NODE_VERSION" ]; then
+      NODE_VERSION="22.14.0"  # フォールバック
+    fi
+    NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz"
+    TMP_NODE=$(mktemp /tmp/node-XXXXXX.tar.gz)
+    rm -rf "$NODE_LATEST_DIR" && mkdir -p "$NODE_LATEST_DIR"
+    if curl -sL --proxy http://127.0.0.1:3128 "$NODE_URL" -o "$TMP_NODE" \
+       && tar -xz -C "$NODE_LATEST_DIR" --strip-components=1 -f "$TMP_NODE"; then
+      echo "Node.js v${NODE_VERSION} installed at $NODE_LATEST_DIR"
+      NODE_READY=true
+    else
+      echo "Failed to install Node.js"
+      rm -rf "$NODE_LATEST_DIR"
+    fi
+    rm -f "$TMP_NODE"
+  fi
+
+  if [ "$NODE_READY" = true ]; then
+    if ! grep -q "node-latest" "$HOME/.bashrc" 2>/dev/null; then
+      cat >> "$HOME/.bashrc" << EOF
+
+# Node.js latest LTS (installed by Claude setup)
+export PATH="$NODE_LATEST_DIR/bin:\$PATH"
+EOF
+    fi
+    export PATH="$NODE_LATEST_DIR/bin:$PATH"
+    echo "Node.js $(node --version 2>/dev/null) is now active"
+  fi
+else
+  echo "Node.js $CURRENT_NODE_MAJOR >= $REQUIRED_NODE_VERSION, no installation needed"
+fi

--- a/tauri/src/tests/context/SelectParameterProvider.test.tsx
+++ b/tauri/src/tests/context/SelectParameterProvider.test.tsx
@@ -38,6 +38,7 @@ const mockConvertParams: ConvertParams = {
 		srcType: () => "table",
 		srcElements: () => createCommandParams(),
 		srcTypeSettings: () => createCommandParams(),
+		jdbcElements: () => createCommandParams(),
 		settingElements: () => createCommandParams(),
 	},
 	convertResult: {
@@ -63,6 +64,7 @@ const mockGenerateParams: GenerateParams = {
 		srcType: () => "csv",
 		srcElements: () => createCommandParams(),
 		srcTypeSettings: () => createCommandParams(),
+		jdbcElements: () => createCommandParams(),
 		settingElements: () => createCommandParams(),
 	},
 	templateOption: {

--- a/tauri/src/tests/model/SelectParameter.test.ts
+++ b/tauri/src/tests/model/SelectParameter.test.ts
@@ -1,3 +1,4 @@
+import type { CommandParams } from "../../model/CommandParam";
 import type {
 	CompareParams,
 	ConvertParams,
@@ -7,6 +8,12 @@ import type {
 } from "../../model/SelectParameter";
 import { SelectParameter } from "../../model/SelectParameter";
 
+const createCommandParams = (): CommandParams => ({
+	name: "",
+	prefix: "",
+	elements: [],
+});
+
 describe("SelectParameterクラス", () => {
 	const mockConvertParams: ConvertParams = {
 		srcData: {
@@ -14,21 +21,10 @@ describe("SelectParameterクラス", () => {
 			prefix: "convert",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		convertResult: {
 			name: "convertResult",
@@ -49,42 +45,20 @@ describe("SelectParameterクラス", () => {
 			prefix: "compare",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		oldData: {
 			name: "compareOldData",
 			prefix: "compare",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		imageOption: {
 			name: "",
@@ -106,21 +80,10 @@ describe("SelectParameterクラス", () => {
 			prefix: "compare",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 	};
 
@@ -131,21 +94,10 @@ describe("SelectParameterクラス", () => {
 			prefix: "generate",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		templateOption: {
 			name: "",
@@ -161,21 +113,10 @@ describe("SelectParameterクラス", () => {
 			prefix: "run",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		templateOption: {
 			name: "",
@@ -196,21 +137,10 @@ describe("SelectParameterクラス", () => {
 			prefix: "parameterize",
 			elements: [],
 			srcType: () => "csv",
-			srcElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			srcTypeSettings: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
-			settingElements: () => ({
-				name: "",
-				prefix: "",
-				elements: [],
-			}),
+			srcElements: () => createCommandParams(),
+			srcTypeSettings: () => createCommandParams(),
+			jdbcElements: () => createCommandParams(),
+			settingElements: () => createCommandParams(),
 		},
 		templateOption: {
 			name: "",


### PR DESCRIPTION
## Summary
Extended the Maven proxy setup script to automatically install Node.js LTS (version 20 or later) if not already available on the system.

## Key Changes
- Added Node.js version detection to check if the current installed version meets the minimum requirement (v20)
- Implemented automatic installation of the latest Node.js LTS release if the version is below the requirement
- Downloads Node.js from the official distribution using the configured Maven proxy
- Includes fallback version (22.14.0) in case the latest version cannot be determined
- Updates `~/.bashrc` to add the installed Node.js to the PATH for future shell sessions
- Immediately exports the Node.js path for the current session

## Implementation Details
- Uses `curl` with proxy configuration to fetch both the latest LTS version information and the binary
- Extracts Node.js to `$HOME/node-latest` directory
- Includes idempotent checks to avoid reinstalling if Node.js is already present
- Provides clear console output for debugging and status tracking
- Gracefully handles installation failures with cleanup of temporary files

https://claude.ai/code/session_01KGxUj52JafZhFneKqT4Tpw