### PR TITLE
Add help window with sidebar help link button

### DIFF
--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>DBUnit CLI Help</title>
+</head>
+<body>
+  <h1>DBUnit CLI Help</h1>
+  <p>Coming soon.</p>
+</body>
+</html>

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
     "dialog:allow-ask",
     "dialog:allow-confirm",
     "cli:allow-cli-matches",
+    "core:webview:allow-create-webview",
     {
       "identifier": "http:default",
       "allow": [

--- a/tauri/src/app/main/Sidebar.tsx
+++ b/tauri/src/app/main/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import NamedParameters from "../sidebar/NamedParameters";
 import NameEditMenu from "../sidebar/NameEditMenu";
+import SidebarHelpLink from "../sidebar/SidebarHelpLink";
 
 interface SidebarProps {
 	setSidebarWidth: (width: number) => void;
@@ -44,11 +45,14 @@ export default function Sidebar({ setSidebarWidth }: SidebarProps) {
 		<div
 			ref={sidebarRef}
 			style={{ width: `${width}px` }}
-			className="h-full overflow-y-auto"
+			className="flex flex-col h-full"
 		>
-			<div className="h-full px-3 pb-4 pt-4">
+			<div className="flex-1 overflow-y-auto px-3 pt-4 pb-2">
 				<NameEditMenu editName={editName} setEditName={setEditName} />
 				<NamedParameters setEditName={setEditName} />
+			</div>
+			<div className="border-t border-gray-200 px-3 py-2">
+				<SidebarHelpLink />
 			</div>
 			<div
 				onMouseDown={handleMouseDown}

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -4,6 +4,11 @@ import { HelpIcon } from "../../components/element/Icon";
 
 export default function SidebarHelpLink() {
 	const handleOpenHelp = async () => {
+		const existing = await WebviewWindow.getByLabel("help");
+		if (existing !== null) {
+			await existing.setFocus();
+			return;
+		}
 		const webview = new WebviewWindow("help", {
 			url: "/help/index.html",
 			title: "Help",

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -1,0 +1,20 @@
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { ButtonIcon } from "../../components/element/ButtonIcon";
+import { HelpIcon } from "../../components/element/Icon";
+
+export default function SidebarHelpLink() {
+	const handleOpenHelp = async () => {
+		const webview = new WebviewWindow("help", {
+			url: "/help/index.html",
+			title: "Help",
+			width: 900,
+			height: 700,
+		});
+		webview.once("tauri://error", console.error);
+	};
+	return (
+		<ButtonIcon title="Help" handleClick={handleOpenHelp}>
+			<HelpIcon />
+		</ButtonIcon>
+	);
+}

--- a/tauri/src/components/element/Icon.tsx
+++ b/tauri/src/components/element/Icon.tsx
@@ -172,6 +172,20 @@ export function PreviewIcon(props: { title?: string; fill?: string }) {
 		</svg>
 	);
 }
+export function HelpIcon(props: { title?: string; fill?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			height="24px"
+			viewBox="0 -960 960 960"
+			width="24px"
+			fill={props.fill ?? "#5f6368"}
+		>
+			<title>{props.title ?? "help"}</title>
+			<path d="M478-240q21 0 35.5-14.5T528-290q0-21-14.5-35.5T478-340q-21 0-35.5 14.5T428-290q0 21 14.5 35.5T478-240Zm-36-154h74q0-36 8-52t42-44q30-26 44.5-51.5T626-600q0-57-41.5-91.5T484-726q-51 0-88.5 27T343-630l66 26q8-25 27.5-42t47.5-17q28 0 47 15.5t19 40.5q0 22-12.5 40.5T506-540q-35 30-49.5 54.5T442-394ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" />
+		</svg>
+	);
+}
 export function ExpandIcon(props: { title?: string; close: boolean }) {
 	return (
 		<svg


### PR DESCRIPTION
## Summary
This PR adds a help system to the application by introducing a new help window that can be opened from a help button in the sidebar.

## Key Changes
- **New SidebarHelpLink component**: Created a new component that renders a help button in the sidebar. Clicking the button opens a help window using Tauri's WebviewWindow API. If the help window is already open, it focuses the existing window instead of creating a duplicate.
- **HelpIcon component**: Added a new Material Design help icon (question mark in circle) to the Icon component library.
- **Help page**: Created a basic help HTML page at `public/help/index.html` with placeholder content ("Coming soon").
- **Sidebar layout restructure**: Modified the Sidebar component to use flexbox layout, allowing the help button to be positioned at the bottom of the sidebar with a top border separator.
- **Tauri capabilities**: Added `core:webview:allow-create-webview` permission to enable the help window creation.

## Implementation Details
- The help window is configured with dimensions of 900x700 pixels and loads from `/help/index.html`
- The WebviewWindow API is used to check for existing help windows before creating new ones, preventing multiple instances
- The help button is styled using the existing ButtonIcon component and positioned in a footer section of the sidebar

https://claude.ai/code/session_01DAG9qZin7VMnamrByA9ijr