### PR TITLE
Extract path resolution logic into reusable hook

### DIFF
--- a/tauri/src/app/form/section/element/Chooser.tsx
+++ b/tauri/src/app/form/section/element/Chooser.tsx
@@ -1,75 +1,21 @@
 import { core } from "@tauri-apps/api";
-import { isAbsolute, sep } from "@tauri-apps/api/path";
+import { sep } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
 	DirectoryButton,
 	FileButton,
 	OpenButton,
 } from "../../../../components/element/ButtonIcon";
-import { useEnviroment } from "../../../../context/EnviromentProvider";
 import { useWorkspaceContext } from "../../../../context/WorkspaceResourcesProvider";
-import type { Attribute } from "../../../../model/CommandOption";
-import type { WorkspaceContext } from "../../../../model/WorkspaceResources";
-import { fetchData } from "../../../../utils/fetchUtils";
+import { useResolveAbsolutePath } from "../../../../hooks/useWorkspaceResources";
 import type { FileProp } from "./FormElementProp";
-
-async function resolvePathViaSidecar(
-	path: string,
-	defaultPath: string,
-	apiUrl: string,
-): Promise<string> {
-	try {
-		const fetchParams = {
-			endpoint: `${apiUrl}workspace/resolve-path`,
-			options: {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ path, defaultPath }),
-			},
-		};
-		const response = await fetchData(fetchParams);
-		return await response.text();
-	} catch (e) {
-		console.error("resolvePathViaSidecar failed, falling back to frontend:", e);
-		return "";
-	}
-}
-
-async function resolveAbsolutePath(
-	path: string,
-	context: WorkspaceContext,
-	attribute: Attribute,
-	apiUrl: string,
-): Promise<string> {
-	const sidecarResult = await resolvePathViaSidecar(
-		path,
-		attribute.defaultPath,
-		apiUrl,
-	);
-	if (sidecarResult) {
-		return sidecarResult;
-	}
-	if (await isAbsolute(path)) {
-		return path;
-	}
-	const basePath = context.getPath(attribute.defaultPath);
-	if (path) {
-		return basePath + sep() + path;
-	}
-	return basePath;
-}
 
 export function FileChooser(prop: FileProp) {
 	const context = useWorkspaceContext();
-	const environment = useEnviroment();
+	const resolveAbsolutePath = useResolveAbsolutePath();
 	const handleFileChooserClick = () => {
 		const basePath = context.getPath(prop.element.attribute.defaultPath);
-		resolveAbsolutePath(
-			prop.path,
-			context,
-			prop.element.attribute,
-			environment.apiUrl,
-		).then((defaultPath) =>
+		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
 			open({ defaultPath }).then((files) => {
 				if (files) {
 					prop.setPath((files as string).replace(basePath + sep(), ""));
@@ -82,15 +28,10 @@ export function FileChooser(prop: FileProp) {
 }
 export function DirectoryChooser(prop: FileProp) {
 	const context = useWorkspaceContext();
-	const environment = useEnviroment();
+	const resolveAbsolutePath = useResolveAbsolutePath();
 	const handleDirectoryChooserClick = () => {
 		const basePath = context.getPath(prop.element.attribute.defaultPath);
-		resolveAbsolutePath(
-			prop.path,
-			context,
-			prop.element.attribute,
-			environment.apiUrl,
-		).then((defaultPath) =>
+		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
 			open({ defaultPath, directory: true }).then((files) => {
 				if (files) {
 					prop.setPath((files as string).replace(basePath + sep(), ""));
@@ -103,17 +44,14 @@ export function DirectoryChooser(prop: FileProp) {
 }
 
 export function OpenInOS(prop: FileProp) {
-	const context = useWorkspaceContext();
-	const environment = useEnviroment();
+	const resolveAbsolutePath = useResolveAbsolutePath();
 	const handleOpen = async () => {
 		if (!prop.path) {
 			return;
 		}
 		const absolutePath = await resolveAbsolutePath(
 			prop.path,
-			context,
 			prop.element.attribute,
-			environment.apiUrl,
 		);
 		await core.invoke("open_directory", { path: absolutePath });
 	};

--- a/tauri/src/hooks/useWorkspaceResources.ts
+++ b/tauri/src/hooks/useWorkspaceResources.ts
@@ -169,7 +169,7 @@ export const useResolveAbsolutePath = () => {
 			}
 		} catch (e) {
 			console.error(
-				"resolvePathViaSidecar failed, falling back to frontend:",
+				"workspace/resolve-path request failed, falling back to frontend:",
 				e,
 			);
 		}

--- a/tauri/src/hooks/useWorkspaceResources.ts
+++ b/tauri/src/hooks/useWorkspaceResources.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, sep } from "@tauri-apps/api/path";
 import { useEnviroment } from "../context/EnviromentProvider";
 import {
 	useSelectParameter,
@@ -7,7 +8,9 @@ import {
 	useSetParameterList,
 	useSetResourcesSettings,
 	useSetWorkspaceContext,
+	useWorkspaceContext,
 } from "../context/WorkspaceResourcesProvider";
+import type { Attribute } from "../model/CommandOption";
 import {
 	ParameterList,
 	ResourcesSettings,
@@ -143,5 +146,40 @@ export const useRenameParameter = (command: string, name: string) => {
 				}
 			})
 			.catch((ex) => handleFetchError((ex as Error).message, fetchParams));
+	};
+};
+
+export const useResolveAbsolutePath = () => {
+	const { apiUrl } = useEnviroment();
+	const context = useWorkspaceContext();
+	return async (path: string, attribute: Attribute): Promise<string> => {
+		const fetchParams = {
+			endpoint: `${apiUrl}workspace/resolve-path`,
+			options: {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ path, defaultPath: attribute.defaultPath }),
+			},
+		};
+		try {
+			const response = await fetchData(fetchParams);
+			const sidecarResult = await response.text();
+			if (sidecarResult) {
+				return sidecarResult;
+			}
+		} catch (e) {
+			console.error(
+				"resolvePathViaSidecar failed, falling back to frontend:",
+				e,
+			);
+		}
+		if (await isAbsolute(path)) {
+			return path;
+		}
+		const basePath = context.getPath(attribute.defaultPath);
+		if (path) {
+			return basePath + sep() + path;
+		}
+		return basePath;
 	};
 };


### PR DESCRIPTION
## Summary
Refactored path resolution logic from the `Chooser.tsx` component into a new custom hook `useResolveAbsolutePath()` to improve code reusability and maintainability.

## Key Changes
- **Extracted `resolveAbsolutePath` function** from `Chooser.tsx` into a new custom hook `useResolveAbsolutePath()` in `useWorkspaceResources.ts`
- **Simplified component dependencies** by removing direct imports of `useEnviroment()` and `useWorkspaceContext()` from individual components, consolidating them in the hook
- **Updated all path resolution calls** in `FileChooser`, `DirectoryChooser`, and `OpenInOS` components to use the new hook with a simplified API (removed `context` and `apiUrl` parameters)
- **Removed unused imports** from `Chooser.tsx` (`isAbsolute`, `useEnviroment`, `Attribute`, `WorkspaceContext`, `fetchData`)
- **Added necessary imports** to `useWorkspaceResources.ts` to support the new hook implementation

## Implementation Details
The new `useResolveAbsolutePath()` hook encapsulates:
- Sidecar API call to resolve paths via `workspace/resolve-path` endpoint
- Fallback logic for absolute path detection
- Fallback logic for relative path resolution using workspace context
- Error handling with console logging

This change reduces code duplication and makes the path resolution logic easier to test and maintain across the application.

https://claude.ai/code/session_01NNownfAvJ6gHp6ZdbywXJ5