### PR TITLE
Refactor JDBC and Template options into dedicated types

### DIFF
--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -106,18 +106,19 @@ export class DatasetSourceImpl implements DatasetSource {
 				["recursive", "regInclude", "regExclude", "extension"].includes(param),
 		);
 	}
+	private srcTypeRange(): CommandParam[] {
+		return this.elements.slice(
+			this.indexExtension === -1
+				? this.indexRegExclude + 1
+				: this.indexExtension + 1,
+			this.indexOfSetting,
+		);
+	}
 	srcTypeSettings() {
 		const srcTypeSettings = srcTypeDetail.get(this.src);
 		return toCommandParams(
 			this,
-			this.elements
-				.slice(
-					this.indexExtension === -1
-						? this.indexRegExclude + 1
-						: this.indexExtension + 1,
-					this.indexOfSetting,
-				)
-				.filter((it) => !it.name.startsWith("jdbc")),
+			this.srcTypeRange().filter((it) => !it.name.startsWith("jdbc")),
 			srcTypeSettings?.optionCaption,
 			srcTypeSettings?.optional,
 		);
@@ -125,14 +126,7 @@ export class DatasetSourceImpl implements DatasetSource {
 	jdbcElements() {
 		return toCommandParams(
 			this,
-			this.elements
-				.slice(
-					this.indexExtension === -1
-						? this.indexRegExclude + 1
-						: this.indexExtension + 1,
-					this.indexOfSetting,
-				)
-				.filter((it) => it.name.startsWith("jdbc")),
+			this.srcTypeRange().filter((it) => it.name.startsWith("jdbc")),
 			undefined,
 			undefined,
 		);
@@ -156,14 +150,9 @@ export class DatasetSourceImpl implements DatasetSource {
 		return new JdbcOptionImpl(jdbc.name, jdbc.prefix, jdbc.elements);
 	}
 	templateOption(): TemplateOption {
-		const elements = this.elements
-			.slice(
-				this.indexExtension === -1
-					? this.indexRegExclude + 1
-					: this.indexExtension + 1,
-				this.indexOfSetting,
-			)
-			.filter((it) => it.name.startsWith("template"));
+		const elements = this.srcTypeRange().filter((it) =>
+			it.name.startsWith("template"),
+		);
 		return new TemplateOptionImpl(this.name, this.prefix, elements);
 	}
 }

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -150,6 +150,73 @@ export class DatasetSourceImpl implements DatasetSource {
 		);
 	}
 }
