### PR TITLE
Add comprehensive unit tests for form components

### DIFF
--- a/tauri/src/tests/app/form/CompareForm.test.tsx
+++ b/tauri/src/tests/app/form/CompareForm.test.tsx
@@ -1,0 +1,239 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CompareForm } from "../../../app/form/CompareForm";
+import type { CompareParams } from "../../../model/SelectParameter";
+import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import {
+	compareLoadResponseFixture,
+	compareRefreshExpectSrcTypeCsvResponseFixture,
+	compareRefreshNewSrcTypeTableResponseFixture,
+	compareRefreshTargetTypeImageResponseFixture,
+} from "./fixtures";
+
+// Tauri API モック
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ core: { invoke: vi.fn() } }));
+vi.mock("@tauri-apps/api/path", () => ({
+	isAbsolute: vi.fn().mockResolvedValue(false),
+	sep: vi.fn().mockReturnValue("/"),
+}));
+
+// コンテキストフックのモック
+vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
+	useWorkspaceContext: () => workspaceResourcesFixture.context,
+	useResourcesSettings: () => workspaceResourcesFixture.resources,
+}));
+vi.mock("../../../context/EnviromentProvider", () => ({
+	useEnviroment: () => enviromentFixture,
+}));
+
+// JDBC API フックのモック
+vi.mock("../../../hooks/useJdbc", () => ({
+	useJdbcConnectionTest: () => vi.fn(),
+	useJdbcSaveProperties: () => vi.fn(),
+	useDeleteJdbcProperties: () => vi.fn(),
+}));
+
+function makeCompareProps(
+	fixture:
+		| typeof compareLoadResponseFixture
+		| typeof compareRefreshTargetTypeImageResponseFixture
+		| typeof compareRefreshNewSrcTypeTableResponseFixture
+		| typeof compareRefreshExpectSrcTypeCsvResponseFixture = compareLoadResponseFixture,
+): { handleTypeSelect: () => Promise<void>; name: string; compare: CompareParams } {
+	return {
+		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
+		name: "test",
+		compare: fixture as unknown as CompareParams,
+	};
+}
+
+describe("CompareFormの描画テスト", () => {
+	describe("data targetType（loadレスポンス）", () => {
+		it("compare・new・old・result・expectのセクションがこの順で表示される", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("compare");
+			expect(legends[1]).toHaveTextContent("new");
+			expect(legends[2]).toHaveTextContent("old");
+			expect(legends[3]).toHaveTextContent("result");
+			expect(legends[4]).toHaveTextContent("expect");
+		});
+
+		it("compareセクションにtargetTypeが含まれる", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			expect(
+				document.querySelector('select[name="-targetType"]'),
+			).toBeInTheDocument();
+		});
+
+		it("compareセクションにsetting・settingEncodingが含まれる", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-setting"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-settingEncoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("imageオプションセクションは表示されない", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			const legendTexts = Array.from(legends).map((l) => l.textContent);
+			expect(legendTexts).not.toContain("image");
+		});
+
+		it("newセクションにsrcType・src・encodingが含まれる", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			expect(
+				document.querySelector('select[name="-new.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-new.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-new.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("oldセクションにsrcType・src・encodingが含まれる", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			expect(
+				document.querySelector('select[name="-old.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-old.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-old.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("expectセクションにsrcTypeのみ表示される（srcType=none のため src 等は含まれない）", () => {
+			render(<CompareForm {...makeCompareProps()} />);
+
+			expect(
+				document.querySelector('select[name="-expect.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('[name="-expect.src"]'),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("image targetType（targetType=imageのrefreshレスポンス）", () => {
+		it("imageセクションが表示される", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshTargetTypeImageResponseFixture)}
+				/>,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			const legendTexts = Array.from(legends).map((l) => l.textContent);
+			expect(legendTexts).toContain("image");
+		});
+
+		it("imageセクションにthreshold・pixelToleranceLevelが含まれる", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshTargetTypeImageResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-image.threshold"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector(
+					'input[type="text"][name="-image.pixelToleranceLevel"]',
+				),
+			).toBeInTheDocument();
+		});
+
+		it("newセクションのsrcTypeがfileになっている", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshTargetTypeImageResponseFixture)}
+				/>,
+			);
+
+			const newSrcType = document.querySelector(
+				'select[name="-new.srcType"]',
+			) as HTMLSelectElement;
+			expect(newSrcType).toBeInTheDocument();
+			expect(newSrcType?.value).toBe("file");
+		});
+
+		it("oldセクションのsrcTypeがfileになっている", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshTargetTypeImageResponseFixture)}
+				/>,
+			);
+
+			const oldSrcType = document.querySelector(
+				'select[name="-old.srcType"]',
+			) as HTMLSelectElement;
+			expect(oldSrcType).toBeInTheDocument();
+			expect(oldSrcType?.value).toBe("file");
+		});
+	});
+
+	describe("tableソース（newData srcType=tableのrefreshレスポンス）", () => {
+		it("newセクションにJDBC要素（jdbcUrl・jdbcUser・jdbcPass）が含まれる", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshNewSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-new.jdbcUrl"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-new.jdbcUser"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-new.jdbcPass"]'),
+			).toBeInTheDocument();
+		});
+
+		it("Show table optionが表示される", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshNewSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(screen.getByText(/Show table option/)).toBeInTheDocument();
+		});
+	});
+
+	describe("csvExpect（expectData srcType=csvのrefreshレスポンス）", () => {
+		it("expectセクションにsrcType・src・encodingが含まれる", () => {
+			render(
+				<CompareForm
+					{...makeCompareProps(compareRefreshExpectSrcTypeCsvResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('select[name="-expect.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-expect.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-expect.encoding"]'),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/tauri/src/tests/app/form/GenerateForm.test.tsx
+++ b/tauri/src/tests/app/form/GenerateForm.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GenerateForm } from "../../../app/form/GenerateForm";
+import type { GenerateParams } from "../../../model/SelectParameter";
+import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import {
+	generateLoadResponseFixture,
+	generateRefreshSrcTypeTableResponseFixture,
+} from "./fixtures";
+
+// Tauri API モック
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ core: { invoke: vi.fn() } }));
+vi.mock("@tauri-apps/api/path", () => ({
+	isAbsolute: vi.fn().mockResolvedValue(false),
+	sep: vi.fn().mockReturnValue("/"),
+}));
+
+// コンテキストフックのモック
+vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
+	useWorkspaceContext: () => workspaceResourcesFixture.context,
+	useResourcesSettings: () => workspaceResourcesFixture.resources,
+}));
+vi.mock("../../../context/EnviromentProvider", () => ({
+	useEnviroment: () => enviromentFixture,
+}));
+
+// JDBC API フックのモック
+vi.mock("../../../hooks/useJdbc", () => ({
+	useJdbcConnectionTest: () => vi.fn(),
+	useJdbcSaveProperties: () => vi.fn(),
+	useDeleteJdbcProperties: () => vi.fn(),
+}));
+
+function makeGenerateProps(
+	fixture:
+		| typeof generateLoadResponseFixture
+		| typeof generateRefreshSrcTypeTableResponseFixture = generateLoadResponseFixture,
+): { handleTypeSelect: () => Promise<void>; name: string; generate: GenerateParams } {
+	return {
+		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
+		name: "test",
+		generate: fixture as unknown as GenerateParams,
+	};
+}
+
+describe("GenerateFormの描画テスト", () => {
+	describe("csvソース（loadレスポンス）", () => {
+		it("generate・template・srcのセクションがこの順で表示される", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("generate");
+			expect(legends[1]).toHaveTextContent("template");
+			expect(legends[2]).toHaveTextContent("src");
+		});
+
+		it("generateセクションにgenerateType・unit・template・result・resultPath・outputEncodingが含まれる", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			expect(
+				document.querySelector('select[name="-generateType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('select[name="-unit"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-template"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-result"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-resultPath"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-outputEncoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("templateセクションにencodingが含まれる", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-template.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("srcセクションにsrcType・src・encodingが含まれる", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			expect(
+				document.querySelector('select[name="-src.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("traversal option要素（recursive等）は初期状態でhiddenになっている", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			expect(
+				document.querySelector('input[type="checkbox"][name="-src.recursive"]'),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.regInclude"]'),
+			).not.toBeVisible();
+		});
+
+		it("csv option要素（delimiter等）は初期状態でhiddenになっている", () => {
+			render(<GenerateForm {...makeGenerateProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.delimiter"]'),
+			).not.toBeVisible();
+		});
+	});
+
+	describe("tableソース（srcType=tableのrefreshレスポンス）", () => {
+		it("srcセクションにJDBC要素（jdbcUrl・jdbcUser・jdbcPass）が含まれる", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcUrl"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcUser"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-src.jdbcPass"]'),
+			).toBeInTheDocument();
+		});
+
+		it("Show table optionが表示される", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshSrcTypeTableResponseFixture)}
+				/>,
+			);
+
+			expect(screen.getByText(/Show table option/)).toBeInTheDocument();
+		});
+	});
+});

