### PR TITLE
Normalize line endings in file comparison assertions

### DIFF
--- a/core/src/test/java/yo/dbunitcli/application/command/GenerateTest.java
+++ b/core/src/test/java/yo/dbunitcli/application/command/GenerateTest.java
@@ -762,8 +762,9 @@ public class GenerateTest {
         }
 
         private void assertGenerateFileEquals(final String target, final String encode) throws IOException {
-            final String expect = Files.readString(new File(GenerateTest.testResourcesDir + "expect/" + GenerateTest.subDirectory + "/expect/txt", target).toPath(), Charset.forName(encode));
-            final String actual = Files.readString(new File(this.getResult(), target).toPath(), Charset.forName(encode));
+            final Charset charset = Charset.forName(encode);
+            final String expect = Files.readString(new File(GenerateTest.testResourcesDir + "expect/" + GenerateTest.subDirectory + "/expect/txt", target).toPath(), charset).replace("\r\n", "\n").replace("\r", "\n");
+            final String actual = Files.readString(new File(this.getResult(), target).toPath(), charset).replace("\r\n", "\n").replace("\r", "\n");
             Assertions.assertEquals(expect, actual);
         }
 


### PR DESCRIPTION
## Summary
Updated the `assertGenerateFileEquals` method to normalize line endings before comparing generated files, ensuring consistent test results across different operating systems.

## Key Changes
- Extracted `Charset` to a local variable to avoid redundant `Charset.forName()` calls
- Added line ending normalization (`\r\n` → `\n` and `\r` → `\n`) to both expected and actual file contents before comparison
- This ensures tests pass regardless of whether files use Windows (CRLF), Unix (LF), or old Mac (CR) line endings

## Implementation Details
The normalization is applied to both the expected and actual file contents read from disk, converting all line ending variants to Unix-style LF (`\n`). This approach makes the tests more robust and prevents failures due to platform-specific line ending differences.

https://claude.ai/code/session_011iNaFHGg1kWo8jQ4HAxc5f