### PR TITLE
Refactor dataset command form sections by data source type

### DIFF
--- a/tauri/src/app/form/section/CsvFormSection.tsx
+++ b/tauri/src/app/form/section/CsvFormSection.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { CsvTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+
+export default function CsvFormSection({
+	settings,
+}: {
+	settings: CsvTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="csv option"
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.startRow}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.delimiter}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.ignoreQuoted}
+				hidden={!showOptional}
+			/>
+		</>
+	);
+}

--- a/tauri/src/app/form/section/CsvqFormSection.tsx
+++ b/tauri/src/app/form/section/CsvqFormSection.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { CsvqTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+import TemplateText from "./TemplateText";
+
+export default function CsvqFormSection({
+	settings,
+}: {
+	settings: CsvqTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="csvq option"
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.encoding}
+				hidden={false}
+			/>
+			<TemplateText
+				prefix={prefix}
+				element={settings.templateGroup}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateParameterAttribute}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateVarStart}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateVarStop}
+				hidden={!showOptional}
+			/>
+		</>
+	);
+}

--- a/tauri/src/app/form/section/DatasetCommandFormSection.tsx
+++ b/tauri/src/app/form/section/DatasetCommandFormSection.tsx
@@ -1,29 +1,63 @@
-import type { ComponentType } from "react";
+import { useDatasetSrcInfo } from "../../../context/DatasetSrcInfoProvider";
 import type { CommandParams } from "../../../model/CommandParam";
-import CommandFormElements from "./CommandFormElement";
-import DatasetText from "./DatasetTextFormElement";
-import type { Prop } from "./FormElementProp";
+import {
+	CsvqTypeSettingsImpl,
+	CsvTypeSettingsImpl,
+	FixedTypeSettingsImpl,
+	RegTypeSettingsImpl,
+	TableSqlTypeSettingsImpl,
+	XlsTypeSettingsImpl,
+} from "../../../model/CommandParam";
+import CsvFormSection from "./CsvFormSection";
+import CsvqFormSection from "./CsvqFormSection";
+import FixedFormSection from "./FixedFormSection";
+import RegFormSection from "./RegFormSection";
+import TableSqlFormSection from "./TableSqlFormSection";
+import XlsFormSection from "./XlsFormSection";
 
 export default function DatasetCommandFormSection({
 	commandParams,
-	handleTypeSelect,
-	name,
-	textComponent,
 }: {
 	commandParams: CommandParams;
-	handleTypeSelect: (selected: string) => Promise<void>;
-	name: string;
-	textComponent?: ComponentType<Prop>;
 }) {
-	return (
-		<CommandFormElements
-			handleTypeSelect={handleTypeSelect}
-			prefix={commandParams.prefix}
-			name={name}
-			elements={commandParams.elements}
-			optionCaption={commandParams.optionCaption}
-			optional={commandParams.optional}
-			textComponent={textComponent ?? DatasetText}
-		/>
-	);
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const srcType = datasetSrcInfo?.srcType ?? "";
+
+	if (srcType === "csv") {
+		return <CsvFormSection settings={new CsvTypeSettingsImpl(commandParams)} />;
+	}
+	if (srcType === "csvq") {
+		return (
+			<CsvqFormSection settings={new CsvqTypeSettingsImpl(commandParams)} />
+		);
+	}
+	if (srcType === "table") {
+		return (
+			<TableSqlFormSection
+				settings={new TableSqlTypeSettingsImpl(commandParams)}
+			/>
+		);
+	}
+	if (srcType === "sql") {
+		return (
+			<TableSqlFormSection
+				settings={new TableSqlTypeSettingsImpl(commandParams)}
+			/>
+		);
+	}
+	if (srcType === "reg") {
+		return <RegFormSection settings={new RegTypeSettingsImpl(commandParams)} />;
+	}
+	if (srcType === "fixed") {
+		return (
+			<FixedFormSection settings={new FixedTypeSettingsImpl(commandParams)} />
+		);
+	}
+	if (srcType === "xls") {
+		return <XlsFormSection settings={new XlsTypeSettingsImpl(commandParams)} />;
+	}
+	if (srcType === "xlsx") {
+		return <XlsFormSection settings={new XlsTypeSettingsImpl(commandParams)} />;
+	}
+	return null;
 }

