### PR TITLE
Refactor form sections to use ResourceText component

### DIFF
--- a/tauri/src/app/form/section/DatasetFileText.tsx
+++ b/tauri/src/app/form/section/DatasetFileText.tsx
@@ -1,15 +1,11 @@
-import { useState } from "react";
-import { ControllTextBox, InputLabel } from "../../../components/element/Input";
 import {
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
 } from "../../../context/DatasetSrcInfoProvider";
-import { useWorkspaceContext } from "../../../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../../../model/CommandParam";
-import { getPath } from "./Chooser";
 import FileDropDownMenu from "./FileDropDownMenu";
 import type { Prop } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import ResourceText from "./ResourceText";
 
 export default function DatasetFileText({
 	prefix,
@@ -17,17 +13,10 @@ export default function DatasetFileText({
 	hidden,
 	srcType,
 }: Prop) {
-	const [path, setPath] = useState(element.value);
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
-	const context = useWorkspaceContext();
-	const defaultPath = getPath(context, element.attribute.defaultPath, srcType);
-	const id = getId(prefix, element.name);
-	const fieldName = getName(prefix, element.name);
 
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = ev.target.value;
-		setPath(newValue);
+	const handleValueChange = (newValue: string) => {
 		if (datasetSrcInfo && element.name in datasetSrcInfo) {
 			setDatasetSrcInfo({
 				...datasetSrcInfo,
@@ -37,37 +26,23 @@ export default function DatasetFileText({
 	};
 
 	return (
-		<div>
-			<InputLabel
-				text={fieldName}
-				id={id}
-				required={element.attribute.required}
-				hidden={hidden}
-			/>
-			<div className="flex">
-				<div className="flex-1">
-					<ControllTextBox
-						name={fieldName}
-						id={id}
-						hidden={hidden}
-						required={element.attribute.required}
-						value={path}
-						handleChange={handleChange}
-					/>
-					{!hidden && defaultPath && (
-						<p className="text-xs text-gray-400 truncate">{defaultPath}</p>
-					)}
-				</div>
-				{!hidden && (
-					<FileDropDownMenu
-						path={path}
-						setPath={setPath}
-						prefix={prefix}
-						element={element}
-						srcType={srcType}
-					/>
-				)}
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={srcType}
+			resourceFiles={[]}
+			onValueChange={handleValueChange}
+		>
+			{({ path, setPath }) => (
+				<FileDropDownMenu
+					path={path}
+					setPath={setPath}
+					prefix={prefix}
+					element={element}
+					srcType={srcType}
+				/>
+			)}
+		</ResourceText>
 	);
 }

--- a/tauri/src/app/form/section/FileText.tsx
+++ b/tauri/src/app/form/section/FileText.tsx
@@ -1,54 +1,25 @@
-import { useState } from "react";
-import { ControllTextBox, InputLabel } from "../../../components/element/Input";
-import { useWorkspaceContext } from "../../../context/WorkspaceResourcesProvider";
-import { getPath } from "./Chooser";
 import FileDropDownMenu from "./FileDropDownMenu";
 import type { Prop } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import ResourceText from "./ResourceText";
 
 export default function FileText({ prefix, element, hidden, srcType }: Prop) {
-	const [path, setPath] = useState(element.value);
-	const context = useWorkspaceContext();
-	const defaultPath = getPath(context, element.attribute.defaultPath, srcType);
-	const id = getId(prefix, element.name);
-	const fieldName = getName(prefix, element.name);
-
-	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-		setPath(ev.target.value);
-	};
-
 	return (
-		<div>
-			<InputLabel
-				text={fieldName}
-				id={id}
-				required={element.attribute.required}
-				hidden={hidden}
-			/>
-			<div className="flex">
-				<div className="flex-1">
-					<ControllTextBox
-						name={fieldName}
-						id={id}
-						hidden={hidden}
-						required={element.attribute.required}
-						value={path}
-						handleChange={handleChange}
-					/>
-					{!hidden && defaultPath && (
-						<p className="text-xs text-gray-400 truncate">{defaultPath}</p>
-					)}
-				</div>
-				{!hidden && (
-					<FileDropDownMenu
-						path={path}
-						setPath={setPath}
-						prefix={prefix}
-						element={element}
-						srcType={srcType}
-					/>
-				)}
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={srcType}
+			resourceFiles={[]}
+		>
+			{({ path, setPath }) => (
+				<FileDropDownMenu
+					path={path}
+					setPath={setPath}
+					prefix={prefix}
+					element={element}
+					srcType={srcType}
+				/>
+			)}
+		</ResourceText>
 	);
 }

--- a/tauri/src/app/form/section/JdbcFormSection.tsx
+++ b/tauri/src/app/form/section/JdbcFormSection.tsx
@@ -2,14 +2,8 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useState } from "react";
 import { BlueButton } from "../../../components/element/Button";
 import { BlueEditButton } from "../../../components/element/ButtonIcon";
-import {
-	ControllTextBox,
-	InputLabel,
-	ResourceDatalist,
-} from "../../../components/element/Input";
 import { useSetJdbcConnectionState } from "../../../context/JdbcConnectionProvider";
 import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
-import { getId, getName } from "./FormElementProp";
 import {
 	useDeleteJdbcProperties,
 	useJdbcConnectionTest,
@@ -20,6 +14,7 @@ import JdbcSavePropertiesDialog from "../../settings/JdbcSavePropertiesDialog";
 import JdbcUrlBuilderDialog from "../../settings/JdbcUrlBuilderDialog";
 import { RemoveResource } from "../../settings/ResourceEditButton";
 import ResourceDropDownMenu from "./ResourceDropDownMenu";
+import ResourceText from "./ResourceText";
 
 export const JDBC_FIELD_NAMES = [
 	"jdbcUrl",
@@ -73,7 +68,6 @@ export default function JdbcFormSection({
 					key={prefix + element.name}
 					prefix={prefix}
 					element={element}
-					value={jdbcValues[element.name] ?? element.value}
 					onValueChange={handleJdbcValueChange}
 				/>
 			))}
@@ -93,61 +87,68 @@ export default function JdbcFormSection({
 function JdbcTextField({
 	prefix,
 	element,
-	value,
 	onValueChange,
 }: {
 	prefix: string;
 	element: CommandParam;
-	value: string;
 	onValueChange: (name: string, value: string) => void;
 }) {
 	const settings = useResourcesSettings();
-	const labelText = getName(prefix, element.name);
-	const id = getId(prefix, element.name);
 	const isJdbcUrl = element.name === "jdbcUrl";
 	const isJdbcProperties = element.name === "jdbcProperties";
 	const resourceFiles = isJdbcProperties ? settings.jdbcFiles : [];
-	const hasButton = isJdbcUrl || isJdbcProperties;
 
-	const setPath: Dispatch<SetStateAction<string>> = (action) => {
-		const newPath = typeof action === "function" ? action(value) : action;
-		onValueChange(element.name, newPath);
+	const renderMenu = ({
+		path,
+		setPath,
+		isValueInDatalist,
+	}: {
+		path: string;
+		setPath: Dispatch<SetStateAction<string>>;
+		isValueInDatalist: boolean;
+	}) => {
+		const wrappedSetPath: Dispatch<SetStateAction<string>> = (action) => {
+			const newPath = typeof action === "function" ? action(path) : action;
+			setPath(newPath);
+			onValueChange(element.name, newPath);
+		};
+
+		if (isJdbcProperties) {
+			return (
+				<ResourceDropDownMenu
+					prefix={prefix}
+					element={element}
+					path={path}
+					setPath={wrappedSetPath}
+					isValueInDatalist={isValueInDatalist}
+					removeButton={(closeMenu) => (
+						<RemoveJdbcPropertiesButton
+							path={path}
+							setPath={(value) => {
+								wrappedSetPath(value);
+								closeMenu();
+							}}
+						/>
+					)}
+					className="mr-24"
+				/>
+			);
+		}
+		if (isJdbcUrl) {
+			return <JdbcUrlBuilderButton path={path} setPath={wrappedSetPath} />;
+		}
+		return <div className="w-36" />;
 	};
 
 	return (
-		<div>
-			<InputLabel
-				text={labelText}
-				id={id}
-				required={element.attribute.required}
-			/>
-			<div className="flex">
-				<div className={`flex-1${hasButton ? "" : " mr-36"}`}>
-					<ControllTextBox
-						name={labelText}
-						id={id}
-						required={element.attribute.required}
-						value={value}
-						list={isJdbcProperties ? `${id}_list` : undefined}
-						handleChange={(ev) => onValueChange(element.name, ev.target.value)}
-					/>
-					{isJdbcProperties && (
-						<ResourceDatalist id={id} resources={resourceFiles} />
-					)}
-				</div>
-				<div className="flex">
-					{isJdbcProperties && (
-						<JdbcPropertiesDropDownMenu
-							prefix={prefix}
-							element={element}
-							path={value}
-							setPath={setPath}
-						/>
-					)}
-					{isJdbcUrl && <JdbcUrlBuilderButton path={value} setPath={setPath} />}
-				</div>
-			</div>
-		</div>
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			resourceFiles={resourceFiles}
+			onValueChange={(value) => onValueChange(element.name, value)}
+		>
+			{renderMenu}
+		</ResourceText>
 	);
 }
 
@@ -173,41 +174,6 @@ function JdbcUrlBuilderButton({
 				/>
 			)}
 		</>
-	);
-}
-
-function JdbcPropertiesDropDownMenu({
-	prefix,
-	element,
-	path,
-	setPath,
-}: {
-	prefix: string;
-	element: CommandParam;
-	path: string;
-	setPath: Dispatch<SetStateAction<string>>;
-}) {
-	const settings = useResourcesSettings();
-	const isValueInDatalist = settings.jdbcFiles.includes(path);
-
-	return (
-		<ResourceDropDownMenu
-			prefix={prefix}
-			element={element}
-			path={path}
-			setPath={setPath}
-			isValueInDatalist={isValueInDatalist}
-			removeButton={(closeMenu) => (
-				<RemoveJdbcPropertiesButton
-					path={path}
-					setPath={(value) => {
-						setPath(value);
-						closeMenu();
-					}}
-				/>
-			)}
-			className="mr-24"
-		/>
 	);
 }
 


### PR DESCRIPTION
## Summary
This PR refactors multiple form section components to use a new `ResourceText` component, eliminating code duplication and improving maintainability across file and JDBC form inputs.

## Key Changes
- **Created `ResourceText` component**: A new reusable component that encapsulates common text input rendering logic with label, input field, default path display, and menu rendering
- **Refactored `JdbcFormSection`**: 
  - Removed direct imports of `ControllTextBox`, `InputLabel`, and `ResourceDatalist`
  - Simplified `JdbcTextField` to use `ResourceText` component
  - Moved JDBC properties dropdown menu logic into a render function passed to `ResourceText`
  - Removed the standalone `JdbcPropertiesDropDownMenu` component
- **Refactored `DatasetFileText`**: Replaced manual state management and JSX with `ResourceText` component, reducing component size significantly
- **Refactored `FileText`**: Simplified to use `ResourceText` component, removing boilerplate code for input handling and layout

## Implementation Details
- The `ResourceText` component accepts a render function as children that receives `path`, `setPath`, and `isValueInDatalist` to allow flexible menu rendering
- State management for the input value is now centralized in `ResourceText`
- The refactoring maintains all existing functionality while reducing code duplication across three components
- Removed unused imports (`getId`, `getName`, `getPath`, `useWorkspaceContext`) from refactored components

https://claude.ai/code/session_01ABX3W1UmeZbxfiMKNGqDkz