### PR TITLE
Add ImageOption type and refactor image comparison parameters

### DIFF
--- a/tauri/src/app/form/section/ImageOptionFormSection.tsx
+++ b/tauri/src/app/form/section/ImageOptionFormSection.tsx
@@ -1,51 +1,30 @@
-import type { CommandParams } from "../../../model/CommandParam";
+import type { ImageOption } from "../../../model/CommandParam";
 import Check from "./element/Check";
 import Text from "./element/TextFormElement";
 
 export default function ImageOptionFormSection({
 	imageOption,
 }: {
-	imageOption: CommandParams;
+	imageOption: ImageOption;
 }) {
 	const prefix = imageOption.prefix;
 
-	const threshold = imageOption.find("threshold");
-	const pixelToleranceLevel = imageOption.find("pixelToleranceLevel");
-	const allowingPercentOfDifferentPixels = imageOption.find(
-		"allowingPercentOfDifferentPixels",
-	);
-	const rectangleLineWidth = imageOption.find("rectangleLineWidth");
-	const minimalRectangleSize = imageOption.find("minimalRectangleSize");
-	const maximalRectangleCount = imageOption.find("maximalRectangleCount");
-	const excludedAreas = imageOption.find("excludedAreas");
-	const drawExcludedRectangles = imageOption.find("drawExcludedRectangles");
-	const fillExcludedRectangles = imageOption.find("fillExcludedRectangles");
-	const percentOpacityExcludedRectangles = imageOption.find(
-		"percentOpacityExcludedRectangles",
-	);
-	const excludedRectangleColor = imageOption.find("excludedRectangleColor");
-	const fillDifferenceRectangles = imageOption.find("fillDifferenceRectangles");
-	const percentOpacityDifferenceRectangles = imageOption.find(
-		"percentOpacityDifferenceRectangles",
-	);
-	const differenceRectangleColor = imageOption.find("differenceRectangleColor");
-
 	return (
 		<>
-			<Text prefix={prefix} element={threshold} />
-			<Text prefix={prefix} element={pixelToleranceLevel} />
-			<Text prefix={prefix} element={allowingPercentOfDifferentPixels} />
-			<Text prefix={prefix} element={rectangleLineWidth} />
-			<Text prefix={prefix} element={minimalRectangleSize} />
-			<Text prefix={prefix} element={maximalRectangleCount} />
-			<Text prefix={prefix} element={excludedAreas} />
-			<Check prefix={prefix} element={drawExcludedRectangles} />
-			<Check prefix={prefix} element={fillExcludedRectangles} />
-			<Text prefix={prefix} element={percentOpacityExcludedRectangles} />
-			<Text prefix={prefix} element={excludedRectangleColor} />
-			<Check prefix={prefix} element={fillDifferenceRectangles} />
-			<Text prefix={prefix} element={percentOpacityDifferenceRectangles} />
-			<Text prefix={prefix} element={differenceRectangleColor} />
+			<Text prefix={prefix} element={imageOption.threshold} />
+			<Text prefix={prefix} element={imageOption.pixelToleranceLevel} />
+			<Text prefix={prefix} element={imageOption.allowingPercentOfDifferentPixels} />
+			<Text prefix={prefix} element={imageOption.rectangleLineWidth} />
+			<Text prefix={prefix} element={imageOption.minimalRectangleSize} />
+			<Text prefix={prefix} element={imageOption.maximalRectangleCount} />
+			<Text prefix={prefix} element={imageOption.excludedAreas} />
+			<Check prefix={prefix} element={imageOption.drawExcludedRectangles} />
+			<Check prefix={prefix} element={imageOption.fillExcludedRectangles} />
+			<Text prefix={prefix} element={imageOption.percentOpacityExcludedRectangles} />
+			<Text prefix={prefix} element={imageOption.excludedRectangleColor} />
+			<Check prefix={prefix} element={imageOption.fillDifferenceRectangles} />
+			<Text prefix={prefix} element={imageOption.percentOpacityDifferenceRectangles} />
+			<Text prefix={prefix} element={imageOption.differenceRectangleColor} />
 		</>
 	);
 }

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -616,3 +616,67 @@ export class XlsTypeSettingsImpl implements XlsTypeSettings {
 		return findByName(this.elements, "xlsxSchema");
 	}
 }