--- a/tauri/src/app/form/section/DatasetCommandFormSection.tsx
+++ b/tauri/src/app/form/section/DatasetCommandFormSection.tsx
@@ -31,14 +31,7 @@ export default function DatasetCommandFormSection({
 			<CsvqFormSection settings={new CsvqTypeSettingsImpl(commandParams)} />
 		);
 	}
-	if (srcType === "table") {
-		return (
-			<TableSqlFormSection
-				settings={new TableSqlTypeSettingsImpl(commandParams)}
-			/>
-		);
-	}
-	if (srcType === "sql") {
+	if (srcType === "table" || srcType === "sql") {
 		return (
 			<TableSqlFormSection
 				settings={new TableSqlTypeSettingsImpl(commandParams)}
@@ -53,10 +46,7 @@ export default function DatasetCommandFormSection({
 			<FixedFormSection settings={new FixedTypeSettingsImpl(commandParams)} />
 		);
 	}
-	if (srcType === "xls") {
-		return <XlsFormSection settings={new XlsTypeSettingsImpl(commandParams)} />;
-	}
-	if (srcType === "xlsx") {
+	if (srcType === "xls" || srcType === "xlsx") {
 		return <XlsFormSection settings={new XlsTypeSettingsImpl(commandParams)} />;
 	}
 	return null;

--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -43,11 +43,7 @@ export function DatasetLoadForm(prop: {
 				{jdbcOption.elements.length > 0 && (
 					<JdbcFormSection jdbcOption={jdbcOption} />
 				)}
-				<DatasetCommandFormSection
-					commandParams={srcTypeSettings}
-					handleTypeSelect={prop.handleTypeSelect}
-					name={prop.name}
-				/>
+				<DatasetCommandFormSection commandParams={srcTypeSettings} />
 				<DatasetSettingSection settingElements={settingElements} />
 			</fieldset>
 		</DatasetSrcInfoProvider>

--- a/tauri/src/app/form/section/FixedFormSection.tsx
+++ b/tauri/src/app/form/section/FixedFormSection.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { FixedTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+
+export default function FixedFormSection({
+	settings,
+}: {
+	settings: FixedTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="fixed option"
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.startRow}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.fixedLength}
+				hidden={false}
+			/>
+		</>
+	);
+}

--- a/tauri/src/app/form/section/RegFormSection.tsx
+++ b/tauri/src/app/form/section/RegFormSection.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { RegTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+
+export default function RegFormSection({
+	settings,
+}: {
+	settings: RegTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="reg option"
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.startRow}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.regDataSplit}
+				hidden={false}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.regHeaderSplit}
+				hidden={false}
+			/>
+		</>
+	);
+}

--- a/tauri/src/app/form/section/TableSqlFormSection.tsx
+++ b/tauri/src/app/form/section/TableSqlFormSection.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { TableSqlTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+import TemplateText from "./TemplateText";
+
+export default function TableSqlFormSection({
+	settings,
+}: {
+	settings: TableSqlTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption={settings.optionCaption?.caption}
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.useJdbcMetaData}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.encoding}
+				hidden={false}
+			/>
+			<TemplateText
+				prefix={prefix}
+				element={settings.templateGroup}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateParameterAttribute}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateVarStart}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.templateVarStop}
+				hidden={!showOptional}
+			/>
+		</>
+	);
+}

