### PR TITLE
Refactor form sections into specialized components

### DIFF
--- a/tauri/src/app/form/section/DatasetCommandFormSection.tsx
+++ b/tauri/src/app/form/section/DatasetCommandFormSection.tsx
@@ -1,0 +1,29 @@
+import type { ComponentType } from "react";
+import type { CommandParams } from "../../../model/CommandParam";
+import CommandFormElements from "./CommandFormElement";
+import DatasetText from "./DatasetTextFormElement";
+import type { Prop } from "./FormElementProp";
+
+export default function DatasetCommandFormSection({
+	commandParams,
+	handleTypeSelect,
+	name,
+	textComponent,
+}: {
+	commandParams: CommandParams;
+	handleTypeSelect: (selected: string) => Promise<void>;
+	name: string;
+	textComponent?: ComponentType<Prop>;
+}) {
+	return (
+		<CommandFormElements
+			handleTypeSelect={handleTypeSelect}
+			prefix={commandParams.prefix}
+			name={name}
+			elements={commandParams.elements}
+			optionCaption={commandParams.optionCaption}
+			optional={commandParams.optional}
+			textComponent={textComponent ?? DatasetText}
+		/>
+	);
+}

--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -4,7 +4,9 @@ import { JdbcConnectionProvider } from "../../../context/JdbcConnectionProvider"
 import type { DatasetSource } from "../../../model/CommandParam";
 import { buildDatasetSrcInfo } from "./CommandFormElement";
 import DatasetCommandFormSection from "./DatasetCommandFormSection";
+import DatasetSettingSection from "./DatasetSettingSection";
 import JdbcFormSection from "./JdbcFormSection";