--- a/tauri/src/tests/app/form/ParameterizeForm.test.tsx
+++ b/tauri/src/tests/app/form/ParameterizeForm.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ParameterizeForm } from "../../../app/form/ParameterizeForm";
+import type { ParameterizeParams } from "../../../model/SelectParameter";
+import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { parameterizeLoadResponseFixture } from "./fixtures";
+
+// Tauri API モック
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ core: { invoke: vi.fn() } }));
+vi.mock("@tauri-apps/api/path", () => ({
+	isAbsolute: vi.fn().mockResolvedValue(false),
+	sep: vi.fn().mockReturnValue("/"),
+}));
+
+// コンテキストフックのモック
+vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
+	useWorkspaceContext: () => workspaceResourcesFixture.context,
+	useResourcesSettings: () => workspaceResourcesFixture.resources,
+}));
+vi.mock("../../../context/EnviromentProvider", () => ({
+	useEnviroment: () => enviromentFixture,
+}));
+
+// JDBC API フックのモック
+vi.mock("../../../hooks/useJdbc", () => ({
+	useJdbcConnectionTest: () => vi.fn(),
+	useJdbcSaveProperties: () => vi.fn(),
+	useDeleteJdbcProperties: () => vi.fn(),
+}));
+
+function makeParameterizeProps(): {
+	handleTypeSelect: () => Promise<void>;
+	name: string;
+	parameterize: ParameterizeParams;
+} {
+	return {
+		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
+		name: "test",
+		parameterize: parameterizeLoadResponseFixture as unknown as ParameterizeParams,
+	};
+}
+
+describe("ParameterizeFormの描画テスト", () => {
+	describe("csvパラメータ（loadレスポンス）", () => {
+		it("execute・paramのセクションがこの順で表示される", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("execute");
+			expect(legends[1]).toHaveTextContent("param");
+		});
+
+		it("executeセクションにunit・parameterize・ignoreFail・cmd・cmdParam・templateが含まれる", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			expect(
+				document.querySelector('select[name="-unit"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="checkbox"][name="-parameterize"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="checkbox"][name="-ignoreFail"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-cmd"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-cmdParam"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-template"]'),
+			).toBeInTheDocument();
+		});
+
+		it("executeセクション内にtemplateOptionのencoding要素が含まれる", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-template.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("paramセクションにsrcType・src・encodingが含まれる", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			expect(
+				document.querySelector('select[name="-param.srcType"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-param.src"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-param.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("traversal option要素（recursive等）は初期状態でhiddenになっている", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-param.recursive"]',
+				),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-param.regInclude"]'),
+			).not.toBeVisible();
+		});
+
+		it("csv option要素（delimiter等）は初期状態でhiddenになっている", () => {
+			render(<ParameterizeForm {...makeParameterizeProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-param.delimiter"]'),
+			).not.toBeVisible();
+		});
+	});
+});

