### PR TITLE
Extract template form rendering into TemplateFormSection component

### DIFF
--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -1,6 +1,7 @@
 import type { GenerateParams } from "../../model/SelectParameter";
 import CommandFormElements from "./section/CommandFormElement";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
+import TemplateFormSection from "./section/TemplateFormSection";
 
 export function GenerateForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -22,11 +23,10 @@ export function GenerateForm(prop: {
 			{prop.generate.templateOption && (
 				<fieldset className="border border-gray-200 p-3">
 					<legend>{prop.generate.templateOption.prefix}</legend>
-					<CommandFormElements
+					<TemplateFormSection
+						commandParams={prop.generate.templateOption}
 						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
-						prefix={prop.generate.templateOption.prefix}
-						elements={prop.generate.templateOption.elements}
 					/>
 				</fieldset>
 			)}

--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -1,6 +1,7 @@
 import type { ParameterizeParams } from "../../model/SelectParameter";
 import CommandFormElements from "./section/CommandFormElement";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
+import TemplateFormSection from "./section/TemplateFormSection";
 
 export function ParameterizeForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -19,13 +20,17 @@ export function ParameterizeForm(prop: {
 					prefix=""
 					elements={prop.parameterize.elements}
 				/>
-				<CommandFormElements
-					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
-					prefix={templateOption.prefix}
-					elements={templateOption.elements}
-				/>
 			</fieldset>
+			{templateOption && (
+				<fieldset className="border border-gray-200 p-3">
+					<legend>{templateOption.prefix}</legend>
+					<TemplateFormSection
+						commandParams={templateOption}
+						handleTypeSelect={prop.handleTypeSelect}
+						name={prop.name}
+					/>
+				</fieldset>
+			)}
 			<DatasetLoadForm
 				handleTypeSelect={prop.handleTypeSelect}
 				name={prop.name}

--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -20,17 +20,14 @@ export function ParameterizeForm(prop: {
 					prefix=""
 					elements={prop.parameterize.elements}
 				/>
-			</fieldset>
-			{templateOption && (
-				<fieldset className="border border-gray-200 p-3">
-					<legend>{templateOption.prefix}</legend>
+				{templateOption && (
 					<TemplateFormSection
 						commandParams={templateOption}
 						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 					/>
-				</fieldset>
-			)}
+				)}
+			</fieldset>
 			<DatasetLoadForm
 				handleTypeSelect={prop.handleTypeSelect}
 				name={prop.name}


### PR DESCRIPTION
## Summary
Refactored template form rendering logic by extracting it into a new reusable `TemplateFormSection` component. This change reduces code duplication and improves maintainability across multiple forms.

## Key Changes
- Created new `TemplateFormSection` component to encapsulate template form rendering logic
- Updated `ParameterizeForm` to use `TemplateFormSection` instead of directly rendering `CommandFormElements`
  - Added null check for `templateOption` before rendering
  - Simplified prop passing by using `commandParams` object
- Updated `GenerateForm` to use `TemplateFormSection` instead of directly rendering `CommandFormElements`
  - Removed redundant `prefix` and `elements` prop destructuring
  - Consolidated props into single `commandParams` object

## Implementation Details
- The new `TemplateFormSection` component accepts `commandParams`, `handleTypeSelect`, and `name` props
- This abstraction eliminates the need to manually pass `prefix` and `elements` separately, as they're now contained within the `commandParams` object
- Both forms now have consistent template rendering behavior through the shared component

https://claude.ai/code/session_01Mg6ZaNtBVWMuuj4esd1EwU