+import SrcFormSection from "./SrcFormSection";
 
 export function DatasetLoadForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -27,10 +29,11 @@ export function DatasetLoadForm(prop: {
 			>
 				<fieldset className="border border-gray-200 p-3">
 					<legend>{prop.srcData.prefix}</legend>
-					<DatasetCommandFormSection
-						commandParams={src}
-						handleTypeSelect={prop.handleTypeSelect}
+					<SrcFormSection
+						prefix={src.prefix}
 						name={prop.name}
+						elements={src.elements}
+						handleTypeSelect={prop.handleTypeSelect}
 					/>
 					{srcTypeSettingsJdbc.elements.length > 0 && (
 						<JdbcFormSection
@@ -43,10 +46,10 @@ export function DatasetLoadForm(prop: {
 						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 					/>
-					<DatasetCommandFormSection
-						commandParams={settingElements}
-						handleTypeSelect={prop.handleTypeSelect}
+					<DatasetSettingSection
+						prefix={settingElements.prefix}
 						name={prop.name}
+						elements={settingElements.elements}
 					/>
 				</fieldset>
 			</DatasetSrcInfoProvider>

--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -2,8 +2,8 @@ import { useMemo } from "react";
 import { DatasetSrcInfoProvider } from "../../../context/DatasetSrcInfoProvider";
 import { JdbcConnectionProvider } from "../../../context/JdbcConnectionProvider";
 import type { DatasetSource } from "../../../model/CommandParam";
-import CommandFormElements, { buildDatasetSrcInfo } from "./CommandFormElement";
-import DatasetText from "./DatasetTextFormElement";
+import { buildDatasetSrcInfo } from "./CommandFormElement";
+import DatasetCommandFormSection from "./DatasetCommandFormSection";
 import JdbcFormSection from "./JdbcFormSection";
 
 export function DatasetLoadForm(prop: {
@@ -27,14 +27,10 @@ export function DatasetLoadForm(prop: {
 			>
 				<fieldset className="border border-gray-200 p-3">
 					<legend>{prop.srcData.prefix}</legend>
-					<CommandFormElements
+					<DatasetCommandFormSection
+						commandParams={src}
 						handleTypeSelect={prop.handleTypeSelect}
-						prefix={src.prefix}
 						name={prop.name}
-						elements={src.elements}
-						optionCaption={src.optionCaption}
-						optional={src.optional}
-						textComponent={DatasetText}
 					/>
 					{srcTypeSettingsJdbc.elements.length > 0 && (
 						<JdbcFormSection
@@ -42,23 +38,15 @@ export function DatasetLoadForm(prop: {
 							elements={srcTypeSettingsJdbc.elements}
 						/>
 					)}
-					<CommandFormElements
+					<DatasetCommandFormSection
+						commandParams={srcTypeSettings}
 						handleTypeSelect={prop.handleTypeSelect}
-						prefix={srcTypeSettings.prefix}
 						name={prop.name}
-						elements={srcTypeSettings.elements}
-						optionCaption={srcTypeSettings.optionCaption}
-						optional={srcTypeSettings.optional}
-						textComponent={DatasetText}
 					/>
-					<CommandFormElements
+					<DatasetCommandFormSection
+						commandParams={settingElements}
 						handleTypeSelect={prop.handleTypeSelect}
-						prefix={settingElements.prefix}
 						name={prop.name}
-						elements={settingElements.elements}
-						optionCaption={settingElements.optionCaption}
-						optional={settingElements.optional}
-						textComponent={DatasetText}
 					/>
 				</fieldset>
 			</DatasetSrcInfoProvider>

--- a/tauri/src/app/form/section/DatasetSettingSection.tsx
+++ b/tauri/src/app/form/section/DatasetSettingSection.tsx
@@ -1,0 +1,66 @@
+import { Fragment, useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { CommandParam } from "../../../model/CommandParam";
+import Check from "./CheckFormElement";
+import DatasetText from "./DatasetTextFormElement";
+
+const DATASET_OPTIONAL = [
+	"regTableInclude",
+	"regTableExclude",
+	"loadData",
+	"includeMetaData",
+] as const;
+
+function isDatasetOptional(name: string): boolean {
+	return (DATASET_OPTIONAL as readonly string[]).includes(name);
+}
+
+function renderSettingElement(
+	element: CommandParam,
+	prefix: string,
+	hidden: boolean,
+): React.ReactNode {
+	if (element.attribute.type === "FLG") {
+		return <Check prefix={prefix} element={element} hidden={hidden} />;
+	}
+	return <DatasetText prefix={prefix} element={element} hidden={hidden} />;
+}
+
+export default function DatasetSettingSection({
+	prefix,
+	name,
+	elements,
+}: {
+	prefix: string;
+	name: string;
+	elements: CommandParam[];
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const firstOptionalName = elements.find((e) =>
+		isDatasetOptional(e.name),
+	)?.name;
+	const toggleOptional = () => setShowOptional(!showOptional);
+
+	return (
+		<>
+			{elements.map((element) => {
+				const isOptional = isDatasetOptional(element.name);
+				const showExpandButton = element.name === firstOptionalName;
+				return (
+					<Fragment key={name + prefix + element.name}>
+						{showExpandButton && (
+							<div className="pt-2.5">
+								<ExpandButton
+									toggleOptional={toggleOptional}
+									showOptional={showOptional}
+									caption="dataset option"
+								/>
+							</div>
+						)}
+						{renderSettingElement(element, prefix, isOptional && !showOptional)}
+					</Fragment>
+				);
+			})}
+		</>
+	);
+}

--- a/tauri/src/app/form/section/SrcFormSection.tsx
+++ b/tauri/src/app/form/section/SrcFormSection.tsx
@@ -1,0 +1,96 @@
+import { Fragment, useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { CommandParam } from "../../../model/CommandParam";
+import Check from "./CheckFormElement";
+import DatasetText from "./DatasetTextFormElement";
+import type { SelectProp } from "./FormElementProp";
+import SrcTypeSelect from "./SrcTypeSelect";
+
+const TRAVERSAL_OPTIONAL = [
+	"recursive",
+	"regInclude",
+	"regExclude",
+	"extension",
+] as const;
+
+function isTraversalOptional(name: string): boolean {
+	return (TRAVERSAL_OPTIONAL as readonly string[]).includes(name);
+}
+
+function renderSrcElement(
+	element: CommandParam,
+	prefix: string,
+	srcType: string,
+	hidden: boolean,
+	handleTypeSelect: SelectProp["handleTypeSelect"],
+): React.ReactNode {
+	if (element.attribute.type === "ENUM") {
+		return (
+			<SrcTypeSelect
+				handleTypeSelect={handleTypeSelect}
+				prefix={prefix}
+				element={element}
+				hidden={hidden}
+			/>
+		);
+	}
+	if (element.attribute.type === "FLG") {
+		return <Check prefix={prefix} element={element} hidden={hidden} />;
+	}
+	return (
+		<DatasetText
+			prefix={prefix}
+			element={element}
+			hidden={hidden}
+			srcType={element.name === "src" ? srcType : undefined}
+		/>
+	);
+}
+
+export default function SrcFormSection({
+	prefix,
+	name,
+	elements,
+	handleTypeSelect,
+}: {
+	prefix: string;
+	name: string;
+	elements: CommandParam[];
+	handleTypeSelect: SelectProp["handleTypeSelect"];
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const srcType = elements.find((e) => e.name === "srcType")?.value ?? "";
+	const firstOptionalName = elements.find((e) =>
+		isTraversalOptional(e.name),
+	)?.name;
+	const toggleOptional = () => setShowOptional(!showOptional);
+
+	return (
+		<>
+			{elements.map((element) => {
+				const isOptional = isTraversalOptional(element.name);
+				const showExpandButton = element.name === firstOptionalName;
+				return (
+					<Fragment key={name + prefix + element.name}>
+						{showExpandButton && (
+							<div className="pt-2.5">
+								<ExpandButton
+									toggleOptional={toggleOptional}
+									showOptional={showOptional}
+									caption="traversal option"
+								/>
+							</div>
+						)}
+						{renderSrcElement(
+							element,
+							prefix,
+							srcType,
+							isOptional && !showOptional,
+							handleTypeSelect,
+						)}
+					</Fragment>
+				);
+			})}
+		</>
+	);
+}


### PR DESCRIPTION
## Summary
Refactored the dataset load form by extracting specialized form section components to improve code organization, reusability, and maintainability.

## Key Changes
- **New `SrcFormSection` component**: Handles source configuration with collapsible traversal options (recursive, regInclude, regExclude, extension)
- **New `DatasetSettingSection` component**: Manages dataset-specific settings with collapsible options (regTableInclude, regTableExclude, loadData, includeMetaData)
- **New `DatasetCommandFormSection` component**: Generic wrapper for command form elements with customizable text component
- **Refactored `DatasetLoadForm`**: Replaced inline `CommandFormElements` calls with specialized section components, improving readability and separation of concerns

## Implementation Details
- Each section component manages its own optional field visibility state using `useState`
- Optional fields are grouped and revealed via `ExpandButton` with section-specific captions
- `SrcFormSection` includes special handling for source type selection and dataset text rendering
- Extracted helper functions (`isTraversalOptional`, `isDatasetOptional`, `renderSrcElement`, `renderSettingElement`) to encapsulate field classification logic
- Maintained backward compatibility by preserving all existing functionality while improving code structure

https://claude.ai/code/session_019mDpANhJcpjrcdNxTpwSLn