### PR TITLE
Escape template variable delimiters in ST4 rendering

### DIFF
--- a/core/src/main/java/yo/dbunitcli/resource/st4/TemplateRender.java
+++ b/core/src/main/java/yo/dbunitcli/resource/st4/TemplateRender.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public record TemplateRender(
         File templateGroup
@@ -56,12 +57,22 @@ public record TemplateRender(
         return result;
     }
 
+    private static final Pattern TEMPLATE_VAR_DELIMITER_PATTERN =
+            Pattern.compile("(-(?:[\\w.]*\\.)?(?:templateVarStart|templateVarStop)=)(.)");
+
+    private static String escapeTemplateVarDelimiterValues(final String template) {
+        if (!template.contains("templateVarStart") && !template.contains("templateVarStop")) {
+            return template;
+        }
+        return TEMPLATE_VAR_DELIMITER_PATTERN.matcher(template).replaceAll("$1\\\\$2");
+    }
+
     public ST createST(final String result) {
         return new ST(this.createSTGroup(), result);
     }
 
     public ST createST(final String target, final Parameter parameter) {
-        final String template = this.replaceParameter(target, parameter);
+        final String template = this.escapeTemplateVarDelimiterValues(this.replaceParameter(target, parameter));
         final ST st = this.createST(template);
         if (Optional.ofNullable(this.templateParameterAttribute()).orElse("").isEmpty()) {
             parameter.forEach(st::add);

--- a/core/src/test/java/yo/dbunitcli/application/command/ParameterizeTest.java
+++ b/core/src/test/java/yo/dbunitcli/application/command/ParameterizeTest.java
@@ -77,6 +77,13 @@ public class ParameterizeTest {
         }
 
         @Test
+        public void testTemplateVarStartStopConflictWithRenderingDelimiter() {
+            Parameterize.main(new String[]{"-param.src=" + baseDir + "src/csv/has space"
+                    , "-cmd=convert"
+                    , "-template=" + baseDir + "/settings/param/conflictDelimiterTemplate.txt"});
+        }
+
+        @Test
         public void testExecCommandNoneParameter() {
             Parameterize.main(new String[]{
                     "-cmd=$param.inputParam.cmdName$"

--- a/core/src/test/resources/yo/dbunitcli/application/settings/param/conflictDelimiterTemplate.txt
+++ b/core/src/test/resources/yo/dbunitcli/application/settings/param/conflictDelimiterTemplate.txt
@@ -1,0 +1,5 @@
+-templateVarStart=$
+-templateVarStop=$
+-src=$param.src$
+-srcType=csv
+-result=target/test-classes/yo/dbunitcli/application/command/param/conflictDelimiter/result


### PR DESCRIPTION
## Summary
This change fixes a conflict that occurs when StringTemplate4 (ST4) template variable delimiters (`templateVarStart` and `templateVarStop`) are used as parameter values during template rendering. The fix ensures these delimiter values are properly escaped before being processed by ST4.

## Key Changes
- Added `escapeTemplateVarDelimiterValues()` method to detect and escape template variable delimiter parameters
- Implemented a regex pattern (`TEMPLATE_VAR_DELIMITER_PATTERN`) to identify and escape delimiter values in command-line parameters
- Updated `createST(String, Parameter)` to apply escaping before template creation
- Added test case `testTemplateVarStartStopConflictWithRenderingDelimiter()` to verify the fix works correctly
- Added test template file demonstrating the use case with conflicting delimiters

## Implementation Details
The solution uses a regex pattern to match parameter assignments containing `templateVarStart` or `templateVarStop` and escapes the delimiter character with a backslash. This prevents ST4 from interpreting these values as actual template delimiters during rendering, allowing them to be safely used as parameter values.

https://claude.ai/code/session_01S57nEjYaQvS7NEPsqUE1x3