### PR TITLE
Add request cancellation support for parameter operations

### DIFF
--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -58,6 +58,7 @@ export default function Footer(prop: {
 
 		return () => {
 			active = false;
+			abortControllerRef.current?.abort();
 			abortControllerRef.current = null;
 		};
 	}, [running.command, execParameter, saveParameter, saveShell]);

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -23,6 +23,7 @@ export default function Footer(prop: {
 	} as Running);
 	const [isLoading, setIsLoading] = useState(false);
 	const executingRef = useRef(false);
+	const abortControllerRef = useRef<AbortController | null>(null);
 	const parameter = useSelectParameter();
 	const saveParameter = useSaveParameter();
 	const execParameter = useExecParameter();
@@ -35,30 +36,42 @@ export default function Footer(prop: {
 		executingRef.current = true;
 		let active = true;
 		setIsLoading(true);
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
 
 		const handleResult = (result: Running) => {
 			if (active) {
 				executingRef.current = false;
+				abortControllerRef.current = null;
 				setRunning(result);
 				setIsLoading(false);
 			}
 		};
 
 		if (running.command === "exec") {
-			execParameter(prop.formData(false).values, handleResult);
+			execParameter(prop.formData(false).values, handleResult, controller.signal);
 		} else if (running.command === "save") {
-			saveParameter(prop.formData(false).values, handleResult);
+			saveParameter(prop.formData(false).values, handleResult, controller.signal);
 		} else if (running.command === "saveShell") {
-			saveShell(handleResult);
+			saveShell(handleResult, controller.signal);
 		}
 
 		return () => {
 			active = false;
+			abortControllerRef.current = null;
 		};
 	}, [running.command, execParameter, saveParameter, saveShell]);
 
 	const openDirectory = async (path: string) => {
 		await core.invoke("open_directory", { path });
+	};
+
+	const handleCancel = () => {
+		abortControllerRef.current?.abort();
+		abortControllerRef.current = null;
+		executingRef.current = false;
+		setIsLoading(false);
+		setRunning({ command: "", resultMessage: "", resultDir: "" });
 	};
 
 	if (isLoading) {
@@ -71,6 +84,9 @@ export default function Footer(prop: {
 								Now Execution
 							</h3>
 							<div className="block animate-spin h-10 w-10 border-4 border-blue-500 rounded-full border-t-transparent" />
+							<div className="mt-4">
+								<WhiteButton title="Cancel" handleClick={handleCancel} />
+							</div>
 						</div>
 					</div>
 				</div>

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer(prop: {
 							</h3>
 							<div className="block animate-spin h-10 w-10 border-4 border-blue-500 rounded-full border-t-transparent" />
 							<div className="mt-4">
-								<WhiteButton title="Cancel" handleClick={handleCancel} />
+								<WhiteButton title="Abandoned" handleClick={handleCancel} />
 							</div>
 						</div>
 					</div>

--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -10,7 +10,7 @@ import type {
 	ParameterizeOptions,
 } from "../model/SelectParameter";
 import { SelectParameter } from "../model/SelectParameter";
-import { fetchData, getErrorMessage, handleFetchError } from "../utils/fetchUtils";
+import { fetchData, getErrorMessage, handleFetchError, isAbortError } from "../utils/fetchUtils";
 
 export type Running = {
 	command: string;
@@ -87,6 +87,7 @@ const useParameterAction = () => {
 		action: ParameterAction,
 		extraBody: Record<string, unknown>,
 		handleResult: (result: Running) => void,
+		signal?: AbortSignal,
 	) => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl + parameter.command}/${action}`,
@@ -95,11 +96,15 @@ const useParameterAction = () => {
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ name: parameter.name, ...extraBody }),
 			},
+			signal,
 		};
 		try {
 			const response = await fetchData(fetchParams);
 			handleResult(await parseResponse(action, response));
 		} catch (ex) {
+			if (isAbortError(ex)) {
+				return;
+			}
 			const errorMessage = getErrorMessage(ex);
 			handleFetchError(errorMessage, fetchParams);
 			handleResult({ command: "", resultMessage: errorMessage, resultDir: "" });
@@ -112,7 +117,8 @@ export const useSaveParameter = () => {
 	return async (
 		input: { [k: string]: FormDataEntryValue },
 		handleResult: (result: Running) => void,
-	) => execute("save", { input }, handleResult);
+		signal?: AbortSignal,
+	) => execute("save", { input }, handleResult, signal);
 };
 
 export const useExecParameter = () => {
@@ -120,13 +126,14 @@ export const useExecParameter = () => {
 	return async (
 		input: { [k: string]: FormDataEntryValue },
 		handleResult: (result: Running) => void,
-	) => execute("exec", { input }, handleResult);
+		signal?: AbortSignal,
+	) => execute("exec", { input }, handleResult, signal);
 };
 
 export const useSaveShell = () => {
 	const execute = useParameterAction();
-	return async (handleResult: (result: Running) => void) =>
-		execute("shell", {}, handleResult);
+	return async (handleResult: (result: Running) => void, signal?: AbortSignal) =>
+		execute("shell", {}, handleResult, signal);
 };
 
 export const useParameterizeFrom = () => {


### PR DESCRIPTION
## Summary
This PR adds the ability to cancel ongoing parameter operations (exec, save, saveShell) by implementing AbortController support throughout the request chain. Users can now click an "Abandoned" button during execution to cancel the operation.

## Key Changes
- **Footer Component**: 
  - Added `abortControllerRef` to track the current AbortController instance
  - Created `handleCancel()` function to abort requests and reset loading state
  - Added "Abandoned" button in the loading UI that triggers cancellation
  - Pass abort signal to all parameter operation hooks

- **useSelectParameter Hook**:
  - Updated `useParameterAction()` to accept and pass `AbortSignal` to fetch requests
  - Added abort error handling to gracefully ignore cancelled requests
  - Updated `useSaveParameter()`, `useExecParameter()`, and `useSaveShell()` to accept optional signal parameter
  - Imported `isAbortError` utility for proper error detection

## Implementation Details
- AbortController is created at the start of each operation and stored in a ref
- The signal is passed through the entire fetch chain to enable cancellation
- Cleanup function in useEffect aborts any pending requests when component unmounts
- Abort errors are caught and silently ignored (no error message shown to user)
- All refs are properly cleared after operation completion or cancellation

https://claude.ai/code/session_01HbGYJCeoGuupLsdouCDC5j