--- a/tauri/src/app/form/section/XlsFormSection.tsx
+++ b/tauri/src/app/form/section/XlsFormSection.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { XlsTypeSettings } from "../../../model/CommandParam";
+import Check from "./Check";
+import { DatasetPlainText } from "./DatasetTextFormElement";
+import XlsxSchemaText from "./XlsxSchemaText";
+
+export default function XlsFormSection({
+	settings,
+}: {
+	settings: XlsTypeSettings;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	const prefix = settings.prefix;
+
+	return (
+		<>
+			<div className="pt-2.5">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption={settings.optionCaption?.caption}
+				/>
+			</div>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.headerName}
+				hidden={!showOptional}
+			/>
+			<DatasetPlainText
+				prefix={prefix}
+				element={settings.startRow}
+				hidden={!showOptional}
+			/>
+			<Check
+				prefix={prefix}
+				element={settings.addFileInfo}
+				hidden={!showOptional}
+			/>
+			<XlsxSchemaText
+				prefix={prefix}
+				element={settings.xlsxSchema}
+				hidden={!showOptional}
+			/>
+		</>
+	);
+}

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -513,3 +513,237 @@ function toCommandParams(
 		optional: optional,
 	};
 }
+
+export type CsvTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	startRow: CommandParam;
+	addFileInfo: CommandParam;
+	delimiter: CommandParam;
+	ignoreQuoted: CommandParam;
+};
+export class CsvTypeSettingsImpl implements CsvTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get startRow(): CommandParam {
+		return findByName(this.elements, "startRow");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get delimiter(): CommandParam {
+		return findByName(this.elements, "delimiter");
+	}
+	get ignoreQuoted(): CommandParam {
+		return findByName(this.elements, "ignoreQuoted");
+	}
+}
+
+export type CsvqTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	addFileInfo: CommandParam;
+	encoding: CommandParam;
+	templateGroup: CommandParam;
+	templateParameterAttribute: CommandParam;
+	templateVarStart: CommandParam;
+	templateVarStop: CommandParam;
+};
+export class CsvqTypeSettingsImpl implements CsvqTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get encoding(): CommandParam {
+		return findByName(this.elements, "encoding");
+	}
+	get templateGroup(): CommandParam {
+		return findByName(this.elements, "templateGroup");
+	}
+	get templateParameterAttribute(): CommandParam {
+		return findByName(this.elements, "templateParameterAttribute");
+	}
+	get templateVarStart(): CommandParam {
+		return findByName(this.elements, "templateVarStart");
+	}
+	get templateVarStop(): CommandParam {
+		return findByName(this.elements, "templateVarStop");
+	}
+}
+
+export type TableSqlTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	addFileInfo: CommandParam;
+	useJdbcMetaData: CommandParam;
+	encoding: CommandParam;
+	templateGroup: CommandParam;
+	templateParameterAttribute: CommandParam;
+	templateVarStart: CommandParam;
+	templateVarStop: CommandParam;
+};
+export class TableSqlTypeSettingsImpl implements TableSqlTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get useJdbcMetaData(): CommandParam {
+		return findByName(this.elements, "useJdbcMetaData");
+	}
+	get encoding(): CommandParam {
+		return findByName(this.elements, "encoding");
+	}
+	get templateGroup(): CommandParam {
+		return findByName(this.elements, "templateGroup");
+	}
+	get templateParameterAttribute(): CommandParam {
+		return findByName(this.elements, "templateParameterAttribute");
+	}
+	get templateVarStart(): CommandParam {
+		return findByName(this.elements, "templateVarStart");
+	}
+	get templateVarStop(): CommandParam {
+		return findByName(this.elements, "templateVarStop");
+	}
+}
+
+export type RegTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	startRow: CommandParam;
+	addFileInfo: CommandParam;
+	regDataSplit: CommandParam;
+	regHeaderSplit: CommandParam;
+};
+export class RegTypeSettingsImpl implements RegTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get startRow(): CommandParam {
+		return findByName(this.elements, "startRow");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get regDataSplit(): CommandParam {
+		return findByName(this.elements, "regDataSplit");
+	}
+	get regHeaderSplit(): CommandParam {
+		return findByName(this.elements, "regHeaderSplit");
+	}
+}
+
+export type FixedTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	startRow: CommandParam;
+	addFileInfo: CommandParam;
+	fixedLength: CommandParam;
+};
+export class FixedTypeSettingsImpl implements FixedTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get startRow(): CommandParam {
+		return findByName(this.elements, "startRow");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get fixedLength(): CommandParam {
+		return findByName(this.elements, "fixedLength");
+	}
+}
+
+export type XlsTypeSettings = CommandParams & {
+	headerName: CommandParam;
+	startRow: CommandParam;
+	addFileInfo: CommandParam;
+	xlsxSchema: CommandParam;
+};
+export class XlsTypeSettingsImpl implements XlsTypeSettings {
+	name: string;
+	prefix: string;
+	elements: CommandParam[];
+	optionCaption?: { caption: string };
+	optional?: (_: string) => boolean;
+	constructor(params: CommandParams) {
+		this.name = params.name;
+		this.prefix = params.prefix;
+		this.elements = params.elements;
+		this.optionCaption = params.optionCaption;
+		this.optional = params.optional;
+	}
+	get headerName(): CommandParam {
+		return findByName(this.elements, "headerName");
+	}
+	get startRow(): CommandParam {
+		return findByName(this.elements, "startRow");
+	}
+	get addFileInfo(): CommandParam {
+		return findByName(this.elements, "addFileInfo");
+	}
+	get xlsxSchema(): CommandParam {
+		return findByName(this.elements, "xlsxSchema");
+	}
+}


