### PR TITLE
Mock getErrorMessage utility in SelectParameterProvider tests

### DIFF
--- a/tauri/package.json
+++ b/tauri/package.json
@@ -23,6 +23,7 @@
     "@biomejs/biome": "^2.3.15",
     "@tailwindcss/cli": "^4.1.18",
     "@tauri-apps/cli": "^2.10.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/tauri/src/tests/context/SelectParameterProvider.test.tsx
+++ b/tauri/src/tests/context/SelectParameterProvider.test.tsx
@@ -120,6 +120,9 @@ const { mockFetchData } = vi.hoisted(() => {
 vi.mock("../../utils/fetchUtils", () => ({
 	fetchData: mockFetchData,
 	handleFetchError: vi.fn(),
+	getErrorMessage: vi.fn((error: unknown) =>
+		error instanceof Error ? error.message : String(error),
+	),
 }));
 
 const mockEnviroment: Enviroment = { ...enviromentFixture };


### PR DESCRIPTION
## Summary
Updated the test mocks for `fetchUtils` to include the `getErrorMessage` function, ensuring all exported utilities from the module are properly mocked in the SelectParameterProvider test suite.

## Changes
- Added mock implementation for `getErrorMessage` utility function in SelectParameterProvider.test.tsx
- The mock provides a basic implementation that returns the error message if the error is an Error instance, otherwise converts it to a string
- Added `@testing-library/dom` as a dev dependency (transitive dependency resolution)

## Implementation Details
The `getErrorMessage` mock follows a simple error handling pattern:
```typescript
getErrorMessage: vi.fn((error: unknown) =>
  error instanceof Error ? error.message : String(error),
)
```

This ensures that any test code using `getErrorMessage` from the mocked `fetchUtils` module will have a consistent, predictable implementation rather than relying on the actual utility.

https://claude.ai/code/session_0129Mp9MKjdNYticsPvnotVN