### PR TITLE
Refactor dropdown menus to support multiple edit buttons

### DIFF
--- a/tauri/src/app/form/section/DatasetSettingDropDownMenu.tsx
+++ b/tauri/src/app/form/section/DatasetSettingDropDownMenu.tsx
@@ -25,10 +25,10 @@ export default function DatasetSettingDropDownMenu({
 			element={element}
 			srcType={srcType}
 			isValueInDatalist={isValueInDatalist}
-			editButton={
-				!hideDatasetSettingEdit ? (
-					<DatasetSettingEditButton path={path} setPath={setPath} />
-				) : undefined
+			editButtons={
+				!hideDatasetSettingEdit
+					? [<DatasetSettingEditButton path={path} setPath={setPath} />]
+					: undefined
 			}
 			removeButton={() => (
 				<RemoveDatasetSettingButton path={path} setPath={setPath} />

--- a/tauri/src/app/form/section/ResourceDropDownMenu.tsx
+++ b/tauri/src/app/form/section/ResourceDropDownMenu.tsx
@@ -5,7 +5,7 @@ import type { FileProp } from "./FormElementProp";
 
 type Props = Omit<FileProp, "onSelect" | "hidden"> & {
 	isValueInDatalist?: boolean;
-	editButton?: ReactNode;
+	editButtons?: ReactNode[];
 	removeButton?: (closeMenu: () => void) => ReactNode;
 	className?: string;
 };
@@ -17,7 +17,7 @@ export default function ResourceDropDownMenu({
 	element,
 	srcType,
 	isValueInDatalist,
-	editButton,
+	editButtons,
 	removeButton,
 	className,
 }: Props) {
@@ -28,7 +28,7 @@ export default function ResourceDropDownMenu({
 		<DropDownMenu className={className}>
 			{(closeMenu) => (
 				<>
-					{editButton && <li>{editButton}</li>}
+					{editButtons?.map((btn, i) => <li key={i}>{btn}</li>)}
 					{isValueInDatalist && removeButton && (
 						<li>{removeButton(closeMenu)}</li>
 					)}

--- a/tauri/src/app/form/section/SqlSrcDropDownMenu.tsx
+++ b/tauri/src/app/form/section/SqlSrcDropDownMenu.tsx
@@ -1,4 +1,4 @@
-import DropDownMenu from "../../../components/element/DropDownMenu";
+import type { ReactNode } from "react";
 import { useJdbcConnectionState } from "../../../context/JdbcConnectionProvider";
 import {
 	isSqlRelatedType,
@@ -8,8 +8,8 @@ import JdbcTableSelectorButton from "../../settings/JdbcTableSelectorButton";
 import SqlEditorButton, {
 	RemoveSqlEditorButton,
 } from "../../settings/SqlEditorButton";
-import { FileChooser, OpenInOS } from "./Chooser";
 import type { FileProp } from "./FormElementProp";
+import ResourceDropDownMenu from "./ResourceDropDownMenu";
 
 type Props = Omit<FileProp, "onSelect" | "hidden"> & {
 	isValueInDatalist: boolean;
@@ -24,63 +24,44 @@ export default function SqlSrcDropDownMenu({
 	isValueInDatalist,
 }: Props) {
 	const { connectionOk } = useJdbcConnectionState();
-	const isFileType = element.attribute.type.includes("FILE");
-	const isDirType = element.attribute.type.includes("DIR");
-	const isFileOrDir = isFileType || isDirType;
-	const isSqlSrc = isSqlRelatedType(srcType ?? "");
 	const isSqlOrTable = srcType === "sql" || srcType === "table";
+
+	const editButtons: ReactNode[] = [];
+	if (isSqlRelatedType(srcType ?? "")) {
+		editButtons.push(
+			<SqlEditorButton
+				type={srcType as QueryDatasourceType}
+				path={path}
+				setPath={setPath}
+			/>,
+		);
+	}
+	if (srcType === "table" && connectionOk) {
+		editButtons.push(
+			<JdbcTableSelectorButton path={path} setPath={setPath} />,
+		);
+	}
+
 	return (
-		<DropDownMenu>
-			{(closeMenu) => (
-				<>
-					{isSqlSrc && (
-						<li>
-							<SqlEditorButton
-								type={srcType as QueryDatasourceType}
-								path={path}
-								setPath={setPath}
-							/>
-						</li>
-					)}
-					{srcType === "table" && connectionOk && (
-						<li>
-							<JdbcTableSelectorButton path={path} setPath={setPath} />
-						</li>
-					)}
-					{isFileOrDir && path && (
-						<li>
-							<OpenInOS
-								prefix={prefix}
-								element={element}
-								srcType={srcType}
-								path={path}
-								setPath={setPath}
-							/>
-						</li>
-					)}
-					{isSqlOrTable && isValueInDatalist && (
-						<li>
+		<ResourceDropDownMenu
+			path={path}
+			setPath={setPath}
+			prefix={prefix}
+			element={element}
+			srcType={srcType}
+			isValueInDatalist={isValueInDatalist}
+			editButtons={editButtons}
+			removeButton={
+				isSqlOrTable
+					? () => (
 							<RemoveSqlEditorButton
 								path={path}
 								setPath={setPath}
 								type={srcType as QueryDatasourceType}
 							/>
-						</li>
-					)}
-					{isFileType && (
-						<li>
-							<FileChooser
-								prefix={prefix}
-								element={element}
-								srcType={srcType}
-								path={path}
-								setPath={setPath}
-								onSelect={closeMenu}
-							/>
-						</li>
-					)}
-				</>
-			)}
-		</DropDownMenu>
+						)
+					: undefined
+			}
+		/>
 	);
 }

--- a/tauri/src/app/form/section/TemplateDropDownMenu.tsx
+++ b/tauri/src/app/form/section/TemplateDropDownMenu.tsx
@@ -24,7 +24,7 @@ export default function TemplateDropDownMenu({
 			element={element}
 			srcType={srcType}
 			isValueInDatalist={isValueInDatalist}
-			editButton={<TemplateEditButton path={path} setPath={setPath} />}
+			editButtons={[<TemplateEditButton path={path} setPath={setPath} />]}
 			removeButton={() => <RemoveTemplateButton path={path} setPath={setPath} />}
 		/>
 	);

--- a/tauri/src/app/form/section/XlsxSchemaDropDownMenu.tsx
+++ b/tauri/src/app/form/section/XlsxSchemaDropDownMenu.tsx
@@ -24,7 +24,7 @@ export default function XlsxSchemaDropDownMenu({
 			element={element}
 			srcType={srcType}
 			isValueInDatalist={isValueInDatalist}
-			editButton={<XlsxSchemaEditButton path={path} setPath={setPath} />}
+			editButtons={[<XlsxSchemaEditButton path={path} setPath={setPath} />]}
 			removeButton={() => (
 				<RemoveXlsxSchemaButton path={path} setPath={setPath} />
 			)}


### PR DESCRIPTION
## Summary
This PR refactors the dropdown menu components to support multiple edit buttons instead of a single edit button, enabling more flexible menu configurations.

## Key Changes
- **ResourceDropDownMenu**: Changed `editButton` prop from `ReactNode` to `editButtons` array of `ReactNode[]`, allowing multiple edit buttons to be rendered
- **SqlSrcDropDownMenu**: Refactored to build an array of edit buttons conditionally and pass them to `ResourceDropDownMenu`, removing direct `DropDownMenu` usage and the `Chooser` imports
- **DatasetSettingDropDownMenu**: Updated to pass edit button as an array to match the new `editButtons` prop signature
- **TemplateDropDownMenu**: Updated to pass edit button as an array to match the new `editButtons` prop signature
- **XlsxSchemaDropDownMenu**: Updated to pass edit button as an array to match the new `editButtons` prop signature

## Implementation Details
- The `ResourceDropDownMenu` now maps over the `editButtons` array to render each button in its own list item
- `SqlSrcDropDownMenu` now conditionally builds an array of edit buttons (SqlEditorButton and/or JdbcTableSelectorButton) before rendering, improving code clarity and maintainability
- All consumers of `ResourceDropDownMenu` have been updated to use the new array-based API for consistency

https://claude.ai/code/session_014FVHGEJtf92JeaMHaEhwLT