### PR TITLE
Extract template form section into dedicated component

### DIFF
--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -3,6 +3,7 @@ import type { RunParams } from "../../model/SelectParameter";
 import CommandFormElements from "./section/CommandFormElement";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
 import JdbcFormSection from "./section/JdbcFormSection";
+import TemplateFormSection from "./section/TemplateFormSection";
 
 export function RunForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -26,7 +27,7 @@ export function RunForm(prop: {
 			{prop.run.templateOption && (
 				<fieldset className="border border-gray-200 p-3">
 					<legend>template</legend>
-					<CommandFormElements
+					<TemplateFormSection
 						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 						prefix={templateOption.prefix}

--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -28,10 +28,9 @@ export function RunForm(prop: {
 				<fieldset className="border border-gray-200 p-3">
 					<legend>template</legend>
 					<TemplateFormSection
+						commandParams={templateOption}
 						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
-						prefix={templateOption.prefix}
-						elements={templateOption.elements}
 					/>
 				</fieldset>
 			)}

--- a/tauri/src/app/form/section/TemplateFormSection.tsx
+++ b/tauri/src/app/form/section/TemplateFormSection.tsx
@@ -1,23 +1,23 @@
-import type { CommandParam } from "../../../model/CommandParam";
+import type { CommandParams } from "../../../model/CommandParam";
 import CommandFormElements from "./CommandFormElement";
 
 export default function TemplateFormSection({
+	commandParams,
 	handleTypeSelect,
 	name,
-	prefix,
-	elements,
 }: {
+	commandParams: CommandParams;
 	handleTypeSelect: (selected: string) => Promise<void>;
 	name: string;
-	prefix: string;
-	elements: CommandParam[];
 }) {
 	return (
 		<CommandFormElements
 			handleTypeSelect={handleTypeSelect}
 			name={name}
-			prefix={prefix}
-			elements={elements}
+			prefix={commandParams.prefix}
+			elements={commandParams.elements}
+			optionCaption={commandParams.optionCaption}
+			optional={commandParams.optional}
 		/>
 	);
 }

--- a/tauri/src/app/form/section/TemplateFormSection.tsx
+++ b/tauri/src/app/form/section/TemplateFormSection.tsx
@@ -1,5 +1,32 @@
-import type { CommandParams } from "../../../model/CommandParam";
-import CommandFormElements from "./CommandFormElement";
+import { Fragment, useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { CommandParam, CommandParams } from "../../../model/CommandParam";
+import Check from "./CheckFormElement";
+import type { SelectProp } from "./FormElementProp";
+import Select from "./SelectFormElement";
+import TemplateText from "./TemplateText";
+
+function renderElement(
+	element: CommandParam,
+	prefix: string,
+	hidden: boolean,
+	handleTypeSelect: SelectProp["handleTypeSelect"],
+): React.ReactNode {
+	if (element.attribute.type === "FLG") {
+		return <Check prefix={prefix} element={element} hidden={hidden} />;
+	}
+	if (element.attribute.type === "ENUM") {
+		return (
+			<Select
+				handleTypeSelect={handleTypeSelect}
+				prefix={prefix}
+				element={element}
+				hidden={hidden}
+			/>
+		);
+	}
+	return <TemplateText prefix={prefix} element={element} hidden={hidden} />;
+}
 
 export default function TemplateFormSection({
 	commandParams,
@@ -7,17 +34,40 @@ export default function TemplateFormSection({
 	name,
 }: {
 	commandParams: CommandParams;
-	handleTypeSelect: (selected: string) => Promise<void>;
+	handleTypeSelect: SelectProp["handleTypeSelect"];
 	name: string;
 }) {
+	const [showOptional, setShowOptional] = useState(false);
+	const firstOptionalName = commandParams.optionCaption
+		? commandParams.elements.find((e) => commandParams.optional?.(e.name))?.name
+		: undefined;
+	const toggleOptional = () => setShowOptional(!showOptional);
+
 	return (
-		<CommandFormElements
-			handleTypeSelect={handleTypeSelect}
-			name={name}
-			prefix={commandParams.prefix}
-			elements={commandParams.elements}
-			optionCaption={commandParams.optionCaption}
-			optional={commandParams.optional}
-		/>
+		<>
+			{commandParams.elements.map((element) => {
+				const isOptional = commandParams.optional?.(element.name) ?? false;
+				const showExpandButton = element.name === firstOptionalName;
+				return (
+					<Fragment key={name + commandParams.prefix + element.name}>
+						{showExpandButton && (
+							<div className="pt-2.5">
+								<ExpandButton
+									toggleOptional={toggleOptional}
+									showOptional={showOptional}
+									caption={commandParams.optionCaption?.caption}
+								/>
+							</div>
+						)}
+						{renderElement(
+							element,
+							commandParams.prefix,
+							isOptional && !showOptional,
+							handleTypeSelect,
+						)}
+					</Fragment>
+				);
+			})}
+		</>
 	);
 }

--- a/tauri/src/app/form/section/TemplateFormSection.tsx
+++ b/tauri/src/app/form/section/TemplateFormSection.tsx
@@ -1,0 +1,23 @@
+import type { CommandParam } from "../../../model/CommandParam";
+import CommandFormElements from "./CommandFormElement";
+
+export default function TemplateFormSection({
+	handleTypeSelect,
+	name,
+	prefix,
+	elements,
+}: {
+	handleTypeSelect: (selected: string) => Promise<void>;
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+}) {
+	return (
+		<CommandFormElements
+			handleTypeSelect={handleTypeSelect}
+			name={name}
+			prefix={prefix}
+			elements={elements}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary
Refactored the template form rendering logic by extracting it into a dedicated `TemplateFormSection` component, improving code organization and reusability.

## Key Changes
- Created new `TemplateFormSection.tsx` component that encapsulates template form rendering logic
  - Handles conditional rendering of form elements (Check, Select, TemplateText) based on parameter type
  - Manages optional field visibility with expand/collapse functionality
  - Accepts `CommandParams` object and form handlers as props
- Updated `RunForm.tsx` to use the new `TemplateFormSection` component instead of the generic `CommandFormElements`
  - Simplified prop passing by using the structured `CommandParams` object
  - Removed individual prop drilling (`prefix`, `elements`)

## Implementation Details
- The `renderElement` helper function determines which form element component to render based on the parameter's attribute type (FLG, ENUM, or default text)
- Optional field visibility is controlled by the `showOptional` state, with the expand button appearing at the first optional field
- The component maintains the same visual structure and functionality as the previous implementation

https://claude.ai/code/session_01SoK2xeG6W7tVP8qmtmnGZp