### PR TITLE
Refactor command parameter handling with typed element classes

### DIFF
--- a/tauri/src/app/form/CompareForm.tsx
+++ b/tauri/src/app/form/CompareForm.tsx
@@ -4,6 +4,7 @@ import type { CompareParams } from "../../model/SelectParameter";
 import CommandFormElements, {
 	buildDatasetSrcInfo,
 } from "./section/CommandFormElement";
+import ConvertResultFormSection from "./section/ConvertResultFormSection";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
 
 export function CompareForm(prop: {
@@ -98,11 +99,9 @@ export function CompareForm(prop: {
 			/>
 			<fieldset className="border border-gray-200 p-3">
 				<legend>{convertResult.prefix}</legend>
-				<CommandFormElements
+				<ConvertResultFormSection
+					convertResult={convertResult}
 					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
-					prefix={convertResult.prefix}
-					elements={convertResult.elements}
 				/>
 			</fieldset>
 			<DatasetLoadForm

--- a/tauri/src/app/form/ConvertForm.tsx
+++ b/tauri/src/app/form/ConvertForm.tsx
@@ -1,5 +1,5 @@
 import type { ConvertParams } from "../../model/SelectParameter";
-import CommandFormElements from "./section/CommandFormElement";
+import ConvertResultFormSection from "./section/ConvertResultFormSection";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
 
 export function ConvertForm(prop: {
@@ -18,17 +18,9 @@ export function ConvertForm(prop: {
 			/>
 			<fieldset className="border border-gray-200 p-3">
 				<legend>{convertResult.prefix}</legend>
-				<CommandFormElements
+				<ConvertResultFormSection
+					convertResult={convertResult}
 					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
-					prefix={convertResult.prefix}
-					elements={convertResult.elements}
-				/>
-				<CommandFormElements
-					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
-					prefix={convertResult.prefix}
-					elements={convertResult.jdbc ? convertResult.jdbc.elements : []}
 				/>
 			</fieldset>
 		</>

--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -1,7 +1,8 @@
 import type { GenerateParams } from "../../model/SelectParameter";
-import CommandFormElements from "./section/CommandFormElement";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
+import Select from "./section/Select";
 import TemplateFormSection from "./section/TemplateFormSection";
+import Text from "./section/TextFormElement";
 
 export function GenerateForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -9,16 +10,25 @@ export function GenerateForm(prop: {
 	generate: GenerateParams;
 }) {
 	const srcData = prop.generate.srcData;
+	const ce = prop.generate.commandElements;
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
 				<legend>generate</legend>
-				<CommandFormElements
+				<Select
 					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
 					prefix=""
-					elements={prop.generate.elements}
+					element={ce.generateType}
 				/>
+				<Select
+					handleTypeSelect={prop.handleTypeSelect}
+					prefix=""
+					element={ce.unit}
+				/>
+				<Text prefix="" element={ce.template} />
+				<Text prefix="" element={ce.result} />
+				<Text prefix="" element={ce.resultPath} />
+				<Text prefix="" element={ce.outputEncoding} />
 			</fieldset>
 			{prop.generate.templateOption && (
 				<fieldset className="border border-gray-200 p-3">

--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -1,7 +1,9 @@
 import type { ParameterizeParams } from "../../model/SelectParameter";
-import CommandFormElements from "./section/CommandFormElement";
+import Check from "./section/Check";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
+import Select from "./section/Select";
 import TemplateFormSection from "./section/TemplateFormSection";
+import Text from "./section/TextFormElement";
 
 export function ParameterizeForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -10,16 +12,21 @@ export function ParameterizeForm(prop: {
 }) {
 	const paramData = prop.parameterize.paramData;
 	const templateOption = prop.parameterize.templateOption;
+	const ce = prop.parameterize.commandElements;
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
 				<legend>execute</legend>
-				<CommandFormElements
+				<Select
 					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
 					prefix=""
-					elements={prop.parameterize.elements}
+					element={ce.unit}
 				/>
+				<Check prefix="" element={ce.parameterize} />
+				<Check prefix="" element={ce.ignoreFail} />
+				<Text prefix="" element={ce.cmd} />
+				<Text prefix="" element={ce.cmdParam} />
+				<Text prefix="" element={ce.template} />
 				{templateOption && (
 					<TemplateFormSection
 						commandParams={templateOption}

--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -1,8 +1,8 @@
 import { JdbcConnectionProvider } from "../../context/JdbcConnectionProvider";
 import type { RunParams } from "../../model/SelectParameter";
-import CommandFormElements from "./section/CommandFormElement";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
 import JdbcFormSection from "./section/JdbcFormSection";
+import Select from "./section/Select";
 import TemplateFormSection from "./section/TemplateFormSection";
 
 export function RunForm(prop: {
@@ -13,15 +13,15 @@ export function RunForm(prop: {
 	const srcData = prop.run.srcData;
 	const templateOption = prop.run.templateOption;
 	const jdbcOption = prop.run.jdbcOption;
+	const ce = prop.run.commandElements;
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
 				<legend>run</legend>
-				<CommandFormElements
+				<Select
 					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
 					prefix=""
-					elements={prop.run.elements}
+					element={ce.scriptType}
 				/>
 			</fieldset>
 			{prop.run.templateOption && (

--- a/tauri/src/app/form/section/ConvertResultFormSection.tsx
+++ b/tauri/src/app/form/section/ConvertResultFormSection.tsx
@@ -1,0 +1,36 @@
+import type { ConvertResult } from "../../../model/CommandParam";
+import Check from "./Check";
+import Select from "./Select";
+import Text from "./TextFormElement";
+
+export default function ConvertResultFormSection({
+	convertResult,
+	handleTypeSelect,
+}: {
+	convertResult: ConvertResult;
+	handleTypeSelect: (selected: string) => Promise<void>;
+}) {
+	const prefix = convertResult.prefix;
+	return (
+		<>
+			<Select
+				handleTypeSelect={handleTypeSelect}
+				prefix={prefix}
+				element={convertResult.resultType}
+			/>
+			<Text prefix={prefix} element={convertResult.result} />
+			<Text prefix={prefix} element={convertResult.resultPath} />
+			<Check prefix={prefix} element={convertResult.exportEmptyTable} />
+			<Check prefix={prefix} element={convertResult.exportHeader} />
+			<Text prefix={prefix} element={convertResult.outputEncoding} />
+			{convertResult.jdbc && (
+				<>
+					<Text prefix={prefix} element={convertResult.jdbc.jdbcProperties} />
+					<Text prefix={prefix} element={convertResult.jdbc.jdbcUrl} />
+					<Text prefix={prefix} element={convertResult.jdbc.jdbcUser} />
+					<Text prefix={prefix} element={convertResult.jdbc.jdbcPass} />
+				</>
+			)}
+		</>
+	);
+}

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -350,6 +350,57 @@ export class ParameterizeElementsImpl implements ParameterizeElements {
 		return findByName(this.elements, "template");
 	}
 }
+export type ConvertResult = CommandParams & {
+	resultType: CommandParam;
+	result: CommandParam;
+	resultPath: CommandParam;
+	exportEmptyTable: CommandParam;
+	exportHeader: CommandParam;
+	outputEncoding: CommandParam;
+	jdbc?: JdbcOption;
+};
+export class ConvertResultImpl implements ConvertResult {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	private readonly _jdbc?: JdbcOption;
+	constructor(
+		name: string,
+		prefix: string,
+		elements: CommandParam[],
+		rawJdbc?: { prefix: string; elements: CommandParam[] },
+	) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+		this._jdbc = rawJdbc
+			? new JdbcOptionImpl(rawJdbc.prefix, rawJdbc.prefix, rawJdbc.elements)
+			: undefined;
+	}
+	get resultType(): CommandParam {
+		return findByName(this.elements, "resultType");
+	}
+	get result(): CommandParam {
+		return findByName(this.elements, "result");
+	}
+	get resultPath(): CommandParam {
+		return findByName(this.elements, "resultPath");
+	}
+	get exportEmptyTable(): CommandParam {
+		return findByName(this.elements, "exportEmptyTable");
+	}
+	get exportHeader(): CommandParam {
+		return findByName(this.elements, "exportHeader");
+	}
+	get outputEncoding(): CommandParam {
+		return findByName(this.elements, "outputEncoding");
+	}
+	get jdbc(): JdbcOption | undefined {
+		return this._jdbc;
+	}
+}
 export type TemplateOption = CommandParams & {
 	encoding: CommandParam;
 	templateGroup: CommandParam;

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -256,6 +256,100 @@ export class JdbcOptionImpl implements JdbcOption {
 		return findByName(this.elements, "jdbcPass");
 	}
 }
+export type GenerateElements = CommandParams & {
+	generateType: CommandParam;
+	unit: CommandParam;
+	template: CommandParam;
+	result: CommandParam;
+	resultPath: CommandParam;
+	outputEncoding: CommandParam;
+};
+export class GenerateElementsImpl implements GenerateElements {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(name: string, prefix: string, elements: CommandParam[]) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+	}
+	get generateType(): CommandParam {
+		return findByName(this.elements, "generateType");
+	}
+	get unit(): CommandParam {
+		return findByName(this.elements, "unit");
+	}
+	get template(): CommandParam {
+		return findByName(this.elements, "template");
+	}
+	get result(): CommandParam {
+		return findByName(this.elements, "result");
+	}
+	get resultPath(): CommandParam {
+		return findByName(this.elements, "resultPath");
+	}
+	get outputEncoding(): CommandParam {
+		return findByName(this.elements, "outputEncoding");
+	}
+}
+export type RunElements = CommandParams & {
+	scriptType: CommandParam;
+};
+export class RunElementsImpl implements RunElements {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(name: string, prefix: string, elements: CommandParam[]) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+	}
+	get scriptType(): CommandParam {
+		return findByName(this.elements, "scriptType");
+	}
+}
+export type ParameterizeElements = CommandParams & {
+	unit: CommandParam;
+	parameterize: CommandParam;
+	ignoreFail: CommandParam;
+	cmd: CommandParam;
+	cmdParam: CommandParam;
+	template: CommandParam;
+};
+export class ParameterizeElementsImpl implements ParameterizeElements {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(name: string, prefix: string, elements: CommandParam[]) {
+		this.name = name;
+		this.prefix = prefix;
+		this.elements = elements;
+	}
+	get unit(): CommandParam {
+		return findByName(this.elements, "unit");
+	}
+	get parameterize(): CommandParam {
+		return findByName(this.elements, "parameterize");
+	}
+	get ignoreFail(): CommandParam {
+		return findByName(this.elements, "ignoreFail");
+	}
+	get cmd(): CommandParam {
+		return findByName(this.elements, "cmd");
+	}
+	get cmdParam(): CommandParam {
+		return findByName(this.elements, "cmdParam");
+	}
+	get template(): CommandParam {
+		return findByName(this.elements, "template");
+	}
+}
 export type TemplateOption = CommandParams & {
 	encoding: CommandParam;
 	templateGroup: CommandParam;

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -365,7 +365,7 @@ export class ConvertResultImpl implements ConvertResult {
 	elements: CommandParam[];
 	optionCaption?: { caption: string };
 	optional?: (_: string) => boolean;
-	private readonly _jdbc?: JdbcOption;
+	readonly jdbc?: JdbcOption;
 	constructor(
 		name: string,
 		prefix: string,
@@ -375,7 +375,7 @@ export class ConvertResultImpl implements ConvertResult {
 		this.name = name;
 		this.prefix = prefix;
 		this.elements = elements;
-		this._jdbc = rawJdbc
+		this.jdbc = rawJdbc
 			? new JdbcOptionImpl(rawJdbc.prefix, rawJdbc.prefix, rawJdbc.elements)
 			: undefined;
 	}
@@ -396,9 +396,6 @@ export class ConvertResultImpl implements ConvertResult {
 	}
 	get outputEncoding(): CommandParam {
 		return findByName(this.elements, "outputEncoding");
-	}
-	get jdbc(): JdbcOption | undefined {
-		return this._jdbc;
 	}
 }
 export type TemplateOption = CommandParams & {

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -2,12 +2,18 @@ import type {
 	CommandParam,
 	CommandParams,
 	DatasetSource,
+	GenerateElements,
 	JdbcOption,
+	ParameterizeElements,
+	RunElements,
 	TemplateOption,
 } from "./CommandParam";
 import {
 	DatasetSourceImpl,
+	GenerateElementsImpl,
 	JdbcOptionImpl,
+	ParameterizeElementsImpl,
+	RunElementsImpl,
 	TemplateOptionImpl,
 } from "./CommandParam";
 
@@ -50,56 +56,86 @@ export class SelectParameter {
 			);
 		}
 		if (command === "generate") {
-			this.generate = response as GenerateParams;
-			this.generate.srcData = new DatasetSourceImpl(
-				this.generate.srcData.name,
-				this.generate.srcData.prefix,
-				this.generate.srcData.elements,
-			);
-			if (this.generate.templateOption) {
-				this.generate.templateOption = new TemplateOptionImpl(
-					this.generate.templateOption.prefix,
-					this.generate.templateOption.prefix,
-					this.generate.templateOption.elements,
-				);
-			}
+			const rawGenerate = response as {
+				elements: CommandParam[];
+				srcData: DatasetSource;
+				templateOption?: TemplateOption;
+			};
+			this.generate = {
+				commandElements: new GenerateElementsImpl(
+					"generate",
+					"",
+					rawGenerate.elements,
+				),
+				srcData: new DatasetSourceImpl(
+					rawGenerate.srcData.name,
+					rawGenerate.srcData.prefix,
+					rawGenerate.srcData.elements,
+				),
+				templateOption: rawGenerate.templateOption
+					? new TemplateOptionImpl(
+							rawGenerate.templateOption.prefix,
+							rawGenerate.templateOption.prefix,
+							rawGenerate.templateOption.elements,
+						)
+					: undefined,
+			};
 		}
 		if (command === "run") {
-			this.run = response as RunParams;
-			this.run.srcData = new DatasetSourceImpl(
-				this.run.srcData.name,
-				this.run.srcData.prefix,
-				this.run.srcData.elements,
-			);
-			if (this.run.templateOption) {
-				this.run.templateOption = new TemplateOptionImpl(
-					this.run.templateOption.prefix,
-					this.run.templateOption.prefix,
-					this.run.templateOption.elements,
-				);
-			}
-			if (this.run.jdbcOption) {
-				this.run.jdbcOption = new JdbcOptionImpl(
-					this.run.jdbcOption.prefix,
-					this.run.jdbcOption.prefix,
-					this.run.jdbcOption.elements,
-				);
-			}
+			const rawRun = response as {
+				elements: CommandParam[];
+				srcData: DatasetSource;
+				templateOption?: TemplateOption;
+				jdbcOption?: JdbcOption;
+			};
+			this.run = {
+				commandElements: new RunElementsImpl("run", "", rawRun.elements),
+				srcData: new DatasetSourceImpl(
+					rawRun.srcData.name,
+					rawRun.srcData.prefix,
+					rawRun.srcData.elements,
+				),
+				templateOption: rawRun.templateOption
+					? new TemplateOptionImpl(
+							rawRun.templateOption.prefix,
+							rawRun.templateOption.prefix,
+							rawRun.templateOption.elements,
+						)
+					: undefined,
+				jdbcOption: rawRun.jdbcOption
+					? new JdbcOptionImpl(
+							rawRun.jdbcOption.prefix,
+							rawRun.jdbcOption.prefix,
+							rawRun.jdbcOption.elements,
+						)
+					: undefined,
+			};
 		}
 		if (command === "parameterize") {
-			this.parameterize = response as ParameterizeParams;
-			this.parameterize.paramData = new DatasetSourceImpl(
-				this.parameterize.paramData.name,
-				this.parameterize.paramData.prefix,
-				this.parameterize.paramData.elements,
-			);
-			if (this.parameterize.templateOption) {
-				this.parameterize.templateOption = new TemplateOptionImpl(
-					this.parameterize.templateOption.prefix,
-					this.parameterize.templateOption.prefix,
-					this.parameterize.templateOption.elements,
-				);
-			}
+			const rawParameterize = response as {
+				elements: CommandParam[];
+				paramData: DatasetSource;
+				templateOption?: TemplateOption;
+			};
+			this.parameterize = {
+				commandElements: new ParameterizeElementsImpl(
+					"parameterize",
+					"",
+					rawParameterize.elements,
+				),
+				paramData: new DatasetSourceImpl(
+					rawParameterize.paramData.name,
+					rawParameterize.paramData.prefix,
+					rawParameterize.paramData.elements,
+				),
+				templateOption: rawParameterize.templateOption
+					? new TemplateOptionImpl(
+							rawParameterize.templateOption.prefix,
+							rawParameterize.templateOption.prefix,
+							rawParameterize.templateOption.elements,
+						)
+					: undefined,
+			};
 		}
 	}
 	currentParameter() {
@@ -140,18 +176,18 @@ export type CompareParams = {
 	expectData: DatasetSource;
 };
 export type GenerateParams = {
-	elements: CommandParam[];
+	commandElements: GenerateElements;
 	srcData: DatasetSource;
-	templateOption: TemplateOption;
+	templateOption?: TemplateOption;
 };
 export type RunParams = {
-	elements: CommandParam[];
+	commandElements: RunElements;
 	srcData: DatasetSource;
-	templateOption: TemplateOption;
-	jdbcOption: JdbcOption;
+	templateOption?: TemplateOption;
+	jdbcOption?: JdbcOption;
 };
 export type ParameterizeParams = {
-	elements: CommandParam[];
+	commandElements: ParameterizeElements;
 	paramData: DatasetSource;
-	templateOption: TemplateOption;
+	templateOption?: TemplateOption;
 };

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -1,6 +1,7 @@
 import type {
 	CommandParam,
 	CommandParams,
+	ConvertResult,
 	DatasetSource,
 	GenerateElements,
 	JdbcOption,
@@ -9,6 +10,7 @@ import type {
 	TemplateOption,
 } from "./CommandParam";
 import {
+	ConvertResultImpl,
 	DatasetSourceImpl,
 	GenerateElementsImpl,
 	JdbcOptionImpl,
@@ -30,30 +32,62 @@ export class SelectParameter {
 		this.name = name;
 		this.command = command;
 		if (command === "convert") {
-			this.convert = response as ConvertParams;
-			this.convert.srcData = new DatasetSourceImpl(
-				this.convert.srcData.name,
-				this.convert.srcData.prefix,
-				this.convert.srcData.elements,
-			);
+			const rawConvert = response as {
+				srcData: DatasetSource;
+				convertResult: {
+					prefix: string;
+					elements: CommandParam[];
+					jdbc?: { prefix: string; elements: CommandParam[] };
+				};
+			};
+			this.convert = {
+				srcData: new DatasetSourceImpl(
+					rawConvert.srcData.name,
+					rawConvert.srcData.prefix,
+					rawConvert.srcData.elements,
+				),
+				convertResult: new ConvertResultImpl(
+					rawConvert.convertResult.prefix,
+					rawConvert.convertResult.prefix,
+					rawConvert.convertResult.elements,
+					rawConvert.convertResult.jdbc,
+				),
+			};
 		}
 		if (command === "compare") {
-			this.compare = response as CompareParams;
-			this.compare.newData = new DatasetSourceImpl(
-				this.compare.newData.name,
-				this.compare.newData.prefix,
-				this.compare.newData.elements,
-			);
-			this.compare.oldData = new DatasetSourceImpl(
-				this.compare.oldData.name,
-				this.compare.oldData.prefix,
-				this.compare.oldData.elements,
-			);
-			this.compare.expectData = new DatasetSourceImpl(
-				this.compare.expectData.name,
-				this.compare.expectData.prefix,
-				this.compare.expectData.elements,
-			);
+			const rawCompare = response as {
+				elements: CommandParam[];
+				newData: DatasetSource;
+				oldData: DatasetSource;
+				imageOption: CommandParams;
+				convertResult: { prefix: string; elements: CommandParam[] };
+				expectData: DatasetSource;
+			};
+			this.compare = {
+				elements: rawCompare.elements,
+				newData: new DatasetSourceImpl(
+					rawCompare.newData.name,
+					rawCompare.newData.prefix,
+					rawCompare.newData.elements,
+				),
+				oldData: new DatasetSourceImpl(
+					rawCompare.oldData.name,
+					rawCompare.oldData.prefix,
+					rawCompare.oldData.elements,
+				),
+				imageOption: rawCompare.imageOption,
+				convertResult: new ConvertResultImpl(
+					rawCompare.convertResult.prefix,
+					rawCompare.convertResult.prefix,
+					rawCompare.convertResult.elements,
+					undefined,
+				),
+				expectData: new DatasetSourceImpl(
+					rawCompare.expectData.name,
+					rawCompare.expectData.prefix,
+					rawCompare.expectData.elements,
+				),
+			};
 		}
 		if (command === "generate") {
 			const rawGenerate = response as {
@@ -154,9 +188,6 @@ export class SelectParameter {
 		return this.parameterize;
 	}
 }
-export type ConvertResult = CommandParams & {
-	jdbc: CommandParams;
-};
 export type Parameter =
 	| ConvertParams
 	| CompareParams


### PR DESCRIPTION
## Summary
This PR refactors the command parameter handling in SelectParameter to use dedicated typed element classes (`GenerateElements`, `RunElements`, `ParameterizeElements`, `ConvertResult`) instead of generic arrays. This improves type safety and provides better IDE support through typed property accessors.

## Key Changes

- **New typed element classes in CommandParam.ts:**
  - `GenerateElementsImpl`: Provides typed accessors for generate command parameters (generateType, unit, template, result, resultPath, outputEncoding)
  - `RunElementsImpl`: Provides typed accessor for scriptType parameter
  - `ParameterizeElementsImpl`: Provides typed accessors for parameterize command parameters (unit, parameterize, ignoreFail, cmd, cmdParam, template)
  - `ConvertResultImpl`: Provides typed accessors for convert result parameters with optional JDBC configuration

- **Updated SelectParameter.ts:**
  - Refactored response parsing for all commands (convert, compare, generate, run, parameterize) to instantiate the new typed element classes
  - Changed `GenerateParams`, `RunParams`, and `ParameterizeParams` to use `commandElements` property with their respective typed classes instead of generic `elements` array
  - Made `templateOption` and `jdbcOption` optional in their respective parameter types
  - Moved `ConvertResult` type definition from SelectParameter.ts to CommandParam.ts

- **Updated form components:**
  - `GenerateForm.tsx`: Replaced generic `CommandFormElements` with individual `Select` and `Text` components using typed accessors
  - `RunForm.tsx`: Replaced generic element handling with typed `Select` component for scriptType
  - `ParameterizeForm.tsx`: Replaced generic element handling with individual `Select`, `Check`, and `Text` components using typed accessors
  - `ConvertForm.tsx` and `CompareForm.tsx`: Introduced new `ConvertResultFormSection` component to handle convert result rendering
  - Created new `ConvertResultFormSection.tsx` component for rendering convert result parameters with optional JDBC fields

## Implementation Details

- All new element classes follow the same pattern: storing name, prefix, and elements array, with typed getter methods that use `findByName()` to locate specific parameters
- The refactoring maintains backward compatibility with the response structure while providing better type safety at the component level
- Optional parameters are now properly typed as optional in the parameter type definitions

https://claude.ai/code/session_01NfUavUmbDQq9Z76wFVvt3N