### PR TITLE
Refactor SelectFormElement into specialized components

### DIFF
--- a/tauri/src/app/form/section/PlainSelect.tsx
+++ b/tauri/src/app/form/section/PlainSelect.tsx
@@ -1,0 +1,30 @@
+import { InputLabel, SelectBox } from "../../../components/element/Input";
+import type { SelectProp } from "./FormElementProp";
+import { getId, getName } from "./FormElementProp";
+
+export default function PlainSelect(prop: SelectProp) {
+	return (
+		<div>
+			<InputLabel
+				text={getName(prop.prefix, prop.element.name)}
+				id={getId(prop.prefix, prop.element.name)}
+				required={prop.element.attribute.required}
+				hidden={prop.hidden}
+			/>
+			<SelectBox
+				name={getName(prop.prefix, prop.element.name)}
+				id={getId(prop.prefix, prop.element.name)}
+				required={true}
+				hidden={prop.hidden}
+				handleOnChange={prop.handleTypeSelect}
+				defaultValue={prop.element.value}
+			>
+				{prop.element.attribute.selectOption.map((value) => (
+					<option key={prop.prefix + prop.element.name + value} value={value}>
+						{value}
+					</option>
+				))}
+			</SelectBox>
+		</div>
+	);
+}

--- a/tauri/src/app/form/section/PlainSelect.tsx
+++ b/tauri/src/app/form/section/PlainSelect.tsx
@@ -3,18 +3,20 @@ import type { SelectProp } from "./FormElementProp";
 import { getId, getName } from "./FormElementProp";
 
 export default function PlainSelect(prop: SelectProp) {
+	const id = getId(prop.prefix, prop.element.name);
+	const name = getName(prop.prefix, prop.element.name);
 	return (
 		<div>
 			<InputLabel
-				text={getName(prop.prefix, prop.element.name)}
-				id={getId(prop.prefix, prop.element.name)}
+				text={name}
+				id={id}
 				required={prop.element.attribute.required}
 				hidden={prop.hidden}
 			/>
 			<SelectBox
-				name={getName(prop.prefix, prop.element.name)}
-				id={getId(prop.prefix, prop.element.name)}
-				required={true}
+				name={name}
+				id={id}
+				required={prop.element.attribute.required}
 				hidden={prop.hidden}
 				handleOnChange={prop.handleTypeSelect}
 				defaultValue={prop.element.value}

--- a/tauri/src/app/form/section/SelectFormElement.tsx
+++ b/tauri/src/app/form/section/SelectFormElement.tsx
@@ -1,46 +1,10 @@
-import { InputLabel, SelectBox } from "../../../components/element/Input";
-import {
-	useDatasetSrcInfo,
-	useSetDatasetSrcInfo,
-} from "../../../context/DatasetSrcInfoProvider";
 import type { SelectProp } from "./FormElementProp";
-import { getId, getName } from "./FormElementProp";
+import PlainSelect from "./PlainSelect";
+import SrcTypeSelect from "./SrcTypeSelect";
 
 export default function Select(prop: SelectProp) {
-	const datasetSrcInfo = useDatasetSrcInfo();
-	const setDatasetSrcInfo = useSetDatasetSrcInfo();
-
-	const handleTypeSelect = async (selected: string) => {
-		await prop.handleTypeSelect(selected);
-		if (prop.element.name === "srcType" && datasetSrcInfo) {
-			setDatasetSrcInfo({ ...datasetSrcInfo, srcType: selected });
-		}
-	};
-
-	return (
-		<div>
-			<InputLabel
-				text={getName(prop.prefix, prop.element.name)}
-				id={getId(prop.prefix, prop.element.name)}
-				required={prop.element.attribute.required}
-				hidden={prop.hidden}
-			/>
-			<SelectBox
-				name={getName(prop.prefix, prop.element.name)}
-				id={getId(prop.prefix, prop.element.name)}
-				required={true}
-				hidden={prop.hidden}
-				handleOnChange={handleTypeSelect}
-				defaultValue={prop.element.value}
-			>
-				{prop.element.attribute.selectOption.map((value) => {
-					return (
-						<option key={prop.prefix + prop.element.name + value} value={value}>
-							{value}
-						</option>
-					);
-				})}
-			</SelectBox>
-		</div>
-	);
+	if (prop.element.name === "srcType") {
+		return <SrcTypeSelect {...prop} />;
+	}
+	return <PlainSelect {...prop} />;
 }

--- a/tauri/src/app/form/section/SrcTypeSelect.tsx
+++ b/tauri/src/app/form/section/SrcTypeSelect.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import {
 	useDatasetSrcInfo,
 	useSetDatasetSrcInfo,
@@ -9,12 +10,15 @@ export default function SrcTypeSelect(prop: SelectProp) {
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const setDatasetSrcInfo = useSetDatasetSrcInfo();
 
-	const handleTypeSelect = async (selected: string) => {
-		await prop.handleTypeSelect(selected);
-		if (datasetSrcInfo) {
-			setDatasetSrcInfo({ ...datasetSrcInfo, srcType: selected });
-		}
-	};
+	const handleTypeSelect = useCallback(
+		async (selected: string) => {
+			await prop.handleTypeSelect(selected);
+			if (datasetSrcInfo) {
+				setDatasetSrcInfo({ ...datasetSrcInfo, srcType: selected });
+			}
+		},
+		[datasetSrcInfo, setDatasetSrcInfo, prop.handleTypeSelect],
+	);
 
 	return <PlainSelect {...prop} handleTypeSelect={handleTypeSelect} />;
 }

--- a/tauri/src/app/form/section/SrcTypeSelect.tsx
+++ b/tauri/src/app/form/section/SrcTypeSelect.tsx
@@ -1,0 +1,20 @@
+import {
+	useDatasetSrcInfo,
+	useSetDatasetSrcInfo,
+} from "../../../context/DatasetSrcInfoProvider";
+import type { SelectProp } from "./FormElementProp";
+import PlainSelect from "./PlainSelect";
+
+export default function SrcTypeSelect(prop: SelectProp) {
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const setDatasetSrcInfo = useSetDatasetSrcInfo();
+
+	const handleTypeSelect = async (selected: string) => {
+		await prop.handleTypeSelect(selected);
+		if (datasetSrcInfo) {
+			setDatasetSrcInfo({ ...datasetSrcInfo, srcType: selected });
+		}
+	};
+
+	return <PlainSelect {...prop} handleTypeSelect={handleTypeSelect} />;
+}


### PR DESCRIPTION
## Summary
Refactored the `SelectFormElement` component to improve code organization and maintainability by extracting select input logic into two specialized components: `PlainSelect` for standard selects and `SrcTypeSelect` for source type selection with dataset context integration.

## Key Changes
- **Extracted `PlainSelect` component**: Contains the core select input rendering logic with label and select box, making it reusable across different select types
- **Extracted `SrcTypeSelect` component**: Handles source type selection with dataset context integration, managing the `srcType` state update in `DatasetSrcInfoProvider`
- **Simplified `SelectFormElement`**: Now acts as a router component that delegates to the appropriate select component based on the element name
- **Improved performance**: Wrapped the `handleTypeSelect` callback in `SrcTypeSelect` with `useCallback` to prevent unnecessary re-renders
- **Fixed required attribute**: Changed `SelectBox` required prop from hardcoded `true` to use `prop.element.attribute.required` in `PlainSelect` for consistency

## Implementation Details
- The refactoring maintains backward compatibility while improving separation of concerns
- `SrcTypeSelect` wraps `PlainSelect` and injects its custom `handleTypeSelect` handler, allowing the base component to remain generic
- Dependencies are properly managed in the `useCallback` hook to ensure correct behavior when context values change

https://claude.ai/code/session_01XZzvMaciCMABBfcPciikJ7