### PR TITLE
Add AbortSignal support to fetch utilities

### DIFF
--- a/tauri/src/utils/fetchUtils.ts
+++ b/tauri/src/utils/fetchUtils.ts
@@ -10,6 +10,7 @@ type ErrorInfo = {
 export type FetchParams = {
 	endpoint: string;
 	options: RequestInit;
+	signal?: AbortSignal;
 };
 
 const createErrorInfo = (
@@ -58,8 +59,11 @@ export async function saveOnSuccess(
 	}
 }
 
-export const fetchData = async ({ endpoint, options }: FetchParams) => {
-	const response = await fetch(endpoint, options);
+export const isAbortError = (error: unknown): boolean =>
+	error instanceof DOMException && error.name === "AbortError";
+
+export const fetchData = async ({ endpoint, options, signal }: FetchParams) => {
+	const response = await fetch(endpoint, { ...options, signal });
 	if (!response.ok) {
 		throw new Error(
 			`

--- a/tauri/src/utils/fetchUtils.ts
+++ b/tauri/src/utils/fetchUtils.ts
@@ -63,7 +63,7 @@ export const isAbortError = (error: unknown): boolean =>
 	error instanceof DOMException && error.name === "AbortError";
 
 export const fetchData = async ({ endpoint, options, signal }: FetchParams) => {
-	const response = await fetch(endpoint, { ...options, signal });
+	const response = await fetch(endpoint, { ...options, signal: signal ?? options.signal });
 	if (!response.ok) {
 		throw new Error(
 			`


### PR DESCRIPTION
## Summary
Enhanced the fetch utilities to support request cancellation via AbortSignal, enabling better control over in-flight HTTP requests.

## Key Changes
- Added optional `signal` parameter to `FetchParams` type for passing AbortSignal to fetch requests
- Updated `fetchData` function to accept and merge the signal with existing request options
- Added `isAbortError` utility function to detect and handle abort errors (DOMException with name "AbortError")

## Implementation Details
- The signal is merged into the fetch options with a fallback to any signal already present in the options object (`signal: signal ?? options.signal`)
- The `isAbortError` helper provides a type-safe way to distinguish abort errors from other fetch failures, useful for handling cancellation scenarios differently from network errors

https://claude.ai/code/session_0119ubMvnffdJpfykzZjWUZJ