### PR TITLE
Remove vitest/globals from TypeScript configuration

### DIFF
--- a/tauri/tsconfig.json
+++ b/tauri/tsconfig.json
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    "types": ["vitest/globals"],
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
Removed the `vitest/globals` type declaration from the TypeScript configuration in `tauri/tsconfig.json`.

## Changes
- Removed `"types": ["vitest/globals"]` from the TypeScript compiler options

## Details
This change removes the explicit type declaration for Vitest's global test utilities from the TypeScript configuration. This may indicate a shift away from using Vitest's global test functions (such as `describe`, `it`, `expect`, etc.) in favor of explicit imports, or a removal of Vitest as a testing dependency for this package.

https://claude.ai/code/session_01N3TtKov9VCoKhQZCHNMU5Q