### PR TITLE
Refactor async dialogs to use React 19 Suspense and use() hook

### DIFF
--- a/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
+++ b/tauri/src/app/settings/DatasetTableNamesPreviewButton.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { Suspense, use, useEffect, useRef, useState } from "react";
 import { BlueButton, WhiteButton } from "../../components/element/Button";
+import { useJdbcConnectionState } from "../../context/JdbcConnectionProvider";
 import { useDatasetSrcInfo } from "../../context/DatasetSrcInfoProvider";
-import { useDatasetTableNames } from "../../hooks/useDatasetSettings";
+import { useDatasetTableNamesApi } from "../../hooks/useDatasetSettings";
 import type { DatasetSrcInfo } from "../../model/CommandOption";
 
 export default function DatasetTableNamesPreviewButton({
@@ -30,30 +31,6 @@ export default function DatasetTableNamesPreviewButton({
 	);
 }
 
-function TableContent({
-	tableNames,
-	loading,
-}: {
-	tableNames: string[];
-	loading: boolean;
-}) {
-	if (loading) {
-		return <p className="text-sm text-gray-400 p-3">Loading...</p>;
-	}
-	if (tableNames.length === 0) {
-		return <p className="text-sm text-gray-400 p-3">No tables found.</p>;
-	}
-	return (
-		<ul className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 space-y-1">
-			{tableNames.map((name) => (
-				<li key={name} className="text-gray-700">
-					{name}
-				</li>
-			))}
-		</ul>
-	);
-}
-
 function DatasetTableNamesPreviewDialog({
 	datasetSrcInfo,
 	handleDialogClose,
@@ -61,8 +38,35 @@ function DatasetTableNamesPreviewDialog({
 	datasetSrcInfo: DatasetSrcInfo;
 	handleDialogClose: () => void;
 }) {
+	const { jdbcValues, connectionOk } = useJdbcConnectionState();
+	const loadTableNames = useDatasetTableNamesApi();
+
+	const srcPath = datasetSrcInfo.srcPath;
+	const srcType = datasetSrcInfo.srcType;
+	const sqlNotReady = srcType === "sql" && !connectionOk;
+
+	const promise =
+		!srcPath || !srcType || srcType === "none" || sqlNotReady
+			? Promise.resolve<string[]>([])
+			: loadTableNames(datasetSrcInfo, jdbcValues);
+
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<TableNamesContent promise={promise} handleDialogClose={handleDialogClose} />
+		</Suspense>
+	);
+}
+
+function TableNamesContent({
+	promise,
+	handleDialogClose,
+}: {
+	promise: Promise<string[]>;
+	handleDialogClose: () => void;
+}) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
-	const { tableNames, loading } = useDatasetTableNames(datasetSrcInfo);
+	const tableNames = use(promise);
+
 	useEffect(() => {
 		dialogRef.current?.showModal();
 	}, []);
@@ -75,7 +79,17 @@ function DatasetTableNamesPreviewDialog({
 		>
 			<div className="p-4 rounded-lg mt-2">
 				<h2 className="text-lg font-bold mb-2">Table List Preview</h2>
-				<TableContent tableNames={tableNames} loading={loading} />
+				{tableNames.length === 0 ? (
+					<p className="text-sm text-gray-400 p-3">No tables found.</p>
+				) : (
+					<ul className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 space-y-1">
+						{tableNames.map((name) => (
+							<li key={name} className="text-gray-700">
+								{name}
+							</li>
+						))}
+					</ul>
+				)}
 			</div>
 			<div className="flex items-center justify-end p-4 gap-2">
 				<WhiteButton title="Close" handleClick={handleDialogClose} />

--- a/tauri/src/app/settings/JdbcPropertiesPreviewDialog.tsx
+++ b/tauri/src/app/settings/JdbcPropertiesPreviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Suspense, use } from "react";
 import { SettingDialog } from "../../components/dialog";
 import { useJdbcReadContent } from "../../hooks/useJdbc";
 
@@ -29,22 +29,32 @@ export default function JdbcPropertiesPreviewDialog({
 	handleDialogClose,
 	handleApply,
 }: JdbcPropertiesPreviewDialogProps) {
-	const [content, setContent] = useState<Record<string, string> | null>(null);
 	const readContent = useJdbcReadContent();
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<Dialog
+				promise={readContent(path)}
+				path={path}
+				handleDialogClose={handleDialogClose}
+				handleApply={handleApply}
+			/>
+		</Suspense>
+	);
+}
 
-	useEffect(() => {
-		let cancelled = false;
-		readContent(path).then((result) => {
-			if (!cancelled) {
-				setContent(result);
-			}
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [path, readContent]);
-
-	const jdbcFormValues = content !== null ? toJdbcFormValues(content) : {};
+function Dialog({
+	promise,
+	path,
+	handleDialogClose,
+	handleApply,
+}: {
+	promise: Promise<Record<string, string>>;
+	path: string;
+	handleDialogClose: () => void;
+	handleApply: (values: Partial<Record<string, string>>) => void;
+}) {
+	const content = use(promise);
+	const jdbcFormValues = toJdbcFormValues(content);
 
 	return (
 		<SettingDialog
@@ -56,13 +66,9 @@ export default function JdbcPropertiesPreviewDialog({
 			<div className="w-[600px]">
 				<h2 className="text-lg font-bold mb-2">Properties File Preview</h2>
 				<p className="text-sm text-gray-500 mb-3 break-all">{path}</p>
-				{content === null ? (
-					<p className="text-sm text-gray-400 p-3">Loading...</p>
-				) : (
-					<pre className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all">
-						{JSON.stringify(content, null, 2)}
-					</pre>
-				)}
+				<pre className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all">
+					{JSON.stringify(content, null, 2)}
+				</pre>
 			</div>
 		</SettingDialog>
 	);

--- a/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
+++ b/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Suspense, use, useState } from "react";
 import { SettingDialog } from "../../components/dialog";
 import { useJdbcTables } from "../../hooks/useJdbc";
 import { useSaveDataSource } from "../../hooks/useQueryDatasource";
@@ -13,35 +13,6 @@ interface JdbcTableSelectorDialogProps {
 	handleSave: (path: string) => void;
 }
 
-function TableContent({
-	loading,
-	tables,
-	selected,
-	onToggleAll,
-	onToggle,
-}: {
-	loading: boolean;
-	tables: string[];
-	selected: Set<string>;
-	onToggleAll: (checked: boolean) => void;
-	onToggle: (table: string) => void;
-}) {
-	if (loading) {
-		return <p className="text-sm text-gray-500">Loading...</p>;
-	}
-	if (tables.length === 0) {
-		return <p className="text-sm text-gray-500">No tables found</p>;
-	}
-	return (
-		<TableList
-			tables={tables}
-			selected={selected}
-			onToggleAll={onToggleAll}
-			onToggle={onToggle}
-		/>
-	);
-}
-
 export default function JdbcTableSelectorDialog({
 	jdbcValues,
 	currentContent,
@@ -49,33 +20,44 @@ export default function JdbcTableSelectorDialog({
 	handleDialogClose,
 	handleSave,
 }: JdbcTableSelectorDialogProps) {
-	const [tables, setTables] = useState<string[]>([]);
-	const [selected, setSelected] = useState<Set<string>>(new Set());
-	const [loading, setLoading] = useState(true);
 	const getJdbcTables = useJdbcTables();
-	const saveDataSource = useSaveDataSource();
-	const jdbcValuesRef = useRef(jdbcValues);
-	const currentContentRef = useRef(currentContent);
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<Dialog
+				promise={getJdbcTables(jdbcValues)}
+				currentContent={currentContent}
+				fileName={fileName}
+				handleDialogClose={handleDialogClose}
+				handleSave={handleSave}
+			/>
+		</Suspense>
+	);
+}
 
-	useEffect(() => {
-		const load = async () => {
-			setLoading(true);
-			try {
-				const result = await getJdbcTables(jdbcValuesRef.current);
-				setTables(result);
-				const existing = new Set(
-					currentContentRef.current
-						.split("\n")
-						.map((t) => t.trim())
-						.filter((t) => t.length > 0),
-				);
-				setSelected(existing);
-			} finally {
-				setLoading(false);
-			}
-		};
-		void load();
-	}, [getJdbcTables]);
+function Dialog({
+	promise,
+	currentContent,
+	fileName,
+	handleDialogClose,
+	handleSave,
+}: {
+	promise: Promise<string[]>;
+	currentContent: string;
+	fileName: string;
+	handleDialogClose: () => void;
+	handleSave: (path: string) => void;
+}) {
+	const tables = use(promise);
+	const [selected, setSelected] = useState<Set<string>>(
+		() =>
+			new Set(
+				currentContent
+					.split("\n")
+					.map((t) => t.trim())
+					.filter((t) => t.length > 0),
+			),
+	);
+	const saveDataSource = useSaveDataSource();
 
 	const toggleTable = (table: string) => {
 		setSelected((prev) => {
@@ -113,13 +95,16 @@ export default function JdbcTableSelectorDialog({
 		>
 			<div className="p-4">
 				<h2 className="text-lg font-semibold mb-4">Select Tables</h2>
-				<TableContent
-					loading={loading}
-					tables={tables}
-					selected={selected}
-					onToggleAll={toggleAll}
-					onToggle={toggleTable}
-				/>
+				{tables.length === 0 ? (
+					<p className="text-sm text-gray-500">No tables found</p>
+				) : (
+					<TableList
+						tables={tables}
+						selected={selected}
+						onToggleAll={toggleAll}
+						onToggle={toggleTable}
+					/>
+				)}
 			</div>
 		</SettingDialog>
 	);

--- a/tauri/src/app/settings/SqlTableInsertDialog.tsx
+++ b/tauri/src/app/settings/SqlTableInsertDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { Suspense, use, useState } from "react";
 import {
 	BlueButton,
 	WhiteButton,
@@ -17,20 +17,53 @@ export default function SqlTableInsertDialog({
 	onInsert,
 	onClose,
 }: SqlTableInsertDialogProps) {
-	const [tables, setTables] = useState<string[] | null>(null);
-	const [selected, setSelected] = useState<Set<string>>(new Set());
-	const [loading, setLoading] = useState(false);
+	const [tablesPromise, setTablesPromise] = useState<Promise<string[]> | null>(
+		null,
+	);
 	const getJdbcTables = useJdbcTables();
 
-	const handleLoad = useCallback(async () => {
-		setLoading(true);
-		try {
-			const result = await getJdbcTables(jdbcValues);
-			setTables(result);
-		} finally {
-			setLoading(false);
-		}
-	}, [getJdbcTables, jdbcValues]);
+	const handleLoad = () => {
+		setTablesPromise(getJdbcTables(jdbcValues));
+	};
+
+	return (
+		<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+			<div className="bg-white rounded-lg shadow-lg p-6 w-96 max-w-full">
+				<h2 className="text-lg font-semibold mb-4">Select Tables</h2>
+				<div className="mb-4">
+					<BlueButton title="Load Tables" handleClick={handleLoad} />
+				</div>
+				{tablesPromise === null ? (
+					<div className="flex gap-2 justify-end">
+						<WhiteButton title="Cancel" handleClick={onClose} />
+					</div>
+				) : (
+					<Suspense
+						fallback={<p className="text-sm text-gray-500">Loading...</p>}
+					>
+						<TablesContent
+							promise={tablesPromise}
+							onInsert={onInsert}
+							onClose={onClose}
+						/>
+					</Suspense>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function TablesContent({
+	promise,
+	onInsert,
+	onClose,
+}: {
+	promise: Promise<string[]>;
+	onInsert: (tables: string[]) => void;
+	onClose: () => void;
+}) {
+	const tables = use(promise);
+	const [selected, setSelected] = useState<Set<string>>(new Set());
 
 	const toggleTable = (table: string) => {
 		setSelected((prev) => {
@@ -46,50 +79,40 @@ export default function SqlTableInsertDialog({
 
 	const toggleAll = (checked: boolean) => {
 		if (checked) {
-			setSelected(new Set(tables ?? []));
+			setSelected(new Set(tables));
 		} else {
 			setSelected(new Set());
 		}
 	};
 
 	const handleInsert = () => {
-		const selectedTables = (tables ?? []).filter((t) => selected.has(t));
+		const selectedTables = tables.filter((t) => selected.has(t));
 		onInsert(selectedTables);
 	};
 
 	return (
-		<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-			<div className="bg-white rounded-lg shadow-lg p-6 w-96 max-w-full">
-				<h2 className="text-lg font-semibold mb-4">Select Tables</h2>
-				<div className="mb-4">
-					<BlueButton title="Load Tables" handleClick={handleLoad} disabled={loading} />
-				</div>
-				<div className="mb-4 min-h-8">
-					{loading && (
-						<p className="text-sm text-gray-500">Loading...</p>
-					)}
-					{!loading && tables !== null && tables.length === 0 && (
-						<p className="text-sm text-gray-500">No tables found</p>
-					)}
-					{!loading && tables !== null && tables.length > 0 && (
-						<TableList
-							tables={tables}
-							selected={selected}
-							onToggleAll={toggleAll}
-							onToggle={toggleTable}
-							maxHeightClass="max-h-72"
-						/>
-					)}
-				</div>
-				<div className="flex gap-2 justify-end">
-					<BlueButton
-						title="Insert"
-						handleClick={handleInsert}
-						disabled={selected.size === 0}
+		<>
+			<div className="mb-4 min-h-8">
+				{tables.length === 0 ? (
+					<p className="text-sm text-gray-500">No tables found</p>
+				) : (
+					<TableList
+						tables={tables}
+						selected={selected}
+						onToggleAll={toggleAll}
+						onToggle={toggleTable}
+						maxHeightClass="max-h-72"
 					/>
-					<WhiteButton title="Cancel" handleClick={onClose} />
-				</div>
+				)}
 			</div>
-		</div>
+			<div className="flex gap-2 justify-end">
+				<BlueButton
+					title="Insert"
+					handleClick={handleInsert}
+					disabled={selected.size === 0}
+				/>
+				<WhiteButton title="Cancel" handleClick={onClose} />
+			</div>
+		</>
 	);
 }

--- a/tauri/src/app/settings/TemplateEditDialog.tsx
+++ b/tauri/src/app/settings/TemplateEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Suspense, use, useState } from "react";
 import { SettingDialog } from "../../components/dialog";
 import {
 	useTemplateLoadContent,
@@ -15,29 +15,38 @@ export default function TemplateEditDialog({
 	setPath?: (path: string) => void;
 	handleDialogClose: () => void;
 }) {
-	const [content, setContent] = useState<string | null>(null);
 	const loadContent = useTemplateLoadContent();
-	const saveContent = useTemplateSaveContent();
+	const promise = name ? loadContent(name) : Promise.resolve("");
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<Dialog
+				promise={promise}
+				name={name}
+				setPath={setPath}
+				handleDialogClose={handleDialogClose}
+			/>
+		</Suspense>
+	);
+}
 
-	useEffect(() => {
-		if (!name) {
-			setContent("");
-			return;
-		}
-		let cancelled = false;
-		loadContent(name).then((result) => {
-			if (!cancelled) {
-				setContent(result);
-			}
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [name, loadContent]);
+function Dialog({
+	promise,
+	name,
+	setPath,
+	handleDialogClose,
+}: {
+	promise: Promise<string>;
+	name: string;
+	setPath?: (path: string) => void;
+	handleDialogClose: () => void;
+}) {
+	const initialContent = use(promise);
+	const [content, setContent] = useState<string>(initialContent);
+	const saveContent = useTemplateSaveContent();
 
 	const handleSave = (path: string) =>
 		saveOnSuccess(
-			() => saveContent(path, content ?? ""),
+			() => saveContent(path, content),
 			() => {
 				setPath?.(path);
 				handleDialogClose();
@@ -49,19 +58,14 @@ export default function TemplateEditDialog({
 			fileName={name}
 			handleDialogClose={handleDialogClose}
 			handleSave={handleSave}
-			commitDisabled={content === null}
 		>
 			<div className="w-[800px] p-4">
 				<h2 className="text-lg font-bold mb-2">Template File Edit</h2>
-				{content === null ? (
-					<p className="text-sm text-gray-400 p-3">Loading...</p>
-				) : (
-					<textarea
-						className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 w-full h-96 font-mono focus-visible:ring-3 ring-indigo-300"
-						value={content}
-						onChange={(e) => setContent(e.target.value)}
-					/>
-				)}
+				<textarea
+					className="text-sm bg-gray-50 border border-gray-300 rounded-lg p-3 w-full h-96 font-mono focus-visible:ring-3 ring-indigo-300"
+					value={content}
+					onChange={(e) => setContent(e.target.value)}
+				/>
 			</div>
 		</SettingDialog>
 	);


### PR DESCRIPTION
## Summary
Refactored multiple dialog components to leverage React 19's `Suspense` and `use()` hook for handling async operations, replacing manual state management with promises and `useEffect` hooks.

## Key Changes
- **SqlTableInsertDialog**: Converted from callback-based loading with `useState`/`useCallback` to promise-based approach with `Suspense` and `use()`. Extracted table content rendering into a separate `TablesContent` component that receives the promise.

- **JdbcTableSelectorDialog**: Replaced `useEffect` with promise-based initialization. Removed `useRef` for tracking values and instead pass the promise directly to a new `Dialog` component. Simplified state initialization using lazy initializer for `selected` state.

- **DatasetTableNamesPreviewButton**: Refactored to use `Suspense` and `use()` hook. Renamed `useDatasetTableNames` to `useDatasetTableNamesApi` and changed it to return a function that creates promises. Extracted table content rendering into `TableNamesContent` component.

- **TemplateEditDialog**: Converted from `useEffect`-based content loading to promise-based approach. Extracted dialog content into a separate `Dialog` component that uses `use()` to unwrap the promise and initializes state with the loaded content.

- **JdbcPropertiesPreviewDialog**: Replaced `useEffect` with promise-based loading using `Suspense` and `use()`. Extracted dialog logic into a separate `Dialog` component.

## Implementation Details
- All async operations now return promises that are passed to `Suspense` boundaries with appropriate fallback UI
- The `use()` hook unwraps promises within components rendered inside `Suspense` boundaries
- Removed manual loading state management (`loading`, `setLoading`) in favor of Suspense fallbacks
- Simplified component logic by moving promise handling to dedicated sub-components
- Maintained all existing functionality while improving code clarity and reducing boilerplate

https://claude.ai/code/session_01D76JVQH135cr7fGgHfTLXX