### PR DESCRIPTION
## Summary
Refactored the dataset command form rendering to be type-specific by introducing dedicated form section components for each data source type (CSV, CSVQ, Table/SQL, Reg, Fixed, XLS/XLSX). This replaces the generic command form element approach with specialized UI components that handle type-specific settings and optional field visibility.

## Key Changes

- **Added type-specific settings classes** in `CommandParam.ts`:
  - `CsvTypeSettings` / `CsvTypeSettingsImpl`
  - `CsvqTypeSettings` / `CsvqTypeSettingsImpl`
  - `TableSqlTypeSettings` / `TableSqlTypeSettingsImpl`
  - `RegTypeSettings` / `RegTypeSettingsImpl`
  - `FixedTypeSettings` / `FixedTypeSettingsImpl`
  - `XlsTypeSettings` / `XlsTypeSettingsImpl`
  
  Each type extends `CommandParams` and provides typed getters for accessing specific command parameters via the `findByName` utility.

- **Created dedicated form section components**:
  - `CsvFormSection.tsx` - Handles CSV-specific options (headerName, startRow, delimiter, ignoreQuoted, addFileInfo)
  - `CsvqFormSection.tsx` - Handles CSVQ-specific options with template settings
  - `TableSqlFormSection.tsx` - Handles Table/SQL options with JDBC metadata and template settings
  - `RegFormSection.tsx` - Handles regex-based parsing options
  - `FixedFormSection.tsx` - Handles fixed-length format options
  - `XlsFormSection.tsx` - Handles Excel format options with schema support

- **Refactored `DatasetCommandFormSection.tsx`**:
  - Now uses `useDatasetSrcInfo` hook to determine the data source type
  - Routes to the appropriate form section component based on `srcType`
  - Removed generic `CommandFormElements` approach in favor of type-specific rendering
  - Removed unused props (`handleTypeSelect`, `name`, `textComponent`)

- **Updated `DatasetLoadForm.tsx`**:
  - Simplified `DatasetCommandFormSection` call by removing unused props

## Implementation Details

- Each form section component manages its own `showOptional` state to toggle visibility of optional fields
- Uses `ExpandButton` component to provide a consistent UI for expanding/collapsing optional settings
- Settings classes use lazy property getters that call `findByName` to locate parameters by name from the elements array
- Form sections use existing form element components (`DatasetPlainText`, `Check`, `TemplateText`, `XlsxSchemaText`) for consistent styling and behavior

https://claude.ai/code/session_015P7fdnNnVxfwcq43o2qQBY