### PR TITLE
Refactor CommandParam types and improve type safety

### DIFF
--- a/tauri/src/app/form/CompareForm.tsx
+++ b/tauri/src/app/form/CompareForm.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
-import { buildDatasetSrcInfo } from "../../model/CommandParam";
 import type { CompareParams } from "../../model/SelectParameter";
 import ConvertResultFormSection from "./section/ConvertResultFormSection";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
@@ -19,16 +18,14 @@ export function CompareForm(prop: {
 	const expectData = prop.compare.expectData;
 	const convertResult = prop.compare.convertResult;
 
-	const find = (name: string) =>
-		prop.compare.elements.find((e) => e.name === name);
-	const targetTypeElement = find("targetType");
+	const targetTypeElement = prop.compare.targetType;
 	const targetType = targetTypeElement?.value ?? "data";
-	const settingElement = find("setting") ?? null;
-	const settingEncodingElement = find("settingEncoding");
+	const settingElement = prop.compare.setting ?? null;
+	const settingEncodingElement = prop.compare.settingEncoding;
 
 	const oldDataInitialInfo = useMemo(
-		() => buildDatasetSrcInfo(oldData.elements),
-		[oldData.elements],
+		() => oldData.buildDatasetSrcInfo(),
+		[oldData],
 	);
 
 	return (

--- a/tauri/src/app/form/section/ConvertResultFormSection.tsx
+++ b/tauri/src/app/form/section/ConvertResultFormSection.tsx
@@ -11,12 +11,8 @@ export default function ConvertResultFormSection({
 	handleTypeSelect: (selected: string) => Promise<void>;
 }) {
 	const prefix = convertResult.prefix;
-	const excelTable = convertResult.elements.find(
-		(e) => e.name === "excelTable",
-	);
-	const outputEncoding = convertResult.elements.find(
-		(e) => e.name === "outputEncoding",
-	);
+	const excelTable = convertResult.excelTable;
+	const outputEncoding = convertResult.outputEncoding;
 	return (
 		<>
 			<Select

--- a/tauri/src/app/form/section/DatasetCommandFormSection.tsx
+++ b/tauri/src/app/form/section/DatasetCommandFormSection.tsx
@@ -1,5 +1,5 @@
 import { useDatasetSrcInfo } from "../../../context/DatasetSrcInfoProvider";
-import type { CommandParam, CommandParams } from "../../../model/CommandParam";
+import type { CommandParam, SrcTypeSettings } from "../../../model/CommandParam";
 import {
 	CsvqTypeSettingsImpl,
 	CsvTypeSettingsImpl,
@@ -20,65 +20,63 @@ export default function DatasetCommandFormSection({
 	handleValueChange,
 	handleToggleChecked,
 }: {
-	commandParams: CommandParams;
+	commandParams: SrcTypeSettings | null;
 	handleValueChange: (param: CommandParam) => (newValue: string) => void;
 	handleToggleChecked: (param: CommandParam) => (checked: boolean) => void;
 }) {
-	const datasetSrcInfo = useDatasetSrcInfo();
-	const srcType = datasetSrcInfo.srcType;
-	const { prefix, elements } = commandParams;
+	const { srcType } = useDatasetSrcInfo();
 
-	if (srcType === "csv") {
+	if (commandParams instanceof CsvTypeSettingsImpl) {
 		return (
 			<CsvFormSection
-				settings={new CsvTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>
 		);
 	}
-	if (srcType === "csvq") {
+	if (commandParams instanceof CsvqTypeSettingsImpl) {
 		return (
 			<CsvqFormSection
-				settings={new CsvqTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>
 		);
 	}
-	if (srcType === "table" || srcType === "sql") {
+	if (commandParams instanceof TableSqlTypeSettingsImpl) {
 		return (
 			<TableSqlFormSection
 				srcType={srcType}
-				settings={new TableSqlTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>
 		);
 	}
-	if (srcType === "reg") {
+	if (commandParams instanceof RegTypeSettingsImpl) {
 		return (
 			<RegFormSection
-				settings={new RegTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>
 		);
 	}
-	if (srcType === "fixed") {
+	if (commandParams instanceof FixedTypeSettingsImpl) {
 		return (
 			<FixedFormSection
-				settings={new FixedTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>
 		);
 	}
-	if (srcType === "xls" || srcType === "xlsx") {
+	if (commandParams instanceof XlsTypeSettingsImpl) {
 		return (
 			<XlsFormSection
 				srcType={srcType}
-				settings={new XlsTypeSettingsImpl(prefix, elements)}
+				settings={commandParams}
 				handleValueChange={handleValueChange}
 				handleToggleChecked={handleToggleChecked}
 			/>

--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -8,7 +8,6 @@ import type {
 	DatasetSource,
 	DatasetSrcInfo,
 } from "../../../model/CommandParam";
-import { buildDatasetSrcInfo } from "../../../model/CommandParam";
 import DatasetCommandFormSection from "./DatasetCommandFormSection";
 import DatasetSettingSection from "./DatasetSettingSection";
 import JdbcFormSection from "./JdbcFormSection";
@@ -38,7 +37,7 @@ export function DatasetLoadForm(prop: {
 	const srcElements = prop.srcData.srcElements();
 	const srcTypeSettings = prop.srcData.srcTypeSettings();
 	const settingElements = prop.srcData.settingElements();
-	const initialDatasetSrcInfo = buildDatasetSrcInfo(prop.srcData.elements);
+	const initialDatasetSrcInfo = prop.srcData.buildDatasetSrcInfo();
 	const jdbcOption = prop.srcData.jdbcOption();
 	return (
 		<DatasetSrcInfoProvider
@@ -53,7 +52,7 @@ export function DatasetLoadForm(prop: {
 					handleValueChange={handleValueChange}
 					handleToggleChecked={handleToggleChecked}
 				/>
-				{jdbcOption.elements.length > 0 && (
+				{jdbcOption !== undefined && (
 					<JdbcFormSection jdbcOption={jdbcOption} />
 				)}
 				<DatasetCommandFormSection

--- a/tauri/src/model/CommandParam.ts
+++ b/tauri/src/model/CommandParam.ts
@@ -21,8 +21,14 @@ export type CommandParam = {
 };
 export type CommandParams = {
 	prefix: string;
-	elements: CommandParam[];
 };
+export type SrcTypeSettings =
+	| CsvTypeSettings
+	| CsvqTypeSettings
+	| TableSqlTypeSettings
+	| RegTypeSettings
+	| FixedTypeSettings
+	| XlsTypeSettings;
 export type SrcInfo = {
 	srcPath: string;
 	encoding?: string;
@@ -67,15 +73,15 @@ export type SettingElements = CommandParams & {
 export type DatasetSource = CommandParams & {
 	srcType: () => string;
 	srcElements: () => SrcElements;
-	srcTypeSettings: () => CommandParams;
-	jdbcElements: () => CommandParams;
+	srcTypeSettings: () => SrcTypeSettings | null;
 	settingElements: () => SettingElements;
-	jdbcOption: () => JdbcOption;
+	jdbcOption: () => JdbcOption | undefined;
 	templateOption: () => TemplateOption;
+	buildDatasetSrcInfo: () => DatasetSrcInfo;
 };
 export class DatasetSourceImpl implements DatasetSource {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	private indexOfSetting: number;
 	private indexExtension: number;
 	private indexRegExclude: number;
@@ -122,28 +128,42 @@ export class DatasetSourceImpl implements DatasetSource {
 			this.indexOfSetting,
 		);
 	}
-	srcTypeSettings() {
-		return toCommandParams(
-			this,
-			this.srcTypeRange().filter((it) => !it.name.startsWith("jdbc")),
+	srcTypeSettings(): SrcTypeSettings | null {
+		const prefix = this.prefix;
+		const elements = this.srcTypeRange().filter(
+			(it) => !it.name.startsWith("jdbc"),
 		);
-	}
-	jdbcElements() {
-		return toCommandParams(
-			this,
-			this.srcTypeRange().filter((it) => it.name.startsWith("jdbc")),
-		);
+		switch (this.src) {
+			case "csv":
+				return new CsvTypeSettingsImpl(prefix, elements);
+			case "csvq":
+				return new CsvqTypeSettingsImpl(prefix, elements);
+			case "table":
+			case "sql":
+				return new TableSqlTypeSettingsImpl(prefix, elements);
+			case "reg":
+				return new RegTypeSettingsImpl(prefix, elements);
+			case "fixed":
+				return new FixedTypeSettingsImpl(prefix, elements);
+			case "xls":
+			case "xlsx":
+				return new XlsTypeSettingsImpl(prefix, elements);
+			default:
+				return null;
+		}
 	}
 	settingElements(): SettingElements {
 		const elements = this.elements.slice(this.indexOfSetting);
 		return new SettingElementsImpl(this.prefix, elements);
 	}
-	jdbcOption(): JdbcOption {
-		const jdbc = this.jdbcElements();
-		if (jdbc.elements.length === 0) {
-			return jdbc as unknown as JdbcOption;
+	jdbcOption(): JdbcOption | undefined {
+		const jdbcElements = this.srcTypeRange().filter((it) =>
+			it.name.startsWith("jdbc"),
+		);
+		if (jdbcElements.length === 0) {
+			return undefined;
 		}
-		return new JdbcOptionImpl(jdbc.prefix, jdbc.elements);
+		return new JdbcOptionImpl(this.prefix, jdbcElements);
 	}
 	templateOption(): TemplateOption {
 		const elements = this.srcTypeRange().filter((it) =>
@@ -151,10 +171,13 @@ export class DatasetSourceImpl implements DatasetSource {
 		);
 		return new TemplateOptionImpl(this.prefix, elements);
 	}
+	buildDatasetSrcInfo(): DatasetSrcInfo {
+		return buildDatasetSrcInfo(this.elements);
+	}
 }
 class SrcElementsImpl implements SrcElements {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly srcType: CommandParam;
 	readonly src: CommandParam;
 	readonly encoding: CommandParam | undefined;
@@ -176,7 +199,7 @@ class SrcElementsImpl implements SrcElements {
 }
 class SettingElementsImpl implements SettingElements {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly setting: CommandParam;
 	readonly settingEncoding: CommandParam;
 	readonly regTableInclude: CommandParam;
@@ -216,7 +239,7 @@ export type JdbcOption = CommandParams & {
 };
 export class JdbcOptionImpl implements JdbcOption {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly jdbcProperties: CommandParam;
 	readonly jdbcUrl: CommandParam;
 	readonly jdbcUser: CommandParam;
@@ -240,7 +263,7 @@ export type GenerateElements = CommandParams & {
 };
 export class GenerateElementsImpl implements GenerateElements {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly generateType: CommandParam;
 	readonly unit: CommandParam;
 	readonly template: CommandParam;
@@ -263,7 +286,7 @@ export type RunElements = CommandParams & {
 };
 export class RunElementsImpl implements RunElements {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly scriptType: CommandParam;
 	constructor(prefix: string, elements: CommandParam[]) {
 		this.prefix = prefix;
@@ -281,7 +304,7 @@ export type ParameterizeElements = CommandParams & {
 };
 export class ParameterizeElementsImpl implements ParameterizeElements {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly unit: CommandParam;
 	readonly parameterize: CommandParam;
 	readonly ignoreFail: CommandParam;
@@ -306,11 +329,12 @@ export type ConvertResult = CommandParams & {
 	exportEmptyTable: CommandParam;
 	exportHeader: CommandParam;
 	outputEncoding?: CommandParam;
+	excelTable?: CommandParam;
 	jdbc?: JdbcOption;
 };
 export class ConvertResultImpl implements ConvertResult {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly jdbc?: JdbcOption;
 	readonly resultType: CommandParam;
 	readonly result: CommandParam;
@@ -318,6 +342,7 @@ export class ConvertResultImpl implements ConvertResult {
 	readonly exportEmptyTable: CommandParam;
 	readonly exportHeader: CommandParam;
 	readonly outputEncoding: CommandParam | undefined;
+	readonly excelTable: CommandParam | undefined;
 	constructor(
 		prefix: string,
 		elements: CommandParam[],
@@ -334,6 +359,7 @@ export class ConvertResultImpl implements ConvertResult {
 		this.exportEmptyTable = findByName(elements, "exportEmptyTable");
 		this.exportHeader = findByName(elements, "exportHeader");
 		this.outputEncoding = findByNameOptional(elements, "outputEncoding");
+		this.excelTable = findByNameOptional(elements, "excelTable");
 	}
 }
 export type TemplateOption = CommandParams & {
@@ -345,7 +371,7 @@ export type TemplateOption = CommandParams & {
 };
 export class TemplateOptionImpl implements TemplateOption {
 	prefix: string;
-	elements: CommandParam[];
+	private elements: CommandParam[];
 	readonly encoding: CommandParam;
 	readonly templateGroup: CommandParam;
 	readonly templateParameterAttribute: CommandParam;
@@ -363,15 +389,6 @@ export class TemplateOptionImpl implements TemplateOption {
 		this.templateVarStart = findByName(elements, "templateVarStart");
 		this.templateVarStop = findByName(elements, "templateVarStop");
 	}
-}
-function toCommandParams(
-	srcData: CommandParams,
-	elements: CommandParam[],
-): CommandParams {
-	return {
-		prefix: srcData.prefix,
-		elements: elements,
-	};
 }
 
 export function buildSrcInfo(elements: CommandParam[]): SrcInfo {
@@ -421,7 +438,7 @@ export class CsvTypeSettingsImpl implements CsvTypeSettings {
 	readonly ignoreQuoted: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.startRow = findByName(elements, "startRow");
@@ -450,7 +467,7 @@ export class CsvqTypeSettingsImpl implements CsvqTypeSettings {
 	readonly templateVarStop: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.addFileInfo = findByName(elements, "addFileInfo");
@@ -484,7 +501,7 @@ export class TableSqlTypeSettingsImpl implements TableSqlTypeSettings {
 	readonly templateVarStop: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.addFileInfo = findByName(elements, "addFileInfo");
@@ -514,7 +531,7 @@ export class RegTypeSettingsImpl implements RegTypeSettings {
 	readonly regHeaderSplit: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.startRow = findByName(elements, "startRow");
@@ -537,7 +554,7 @@ export class FixedTypeSettingsImpl implements FixedTypeSettings {
 	readonly fixedLength: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.startRow = findByName(elements, "startRow");
@@ -559,7 +576,7 @@ export class XlsTypeSettingsImpl implements XlsTypeSettings {
 	readonly xlsxSchema: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.headerName = findByName(elements, "headerName");
 		this.startRow = findByName(elements, "startRow");
@@ -600,7 +617,7 @@ export class ImageOptionImpl implements ImageOption {
 	readonly differenceRectangleColor: CommandParam;
 	constructor(
 		public prefix: string,
-		public elements: CommandParam[],
+		private elements: CommandParam[],
 	) {
 		this.threshold = findByName(elements, "threshold");
 		this.pixelToleranceLevel = findByName(elements, "pixelToleranceLevel");

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -9,8 +9,6 @@ import type {
 	RunElements,
 	TemplateOption,
 } from "./CommandParam";
-
-type RawParams = { prefix: string; elements: CommandParam[] };
 import {
 	ConvertResultImpl,
 	DatasetSourceImpl,
@@ -21,6 +19,8 @@ import {
 	RunElementsImpl,
 	TemplateOptionImpl,
 } from "./CommandParam";
+
+type RawParams = { prefix: string; elements: CommandParam[] };
 
 export class SelectParameter {
 	readonly name: string;

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -1,6 +1,5 @@
 import type {
 	CommandParam,
-	CommandParams,
 	ConvertResult,
 	DatasetSource,
 	GenerateElements,
@@ -10,6 +9,8 @@ import type {
 	RunElements,
 	TemplateOption,
 } from "./CommandParam";
+
+type RawParams = { prefix: string; elements: CommandParam[] };
 import {
 	ConvertResultImpl,
 	DatasetSourceImpl,
@@ -35,11 +36,9 @@ export class SelectParameter {
 		this.command = command;
 		if (command === "convert") {
 			const rawConvert = response as {
-				srcData: DatasetSource;
-				convertResult: {
-					prefix: string;
-					elements: CommandParam[];
-					jdbc?: { prefix: string; elements: CommandParam[] };
+				srcData: RawParams;
+				convertResult: RawParams & {
+					jdbc?: RawParams;
 				};
 			};
 			this.convert = {
@@ -57,14 +56,18 @@ export class SelectParameter {
 		if (command === "compare") {
 			const rawCompare = response as {
 				elements: CommandParam[];
-				newData: DatasetSource;
-				oldData: DatasetSource;
-				imageOption: CommandParams;
-				convertResult: { prefix: string; elements: CommandParam[] };
-				expectData: DatasetSource;
+				newData: RawParams;
+				oldData: RawParams;
+				imageOption: RawParams;
+				convertResult: RawParams;
+				expectData: RawParams;
 			};
+			const findIn = (name: string) =>
+				rawCompare.elements.find((e) => e.name === name);
 			this.compare = {
-				elements: rawCompare.elements,
+				targetType: findIn("targetType"),
+				setting: findIn("setting"),
+				settingEncoding: findIn("settingEncoding"),
 				newData: new DatasetSourceImpl(
 					rawCompare.newData.prefix,
 					rawCompare.newData.elements,
@@ -91,8 +94,8 @@ export class SelectParameter {
 		if (command === "generate") {
 			const rawGenerate = response as unknown as {
 				elements: CommandParam[];
-				srcData: DatasetSource;
-				templateOption?: TemplateOption;
+				srcData: RawParams;
+				templateOption?: RawParams;
 			};
 			this.generate = {
 				commandElements: new GenerateElementsImpl("", rawGenerate.elements),
@@ -111,9 +114,9 @@ export class SelectParameter {
 		if (command === "run") {
 			const rawRun = response as unknown as {
 				elements: CommandParam[];
-				srcData: DatasetSource;
-				templateOption?: TemplateOption;
-				jdbcOption?: JdbcOption;
+				srcData: RawParams;
+				templateOption?: RawParams;
+				jdbcOption?: RawParams;
 			};
 			this.run = {
 				commandElements: new RunElementsImpl("", rawRun.elements),
@@ -138,8 +141,8 @@ export class SelectParameter {
 		if (command === "parameterize") {
 			const rawParameterize = response as unknown as {
 				elements: CommandParam[];
-				paramData: DatasetSource;
-				templateOption?: TemplateOption;
+				paramData: RawParams;
+				templateOption?: RawParams;
 			};
 			this.parameterize = {
 				commandElements: new ParameterizeElementsImpl(
@@ -186,7 +189,9 @@ export type ConvertParams = {
 	convertResult: ConvertResult;
 };
 export type CompareParams = {
-	elements: CommandParam[];
+	targetType?: CommandParam;
+	setting?: CommandParam;
+	settingEncoding?: CommandParam;
 	newData: DatasetSource;
 	oldData: DatasetSource;
 	imageOption: ImageOption;


### PR DESCRIPTION
## Summary
This PR refactors the CommandParam type system to improve type safety and reduce code duplication. The main changes involve introducing a `SrcTypeSettings` union type, making `elements` properties private across implementation classes, and removing the generic `toCommandParams` helper function in favor of type-specific implementations.

## Key Changes

- **Introduced `SrcTypeSettings` union type**: Created a new union type that encompasses all source type settings implementations (Csv, Csvq, TableSql, Reg, Fixed, Xls), replacing the generic `CommandParams` return type for `srcTypeSettings()`.

- **Refactored `srcTypeSettings()` method**: Changed from a generic helper function to a switch-based factory method that returns the appropriate typed settings implementation based on the source type, or `null` if no match is found.

- **Made `elements` properties private**: Changed `elements` from public to private across all implementation classes (`DatasetSourceImpl`, `SrcElementsImpl`, `SettingElementsImpl`, `JdbcOptionImpl`, `GenerateElementsImpl`, `RunElementsImpl`, `ParameterizeElementsImpl`, `ConvertResultImpl`, `TemplateOptionImpl`, and all type settings implementations) to enforce encapsulation.

- **Removed `jdbcElements()` method**: Eliminated the generic `jdbcElements()` method and integrated its logic directly into `jdbcOption()`, which now returns `JdbcOption | undefined` instead of always returning a `CommandParams`.

- **Added `buildDatasetSrcInfo()` method**: Introduced a new method to `DatasetSource` interface and `DatasetSourceImpl` class to encapsulate the dataset source info building logic.

- **Removed `toCommandParams()` helper**: Deleted the generic helper function as it's no longer needed with type-specific implementations.

- **Updated `CompareParams` type**: Changed from storing generic `elements` array to storing specific command parameters (`targetType`, `setting`, `settingEncoding`).

- **Added `excelTable` property**: Added optional `excelTable` property to `ConvertResult` type and implementation.

- **Simplified component logic**: Updated `DatasetCommandFormSection` to use `instanceof` checks instead of string-based type checking, eliminating the need to reconstruct settings objects.

## Notable Implementation Details

- The `srcTypeSettings()` method now returns concrete typed implementations rather than generic objects, enabling better IDE support and type checking.
- The `jdbcOption()` method now returns `undefined` when no JDBC elements are present, replacing the previous pattern of returning an empty `CommandParams`.
- Component code is simplified by receiving already-instantiated settings objects rather than raw parameters that need to be reconstructed.

https://claude.ai/code/session_01CQcxzUwkdwa5Rnba5582ZT