### PR TITLE
refactor: テーブル選択ロジックを useTableSelection フックに抽出

### DIFF
--- a/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
+++ b/tauri/src/app/settings/JdbcTableSelectorDialog.tsx
@@ -1,7 +1,8 @@
-import { Suspense, use, useState } from "react";
+import { Suspense, use, useMemo } from "react";
 import { SettingDialog } from "../../components/dialog";
 import { useJdbcTables } from "../../hooks/useJdbc";
 import { useSaveDataSource } from "../../hooks/useQueryDatasource";
+import { useTableSelection } from "../../hooks/useTableSelection";
 import { saveOnSuccess } from "../../utils/fetchUtils";
 import TableList from "./TableList";
 
@@ -48,36 +49,16 @@ function Dialog({
 	handleSave: (path: string) => void;
 }) {
 	const tables = use(promise);
-	const [selected, setSelected] = useState<Set<string>>(
+	const initial = useMemo(
 		() =>
-			new Set(
-				currentContent
-					.split("\n")
-					.map((t) => t.trim())
-					.filter((t) => t.length > 0),
-			),
+			currentContent
+				.split("\n")
+				.map((t) => t.trim())
+				.filter((t) => t.length > 0),
+		[currentContent],
 	);
+	const { selected, toggle, toggleAll } = useTableSelection(tables, initial);
 	const saveDataSource = useSaveDataSource();
-
-	const toggleTable = (table: string) => {
-		setSelected((prev) => {
-			const next = new Set(prev);
-			if (next.has(table)) {
-				next.delete(table);
-			} else {
-				next.add(table);
-			}
-			return next;
-		});
-	};
-
-	const toggleAll = (checked: boolean) => {
-		if (checked) {
-			setSelected(new Set(tables));
-		} else {
-			setSelected(new Set());
-		}
-	};
 
 	const handleSaveWithPath = (path: string) => {
 		const contents = tables.filter((t) => selected.has(t)).join("\n");
@@ -102,7 +83,7 @@ function Dialog({
 						tables={tables}
 						selected={selected}
 						onToggleAll={toggleAll}
-						onToggle={toggleTable}
+						onToggle={toggle}
 					/>
 				)}
 			</div>

--- a/tauri/src/app/settings/SqlTableInsertDialog.tsx
+++ b/tauri/src/app/settings/SqlTableInsertDialog.tsx
@@ -4,6 +4,7 @@ import {
 	WhiteButton,
 } from "../../components/element/Button";
 import { useJdbcTables } from "../../hooks/useJdbc";
+import { useTableSelection } from "../../hooks/useTableSelection";
 import TableList from "./TableList";
 
 interface SqlTableInsertDialogProps {
@@ -63,27 +64,7 @@ function TablesContent({
 	onClose: () => void;
 }) {
 	const tables = use(promise);
-	const [selected, setSelected] = useState<Set<string>>(new Set());
-
-	const toggleTable = (table: string) => {
-		setSelected((prev) => {
-			const next = new Set(prev);
-			if (next.has(table)) {
-				next.delete(table);
-			} else {
-				next.add(table);
-			}
-			return next;
-		});
-	};
-
-	const toggleAll = (checked: boolean) => {
-		if (checked) {
-			setSelected(new Set(tables));
-		} else {
-			setSelected(new Set());
-		}
-	};
+	const { selected, toggle, toggleAll } = useTableSelection(tables);
 
 	const handleInsert = () => {
 		const selectedTables = tables.filter((t) => selected.has(t));
@@ -100,7 +81,7 @@ function TablesContent({
 						tables={tables}
 						selected={selected}
 						onToggleAll={toggleAll}
-						onToggle={toggleTable}
+						onToggle={toggle}
 						maxHeightClass="max-h-72"
 					/>
 				)}

--- a/tauri/src/hooks/useTableSelection.ts
+++ b/tauri/src/hooks/useTableSelection.ts
@@ -1,0 +1,29 @@
+import { useState } from "react";
+
+export function useTableSelection(tables: string[], initial: string[] = []) {
+	const [selected, setSelected] = useState<Set<string>>(
+		() => new Set(initial),
+	);
+
+	const toggle = (table: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(table)) {
+				next.delete(table);
+			} else {
+				next.add(table);
+			}
+			return next;
+		});
+	};
+
+	const toggleAll = (checked: boolean) => {
+		if (checked) {
+			setSelected(new Set(tables));
+		} else {
+			setSelected(new Set());
+		}
+	};
+
+	return { selected, toggle, toggleAll };
+}


### PR DESCRIPTION
JdbcTableSelectorDialog と SqlTableInsertDialog で重複していた toggle/toggleAll の Set<string> 操作を共通フックに統合。

https://claude.ai/code/session_01D76JVQH135cr7fGgHfTLXX