+export type ImageOption = CommandParams & {
+	threshold: CommandParam;
+	pixelToleranceLevel: CommandParam;
+	allowingPercentOfDifferentPixels: CommandParam;
+	rectangleLineWidth: CommandParam;
+	minimalRectangleSize: CommandParam;
+	maximalRectangleCount: CommandParam;
+	excludedAreas: CommandParam;
+	drawExcludedRectangles: CommandParam;
+	fillExcludedRectangles: CommandParam;
+	percentOpacityExcludedRectangles: CommandParam;
+	excludedRectangleColor: CommandParam;
+	fillDifferenceRectangles: CommandParam;
+	percentOpacityDifferenceRectangles: CommandParam;
+	differenceRectangleColor: CommandParam;
+};
+export class ImageOptionImpl implements ImageOption {
+	constructor(
+		public prefix: string,
+		public elements: CommandParam[],
+	) {}
+	get threshold(): CommandParam {
+		return findByName(this.elements, "threshold");
+	}
+	get pixelToleranceLevel(): CommandParam {
+		return findByName(this.elements, "pixelToleranceLevel");
+	}
+	get allowingPercentOfDifferentPixels(): CommandParam {
+		return findByName(this.elements, "allowingPercentOfDifferentPixels");
+	}
+	get rectangleLineWidth(): CommandParam {
+		return findByName(this.elements, "rectangleLineWidth");
+	}
+	get minimalRectangleSize(): CommandParam {
+		return findByName(this.elements, "minimalRectangleSize");
+	}
+	get maximalRectangleCount(): CommandParam {
+		return findByName(this.elements, "maximalRectangleCount");
+	}
+	get excludedAreas(): CommandParam {
+		return findByName(this.elements, "excludedAreas");
+	}
+	get drawExcludedRectangles(): CommandParam {
+		return findByName(this.elements, "drawExcludedRectangles");
+	}
+	get fillExcludedRectangles(): CommandParam {
+		return findByName(this.elements, "fillExcludedRectangles");
+	}
+	get percentOpacityExcludedRectangles(): CommandParam {
+		return findByName(this.elements, "percentOpacityExcludedRectangles");
+	}
+	get excludedRectangleColor(): CommandParam {
+		return findByName(this.elements, "excludedRectangleColor");
+	}
+	get fillDifferenceRectangles(): CommandParam {
+		return findByName(this.elements, "fillDifferenceRectangles");
+	}
+	get percentOpacityDifferenceRectangles(): CommandParam {
+		return findByName(this.elements, "percentOpacityDifferenceRectangles");
+	}
+	get differenceRectangleColor(): CommandParam {
+		return findByName(this.elements, "differenceRectangleColor");
+	}
+}

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -4,6 +4,7 @@ import type {
 	ConvertResult,
 	DatasetSource,
 	GenerateElements,
+	ImageOption,
 	JdbcOption,
 	ParameterizeElements,
 	RunElements,
@@ -13,6 +14,7 @@ import {
 	ConvertResultImpl,
 	DatasetSourceImpl,
 	GenerateElementsImpl,
+	ImageOptionImpl,
 	JdbcOptionImpl,
 	ParameterizeElementsImpl,
 	RunElementsImpl,
@@ -71,7 +73,10 @@ export class SelectParameter {
 					rawCompare.oldData.prefix,
 					rawCompare.oldData.elements,
 				),
-				imageOption: rawCompare.imageOption,
+				imageOption: new ImageOptionImpl(
+					rawCompare.imageOption.prefix,
+					rawCompare.imageOption.elements,
+				),
 				convertResult: new ConvertResultImpl(
 					rawCompare.convertResult.prefix,
 					rawCompare.convertResult.elements,
@@ -184,7 +189,7 @@ export type CompareParams = {
 	elements: CommandParam[];
 	newData: DatasetSource;
 	oldData: DatasetSource;
-	imageOption: CommandParams;
+	imageOption: ImageOption;
 	convertResult: ConvertResult;
 	expectData: DatasetSource;
 };


### PR DESCRIPTION
## Summary
This PR introduces a new `ImageOption` type to provide type-safe access to image comparison parameters, replacing the generic `CommandParams` type. This improves code clarity and enables better IDE support through explicit property accessors.

## Key Changes
- **Added `ImageOption` type and `ImageOptionImpl` class** in `CommandParam.ts`:
  - Defines a structured interface for all image comparison options (threshold, pixel tolerance, rectangle settings, etc.)
  - Implements 15 getter methods that use `findByName()` to retrieve parameters from the elements array
  - Extends `CommandParams` to maintain compatibility with the base interface

- **Updated `ImageOptionFormSection` component**:
  - Changed parameter type from generic `CommandParams` to specific `ImageOption` type
  - Removed 15 local variable declarations that called `.find()` on the imageOption object
  - Simplified JSX by directly accessing properties via getters (e.g., `imageOption.threshold` instead of `threshold`)
  - Reduced component code by ~40% while improving readability

- **Updated `SelectParameter` class**:
  - Added `ImageOption` and `ImageOptionImpl` to imports
  - Modified `CompareParams` type to use `ImageOption` instead of `CommandParams`
  - Instantiated `ImageOptionImpl` in the parameter construction logic to provide proper type wrapping

## Implementation Details
The refactoring follows the existing pattern used for other parameter types in the codebase (e.g., `XlsTypeSettings`, `JdbcOption`). The lazy-loading getter pattern allows parameters to be accessed by name without requiring upfront initialization, maintaining the existing flexible architecture while providing type safety at the component level.

https://claude.ai/code/session_01Es5r4sdjZ4zoYLmVzs9LCN