### PR TITLE
Refactor file and directory choosers to reduce code duplication

### DIFF
--- a/tauri/src/app/form/section/element/Chooser.tsx
+++ b/tauri/src/app/form/section/element/Chooser.tsx
@@ -10,13 +10,13 @@ import { useWorkspaceContext } from "../../../../context/WorkspaceResourcesProvi
 import { useResolveAbsolutePath } from "../../../../hooks/useWorkspaceResources";
 import type { FileProp } from "./FormElementProp";
 
-export function FileChooser(prop: FileProp) {
+function useChooserHandler(prop: FileProp, directory?: boolean) {
 	const context = useWorkspaceContext();
 	const resolveAbsolutePath = useResolveAbsolutePath();
-	const handleFileChooserClick = () => {
+	return () => {
 		const basePath = context.getPath(prop.element.attribute.defaultPath);
 		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
-			open({ defaultPath }).then((files) => {
+			open({ defaultPath, directory }).then((files) => {
 				if (files) {
 					prop.setPath((files as string).replace(basePath + sep(), ""));
 					prop.onSelect?.();
@@ -24,23 +24,14 @@ export function FileChooser(prop: FileProp) {
 			}),
 		);
 	};
-	return <FileButton handleClick={handleFileChooserClick} />;
 }
+
+export function FileChooser(prop: FileProp) {
+	return <FileButton handleClick={useChooserHandler(prop)} />;
+}
+
 export function DirectoryChooser(prop: FileProp) {
-	const context = useWorkspaceContext();
-	const resolveAbsolutePath = useResolveAbsolutePath();
-	const handleDirectoryChooserClick = () => {
-		const basePath = context.getPath(prop.element.attribute.defaultPath);
-		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
-			open({ defaultPath, directory: true }).then((files) => {
-				if (files) {
-					prop.setPath((files as string).replace(basePath + sep(), ""));
-					prop.onSelect?.();
-				}
-			}),
-		);
-	};
-	return <DirectoryButton handleClick={handleDirectoryChooserClick} />;
+	return <DirectoryButton handleClick={useChooserHandler(prop, true)} />;
 }
 
 export function OpenInOS(prop: FileProp) {


### PR DESCRIPTION
## Summary
Extracted common logic from `FileChooser` and `DirectoryChooser` components into a reusable `useChooserHandler` hook to eliminate code duplication and improve maintainability.

## Key Changes
- Created `useChooserHandler` custom hook that encapsulates the shared file/directory selection logic
- The hook accepts an optional `directory` parameter to toggle between file and directory selection modes
- Simplified `FileChooser` component to use the hook with `directory` defaulting to `false`
- Simplified `DirectoryChooser` component to use the hook with `directory` set to `true`
- Removed ~15 lines of duplicated code while maintaining identical functionality

## Implementation Details
- The hook returns a click handler function that manages path resolution and file dialog opening
- Both components now share the same underlying logic, reducing maintenance burden and potential for inconsistencies
- No changes to component APIs or external behavior

https://claude.ai/code/session_01FdJ3FR8irdBJs59c5ZcPJi