### PR TITLE
Refactor JDBC form fields into separate specialized components

### DIFF
--- a/tauri/src/app/form/section/JdbcFormSection.tsx
+++ b/tauri/src/app/form/section/JdbcFormSection.tsx
@@ -7,7 +7,9 @@ import {
 } from "../../../hooks/useJdbc";
 import type { JdbcOption } from "../../../model/CommandParam";
 import JdbcSavePropertiesDialog from "../../settings/JdbcSavePropertiesDialog";
+import JdbcPropertiesTextField from "./JdbcPropertiesTextField";
 import JdbcTextField from "./JdbcTextField";
+import JdbcUrlTextField from "./JdbcUrlTextField";
 
 export default function JdbcFormSection({
 	jdbcOption,
@@ -44,7 +46,7 @@ export default function JdbcFormSection({
 
 	return (
 		<>
-			<JdbcTextField
+			<JdbcUrlTextField
 				prefix={prefix}
 				element={jdbcOption.jdbcUrl}
 				onValueChange={handleJdbcValueChange}
@@ -59,7 +61,7 @@ export default function JdbcFormSection({
 				element={jdbcOption.jdbcPass}
 				onValueChange={handleJdbcValueChange}
 			/>
-			<JdbcTextField
+			<JdbcPropertiesTextField
 				prefix={prefix}
 				element={jdbcOption.jdbcProperties}
 				onValueChange={handleJdbcValueChange}

--- a/tauri/src/app/form/section/JdbcPropertiesTextField.tsx
+++ b/tauri/src/app/form/section/JdbcPropertiesTextField.tsx
@@ -1,0 +1,71 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
+import { useDeleteJdbcProperties } from "../../../hooks/useJdbc";
+import type { CommandParam } from "../../../model/CommandParam";
+import { RemoveResource } from "../../settings/ResourceEditButton";
+import ResourceDropDownMenu from "./ResourceDropDownMenu";
+import ResourceText from "./ResourceText";
+
+export default function JdbcPropertiesTextField({
+	prefix,
+	element,
+	onValueChange,
+}: {
+	prefix: string;
+	element: CommandParam;
+	onValueChange: (name: string, value: string) => void;
+}) {
+	const settings = useResourcesSettings();
+	return (
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			resourceFiles={settings.jdbcFiles}
+			onValueChange={(value) => onValueChange(element.name, value)}
+		>
+			{({ path, setPath, isValueInDatalist }) => {
+				const wrappedSetPath: Dispatch<SetStateAction<string>> = (action) => {
+					const newPath = typeof action === "function" ? action(path) : action;
+					setPath(newPath);
+					onValueChange(element.name, newPath);
+				};
+				return (
+					<ResourceDropDownMenu
+						prefix={prefix}
+						element={element}
+						path={path}
+						setPath={wrappedSetPath}
+						isValueInDatalist={isValueInDatalist}
+						removeButton={(closeMenu) => (
+							<RemoveJdbcPropertiesButton
+								path={path}
+								setPath={(value) => {
+									wrappedSetPath(value);
+									closeMenu();
+								}}
+							/>
+						)}
+						className="mr-24"
+					/>
+				);
+			}}
+		</ResourceText>
+	);
+}
+
+function RemoveJdbcPropertiesButton({
+	path,
+	setPath,
+}: {
+	path: string;
+	setPath: (value: string) => void;
+}) {
+	const deleteJdbcProperties = useDeleteJdbcProperties();
+	return (
+		<RemoveResource
+			path={path}
+			setPath={setPath}
+			deleteResource={deleteJdbcProperties}
+		/>
+	);
+}

--- a/tauri/src/app/form/section/JdbcTextField.tsx
+++ b/tauri/src/app/form/section/JdbcTextField.tsx
@@ -1,12 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
-import { useState } from "react";
-import { BlueEditButton } from "../../../components/element/ButtonIcon";
-import { useResourcesSettings } from "../../../context/WorkspaceResourcesProvider";
-import { useDeleteJdbcProperties } from "../../../hooks/useJdbc";
 import type { CommandParam } from "../../../model/CommandParam";
-import JdbcUrlBuilderDialog from "../../settings/JdbcUrlBuilderDialog";
-import { RemoveResource } from "../../settings/ResourceEditButton";
-import ResourceDropDownMenu from "./ResourceDropDownMenu";
 import ResourceText from "./ResourceText";
 
 export default function JdbcTextField({
@@ -18,103 +10,12 @@ export default function JdbcTextField({
 	element: CommandParam;
 	onValueChange: (name: string, value: string) => void;
 }) {
-	const settings = useResourcesSettings();
-	const isJdbcUrl = element.name === "jdbcUrl";
-	const isJdbcProperties = element.name === "jdbcProperties";
-	const resourceFiles = isJdbcProperties ? settings.jdbcFiles : [];
-
-	const renderMenu = ({
-		path,
-		setPath,
-		isValueInDatalist,
-	}: {
-		path: string;
-		setPath: Dispatch<SetStateAction<string>>;
-		isValueInDatalist: boolean;
-	}) => {
-		const wrappedSetPath: Dispatch<SetStateAction<string>> = (action) => {
-			const newPath = typeof action === "function" ? action(path) : action;
-			setPath(newPath);
-			onValueChange(element.name, newPath);
-		};
-
-		if (isJdbcProperties) {
-			return (
-				<ResourceDropDownMenu
-					prefix={prefix}
-					element={element}
-					path={path}
-					setPath={wrappedSetPath}
-					isValueInDatalist={isValueInDatalist}
-					removeButton={(closeMenu) => (
-						<RemoveJdbcPropertiesButton
-							path={path}
-							setPath={(value) => {
-								wrappedSetPath(value);
-								closeMenu();
-							}}
-						/>
-					)}
-					className="mr-24"
-				/>
-			);
-		}
-		if (isJdbcUrl) {
-			return <JdbcUrlBuilderButton path={path} setPath={wrappedSetPath} />;
-		}
-		return <div className="w-36" />;
-	};
-
 	return (
 		<ResourceText
 			prefix={prefix}
 			element={element}
-			resourceFiles={resourceFiles}
+			resourceFiles={[]}
 			onValueChange={(value) => onValueChange(element.name, value)}
-		>
-			{renderMenu}
-		</ResourceText>
-	);
-}
-
-function JdbcUrlBuilderButton({
-	path,
-	setPath,
-}: {
-	path: string;
-	setPath: Dispatch<SetStateAction<string>>;
-}) {
-	const [showDialog, setShowDialog] = useState(false);
-	return (
-		<>
-			<BlueEditButton handleClick={() => setShowDialog(true)} />
-			{showDialog && (
-				<JdbcUrlBuilderDialog
-					currentUrl={path}
-					handleDialogClose={() => setShowDialog(false)}
-					handleSave={(url) => {
-						setPath(url);
-						setShowDialog(false);
-					}}
-				/>
-			)}
-		</>
-	);
-}
-
-function RemoveJdbcPropertiesButton({
-	path,
-	setPath,
-}: {
-	path: string;
-	setPath: (value: string) => void;
-}) {
-	const deleteJdbcProperties = useDeleteJdbcProperties();
-	return (
-		<RemoveResource
-			path={path}
-			setPath={setPath}
-			deleteResource={deleteJdbcProperties}
 		/>
 	);
 }

--- a/tauri/src/app/form/section/JdbcUrlTextField.tsx
+++ b/tauri/src/app/form/section/JdbcUrlTextField.tsx
@@ -1,0 +1,59 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import { BlueEditButton } from "../../../components/element/ButtonIcon";
+import type { CommandParam } from "../../../model/CommandParam";
+import JdbcUrlBuilderDialog from "../../settings/JdbcUrlBuilderDialog";
+import ResourceText from "./ResourceText";
+
+export default function JdbcUrlTextField({
+	prefix,
+	element,
+	onValueChange,
+}: {
+	prefix: string;
+	element: CommandParam;
+	onValueChange: (name: string, value: string) => void;
+}) {
+	return (
+		<ResourceText
+			prefix={prefix}
+			element={element}
+			resourceFiles={[]}
+			onValueChange={(value) => onValueChange(element.name, value)}
+		>
+			{({ path, setPath }) => {
+				const wrappedSetPath: Dispatch<SetStateAction<string>> = (action) => {
+					const newPath = typeof action === "function" ? action(path) : action;
+					setPath(newPath);
+					onValueChange(element.name, newPath);
+				};
+				return <JdbcUrlBuilderButton path={path} setPath={wrappedSetPath} />;
+			}}
+		</ResourceText>
+	);
+}
+
+function JdbcUrlBuilderButton({
+	path,
+	setPath,
+}: {
+	path: string;
+	setPath: Dispatch<SetStateAction<string>>;
+}) {
+	const [showDialog, setShowDialog] = useState(false);
+	return (
+		<>
+			<BlueEditButton handleClick={() => setShowDialog(true)} />
+			{showDialog && (
+				<JdbcUrlBuilderDialog
+					currentUrl={path}
+					handleDialogClose={() => setShowDialog(false)}
+					handleSave={(url) => {
+						setPath(url);
+						setShowDialog(false);
+					}}
+				/>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
## Summary
Refactored the monolithic `JdbcTextField` component into three specialized, single-purpose components to improve code organization, maintainability, and separation of concerns.

## Key Changes
- **Split `JdbcTextField` into three focused components:**
  - `JdbcTextField`: Generic resource text field (simplified, no JDBC-specific logic)
  - `JdbcUrlTextField`: Handles JDBC URL input with URL builder dialog functionality
  - `JdbcPropertiesTextField`: Handles JDBC properties file selection with resource management

- **Updated `JdbcFormSection`** to use the appropriate specialized component for each field type:
  - `JdbcUrlTextField` for the `jdbcUrl` field
  - `JdbcPropertiesTextField` for the `jdbcProperties` field
  - Generic `JdbcTextField` for other fields

## Implementation Details
- Each new component encapsulates its own state management and UI logic
- Removed conditional rendering logic from the generic `JdbcTextField` component
- Maintained all existing functionality including:
  - JDBC URL builder dialog for URL field
  - Resource dropdown menu for properties field
  - Resource deletion capabilities
- Improved code readability by eliminating nested conditionals and complex render functions

https://claude.ai/code/session_01EputpEKc1axs6ccRfngdeQ