### PR TITLE
Simplify TemplateFormSection by removing dynamic element rendering

### DIFF
--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -25,7 +25,6 @@ export function GenerateForm(prop: {
 					<legend>{prop.generate.templateOption.prefix}</legend>
 					<TemplateFormSection
 						commandParams={prop.generate.templateOption}
-						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 					/>
 				</fieldset>

--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -23,7 +23,6 @@ export function ParameterizeForm(prop: {
 				{templateOption && (
 					<TemplateFormSection
 						commandParams={templateOption}
-						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 					/>
 				)}

--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -29,7 +29,6 @@ export function RunForm(prop: {
 					<legend>template</legend>
 					<TemplateFormSection
 						commandParams={templateOption}
-						handleTypeSelect={prop.handleTypeSelect}
 						name={prop.name}
 					/>
 				</fieldset>

--- a/tauri/src/app/form/section/TemplateFormSection.tsx
+++ b/tauri/src/app/form/section/TemplateFormSection.tsx
@@ -1,45 +1,20 @@
-import type { CommandParam, TemplateOption } from "../../../model/CommandParam";
-import Check from "./CheckFormElement";
-import type { SelectProp } from "./FormElementProp";
-import Select from "./SelectFormElement";
+import type { TemplateOption } from "../../../model/CommandParam";
+import ResourceText from "./ResourceText";
 import TemplateText from "./TemplateText";
-
-function renderElement(
-	element: CommandParam,
-	prefix: string,
-	handleTypeSelect: SelectProp["handleTypeSelect"],
-): React.ReactNode {
-	if (element.attribute.type === "FLG") {
-		return <Check prefix={prefix} element={element} hidden={false} />;
-	}
-	if (element.attribute.type === "ENUM") {
-		return (
-			<Select
-				handleTypeSelect={handleTypeSelect}
-				prefix={prefix}
-				element={element}
-				hidden={false}
-			/>
-		);
-	}
-	return <TemplateText prefix={prefix} element={element} hidden={false} />;
-}
 
 export default function TemplateFormSection({
 	commandParams,
-	handleTypeSelect,
 }: {
 	commandParams: TemplateOption;
-	handleTypeSelect: SelectProp["handleTypeSelect"];
 	name: string;
 }) {
 	return (
 		<>
-			{renderElement(commandParams.encoding, commandParams.prefix, handleTypeSelect)}
-			{renderElement(commandParams.templateGroup, commandParams.prefix, handleTypeSelect)}
-			{renderElement(commandParams.templateParameterAttribute, commandParams.prefix, handleTypeSelect)}
-			{renderElement(commandParams.templateVarStart, commandParams.prefix, handleTypeSelect)}
-			{renderElement(commandParams.templateVarStop, commandParams.prefix, handleTypeSelect)}
+			<ResourceText prefix={commandParams.prefix} element={commandParams.encoding} hidden={false} />
+			<TemplateText prefix={commandParams.prefix} element={commandParams.templateGroup} hidden={false} />
+			<ResourceText prefix={commandParams.prefix} element={commandParams.templateParameterAttribute} hidden={false} />
+			<ResourceText prefix={commandParams.prefix} element={commandParams.templateVarStart} hidden={false} />
+			<ResourceText prefix={commandParams.prefix} element={commandParams.templateVarStop} hidden={false} />
 		</>
 	);
 }


### PR DESCRIPTION
## Summary
Refactored `TemplateFormSection` to use explicit component rendering instead of a dynamic `renderElement` function, removing the need for conditional type checking and the `handleTypeSelect` callback prop.

## Key Changes
- Removed the `renderElement` helper function that conditionally rendered `Check`, `Select`, or `TemplateText` components based on element type
- Replaced dynamic rendering with explicit component declarations for each template field
- Updated field rendering to use `ResourceText` component for encoding, templateParameterAttribute, templateVarStart, and templateVarStop
- Kept `TemplateText` component for the templateGroup field
- Removed `handleTypeSelect` prop from `TemplateFormSection` and all parent components (`GenerateForm`, `ParameterizeForm`, `RunForm`)
- Simplified the component's prop interface by removing the `handleTypeSelect` callback

## Implementation Details
The refactoring assumes that the template form fields no longer require dynamic type-based rendering logic. Each field now uses a specific component (`ResourceText` or `TemplateText`) rather than determining the component at runtime based on the element's type attribute. This makes the component structure more explicit and easier to understand at a glance.

https://claude.ai/code/session_01GZBksJbZUdDYdAJPpFBo8w