+function findByName(elements: CommandParam[], name: string): CommandParam {
+	return elements.find((e) => e.name === name)!;
+}
+export type JdbcOption = CommandParams & {
+	jdbcProperties: CommandParam;
+	jdbcUrl: CommandParam;
+	jdbcUser: CommandParam;
+	jdbcPass: CommandParam;
+};
+export class JdbcOptionImpl implements JdbcOption {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(name: string, prefix: string, elements: CommandParam[]) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+	}
+	get jdbcProperties(): CommandParam {
+		return findByName(this.elements, "jdbcProperties");
+	}
+	get jdbcUrl(): CommandParam {
+		return findByName(this.elements, "jdbcUrl");
+	}
+	get jdbcUser(): CommandParam {
+		return findByName(this.elements, "jdbcUser");
+	}
+	get jdbcPass(): CommandParam {
+		return findByName(this.elements, "jdbcPass");
+	}
+}
+export type TemplateOption = CommandParams & {
+	encoding: CommandParam;
+	templateGroup: CommandParam;
+	templateParameterAttribute: CommandParam;
+	templateVarStart: CommandParam;
+	templateVarStop: CommandParam;
+};
+export class TemplateOptionImpl implements TemplateOption {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(name: string, prefix: string, elements: CommandParam[]) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+	}
+	get encoding(): CommandParam {
+		return findByName(this.elements, "encoding");
+	}
+	get templateGroup(): CommandParam {
+		return findByName(this.elements, "templateGroup");
+	}
+	get templateParameterAttribute(): CommandParam {
+		return findByName(this.elements, "templateParameterAttribute");
+	}
+	get templateVarStart(): CommandParam {
+		return findByName(this.elements, "templateVarStart");
+	}
+	get templateVarStop(): CommandParam {
+		return findByName(this.elements, "templateVarStop");
+	}
+}
 const srcTypeDetail = new Map<
 	string,
 	{

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -55,6 +55,8 @@ export type DatasetSource = CommandParams & {
 	srcTypeSettings: () => CommandParams;
 	jdbcElements: () => CommandParams;
 	settingElements: () => CommandParams;
+	jdbcOption: () => JdbcOption;
+	templateOption: () => TemplateOption;
 };
 export class DatasetSourceImpl implements DatasetSource {
 	name: string;
@@ -148,6 +150,21 @@ export class DatasetSourceImpl implements DatasetSource {
 					"includeMetaData",
 				].includes(param),
 		);
+	}
+	jdbcOption(): JdbcOption {
+		const jdbc = this.jdbcElements();
+		return new JdbcOptionImpl(jdbc.name, jdbc.prefix, jdbc.elements);
+	}
+	templateOption(): TemplateOption {
+		const elements = this.elements
+			.slice(
+				this.indexExtension === -1
+					? this.indexRegExclude + 1
+					: this.indexExtension + 1,
+				this.indexOfSetting,
+			)
+			.filter((it) => it.name.startsWith("template"));
+		return new TemplateOptionImpl(this.name, this.prefix, elements);
 	}
 }
 function findByName(elements: CommandParam[], name: string): CommandParam {

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -2,8 +2,14 @@ import type {
 	CommandParam,
 	CommandParams,
 	DatasetSource,
+	JdbcOption,
+	TemplateOption,
 } from "./CommandParam";
-import { DatasetSourceImpl } from "./CommandParam";
+import {
+	DatasetSourceImpl,
+	JdbcOptionImpl,
+	TemplateOptionImpl,
+} from "./CommandParam";
 
 export class SelectParameter {
 	readonly name: string;
@@ -50,6 +56,13 @@ export class SelectParameter {
 				this.generate.srcData.prefix,
 				this.generate.srcData.elements,
 			);
+			if (this.generate.templateOption) {
+				this.generate.templateOption = new TemplateOptionImpl(
+					this.generate.templateOption.prefix,
+					this.generate.templateOption.prefix,
+					this.generate.templateOption.elements,
+				);
+			}
 		}
 		if (command === "run") {
 			this.run = response as RunParams;
@@ -58,6 +71,20 @@ export class SelectParameter {
 				this.run.srcData.prefix,
 				this.run.srcData.elements,
 			);
+			if (this.run.templateOption) {
+				this.run.templateOption = new TemplateOptionImpl(
+					this.run.templateOption.prefix,
+					this.run.templateOption.prefix,
+					this.run.templateOption.elements,
+				);
+			}
+			if (this.run.jdbcOption) {
+				this.run.jdbcOption = new JdbcOptionImpl(
+					this.run.jdbcOption.prefix,
+					this.run.jdbcOption.prefix,
+					this.run.jdbcOption.elements,
+				);
+			}
 		}
 		if (command === "parameterize") {
 			this.parameterize = response as ParameterizeParams;
@@ -66,6 +93,13 @@ export class SelectParameter {
 				this.parameterize.paramData.prefix,
 				this.parameterize.paramData.elements,
 			);
+			if (this.parameterize.templateOption) {
+				this.parameterize.templateOption = new TemplateOptionImpl(
+					this.parameterize.templateOption.prefix,
+					this.parameterize.templateOption.prefix,
+					this.parameterize.templateOption.elements,
+				);
+			}
 		}
 	}
 	currentParameter() {
@@ -108,16 +142,16 @@ export type CompareParams = {
 export type GenerateParams = {
 	elements: CommandParam[];
 	srcData: DatasetSource;
-	templateOption: CommandParams;
+	templateOption: TemplateOption;
 };
 export type RunParams = {
 	elements: CommandParam[];
 	srcData: DatasetSource;
-	templateOption: CommandParams;
-	jdbcOption: CommandParams;
+	templateOption: TemplateOption;
+	jdbcOption: JdbcOption;
 };
 export type ParameterizeParams = {
 	elements: CommandParam[];
 	paramData: DatasetSource;
-	templateOption: CommandParams;
+	templateOption: TemplateOption;
 };


### PR DESCRIPTION
## Summary
This PR refactors the handling of JDBC and Template configuration options by introducing dedicated type definitions and implementation classes, replacing the generic `CommandParams` type. This improves type safety and provides better IDE support for accessing specific option properties.

## Key Changes

- **New Type Definitions**: Added `JdbcOption` and `TemplateOption` types with strongly-typed properties for JDBC and Template configurations
  - `JdbcOption`: Provides typed access to `jdbcProperties`, `jdbcUrl`, `jdbcUser`, and `jdbcPass`
  - `TemplateOption`: Provides typed access to `encoding`, `templateGroup`, `templateParameterAttribute`, `templateVarStart`, and `templateVarStop`

- **New Implementation Classes**: Created `JdbcOptionImpl` and `TemplateOptionImpl` classes that implement the respective interfaces with property getters that use a helper function to find parameters by name

- **Refactored DatasetSource**: 
  - Added `jdbcOption()` and `templateOption()` methods to the `DatasetSource` interface and `DatasetSourceImpl` class
  - Extracted common slice logic into a private `srcTypeRange()` method to reduce code duplication in `srcTypeSettings()` and `jdbcElements()`

- **Updated Parameter Types**: Changed `GenerateParams`, `RunParams`, and `ParameterizeParams` to use the new `TemplateOption` and `JdbcOption` types instead of generic `CommandParams`

- **Updated SelectParameter**: Modified the response handling to instantiate the new `TemplateOptionImpl` and `JdbcOptionImpl` classes when processing responses from the backend

## Implementation Details

- A helper function `findByName()` was added to locate command parameters by name within the elements array
- The refactoring maintains backward compatibility while providing better type checking and autocomplete support
- All option implementations follow the same pattern: storing name, prefix, and elements, with typed getters for specific properties

https://claude.ai/code/session_01Uzai472b6YBUDKr9NeJJYw