--- a/tauri/src/tests/app/form/RunForm.test.tsx
+++ b/tauri/src/tests/app/form/RunForm.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RunForm } from "../../../app/form/RunForm";
+import type { RunParams } from "../../../model/SelectParameter";
+import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import {
+	runLoadResponseFixture,
+	runRefreshScriptTypeCmdResponseFixture,
+	runRefreshScriptTypeSqlResponseFixture,
+} from "./fixtures";
+
+// Tauri API モック
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ core: { invoke: vi.fn() } }));
+vi.mock("@tauri-apps/api/path", () => ({
+	isAbsolute: vi.fn().mockResolvedValue(false),
+	sep: vi.fn().mockReturnValue("/"),
+}));
+
+// コンテキストフックのモック
+vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
+	useWorkspaceContext: () => workspaceResourcesFixture.context,
+	useResourcesSettings: () => workspaceResourcesFixture.resources,
+}));
+vi.mock("../../../context/EnviromentProvider", () => ({
+	useEnviroment: () => enviromentFixture,
+}));
+
+// JDBC API フックのモック
+vi.mock("../../../hooks/useJdbc", () => ({
+	useJdbcConnectionTest: () => vi.fn(),
+	useJdbcSaveProperties: () => vi.fn(),
+	useDeleteJdbcProperties: () => vi.fn(),
+}));
+
+function makeRunProps(
+	fixture:
+		| typeof runLoadResponseFixture
+		| typeof runRefreshScriptTypeCmdResponseFixture
+		| typeof runRefreshScriptTypeSqlResponseFixture = runLoadResponseFixture,
+): { handleTypeSelect: () => Promise<void>; name: string; run: RunParams } {
+	return {
+		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
+		name: "test",
+		run: fixture as unknown as RunParams,
+	};
+}
+
+describe("RunFormの描画テスト", () => {
+	describe("sql scriptType（loadレスポンス）", () => {
+		it("run・template・jdbc・srcのセクションがこの順で表示される", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("run");
+			expect(legends[1]).toHaveTextContent("template");
+			expect(legends[2]).toHaveTextContent("jdbc");
+			expect(legends[3]).toHaveTextContent("src");
+		});
+
+		it("runセクションにscriptTypeが含まれる", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			expect(
+				document.querySelector('select[name="-scriptType"]'),
+			).toBeInTheDocument();
+		});
+
+		it("templateセクションにencodingが含まれる", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-template.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("jdbcセクションにjdbcUrl・jdbcUser・jdbcPassが含まれる", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-jdbc.jdbcUrl"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-jdbc.jdbcUser"]'),
+			).toBeInTheDocument();
+			expect(
+				document.querySelector('input[type="text"][name="-jdbc.jdbcPass"]'),
+			).toBeInTheDocument();
+		});
+
+		it("srcセクションにsrcが含まれる", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			expect(
+				document.querySelector('input[type="text"][name="-src.src"]'),
+			).toBeInTheDocument();
+		});
+
+		it("traversal option要素（recursive等）は初期状態でhiddenになっている", () => {
+			render(<RunForm {...makeRunProps()} />);
+
+			expect(
+				document.querySelector('input[type="checkbox"][name="-src.recursive"]'),
+			).not.toBeVisible();
+			expect(
+				document.querySelector('input[type="text"][name="-src.regInclude"]'),
+			).not.toBeVisible();
+		});
+	});
+
+	describe("cmd scriptType（scriptType=cmdのrefreshレスポンス）", () => {
+		it("templateセクションは表示されない", () => {
+			render(
+				<RunForm {...makeRunProps(runRefreshScriptTypeCmdResponseFixture)} />,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			const legendTexts = Array.from(legends).map((l) => l.textContent);
+			expect(legendTexts).not.toContain("template");
+		});
+
+		it("jdbcセクションは表示されない", () => {
+			render(
+				<RunForm {...makeRunProps(runRefreshScriptTypeCmdResponseFixture)} />,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			const legendTexts = Array.from(legends).map((l) => l.textContent);
+			expect(legendTexts).not.toContain("jdbc");
+		});
+
+		it("srcセクションは表示される", () => {
+			render(
+				<RunForm {...makeRunProps(runRefreshScriptTypeCmdResponseFixture)} />,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			const legendTexts = Array.from(legends).map((l) => l.textContent);
+			expect(legendTexts).toContain("src");
+		});
+	});
+
+	describe("sql scriptType（refreshレスポンス）", () => {
+		it("templateセクションが表示される", () => {
+			render(
+				<RunForm {...makeRunProps(runRefreshScriptTypeSqlResponseFixture)} />,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-template.encoding"]'),
+			).toBeInTheDocument();
+		});
+
+		it("jdbcセクションが表示される", () => {
+			render(
+				<RunForm {...makeRunProps(runRefreshScriptTypeSqlResponseFixture)} />,
+			);
+
+			expect(
+				document.querySelector('input[type="text"][name="-jdbc.jdbcUrl"]'),
+			).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit test suites for four form components: `CompareForm`, `RunForm`, `GenerateForm`, and `ParameterizeForm`. These tests verify the correct rendering of form sections and fields based on different parameter configurations and data types.

## Key Changes
- **CompareForm.test.tsx**: 239 lines of tests covering:
  - Rendering of compare, new, old, result, and expect sections
  - Conditional rendering of image options based on targetType
  - JDBC field visibility for table sources
  - CSV field visibility for expect data

- **RunForm.test.tsx**: 164 lines of tests covering:
  - Rendering of run, template, jdbc, and src sections
  - Conditional visibility of template and jdbc sections based on scriptType (sql vs cmd)
  - Traversal option visibility states

- **GenerateForm.test.tsx**: 152 lines of tests covering:
  - Rendering of generate, template, and src sections
  - Conditional JDBC field visibility for table sources
  - Traversal and CSV option visibility states

- **ParameterizeForm.test.tsx**: 120 lines of tests covering:
  - Rendering of execute and param sections
  - Presence of all required form fields (unit, parameterize, ignoreFail, cmd, etc.)
  - Conditional visibility of traversal and CSV options

## Implementation Details
- All tests use Vitest with React Testing Library
- Comprehensive mocking of Tauri APIs, context hooks, and JDBC hooks
- Tests verify both presence/absence of DOM elements and their visibility states
- Fixture-based approach allows testing multiple parameter configurations per component
- Tests validate form structure, field names, and conditional rendering logic

https://claude.ai/code/session_01T3rth4pEmM5sixxf79E7x6