### PR TITLE
Add help menu with command-specific documentation

### DIFF
--- a/tauri/public/help/compare.html
+++ b/tauri/public/help/compare.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Help - Compare</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; Back to Help</a></p>
+  <h1>Compare</h1>
+  <p>Compare datasets and detect differences. Compares old and new data sources and reports any discrepancies found.</p>
+
+  <h2>Options</h2>
+  <table>
+    <tr><th>Option</th><th>Description</th></tr>
+    <tr><td>targetType</td><td>Type of comparison target</td></tr>
+    <tr><td>setting</td><td>File comparison settings</td></tr>
+    <tr><td>settingEncoding</td><td>Settings file encoding</td></tr>
+    <tr><td>oldData</td><td>Original (old) dataset source</td></tr>
+    <tr><td>newData</td><td>New dataset source to compare against</td></tr>
+    <tr><td>expectData</td><td>Expected result dataset</td></tr>
+    <tr><td>imageOption</td><td>Image comparison options</td></tr>
+    <tr><td>convertResult</td><td>Output format and destination settings</td></tr>
+  </table>
+</body>
+</html>

--- a/tauri/public/help/convert.html
+++ b/tauri/public/help/convert.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Help - Convert</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; Back to Help</a></p>
+  <h1>Convert</h1>
+  <p>Convert data between formats. Reads data from a source dataset and writes it to the specified output format (CSV, Excel, SQL, etc.).</p>
+
+  <h2>Options</h2>
+  <table>
+    <tr><th>Option</th><th>Description</th></tr>
+    <tr><td>srcData</td><td>Source dataset to convert from</td></tr>
+    <tr><td>convertResult</td><td>Output format and destination settings</td></tr>
+  </table>
+</body>
+</html>

--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Help - Generate</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; Back to Help</a></p>
+  <h1>Generate</h1>
+  <p>Generate files from templates. Uses source data and a template engine to produce output files such as SQL, CSV, or other formats.</p>
+
+  <h2>Options</h2>
+  <table>
+    <tr><th>Option</th><th>Description</th></tr>
+    <tr><td>generateType</td><td>Type of generation output</td></tr>
+    <tr><td>unit</td><td>Generate by row, table, or dataset</td></tr>
+    <tr><td>template</td><td>Template file</td></tr>
+    <tr><td>result</td><td>Directory to place result files</td></tr>
+    <tr><td>resultPath</td><td>Result file relative path from result directory</td></tr>
+    <tr><td>outputEncoding</td><td>Output file encoding</td></tr>
+    <tr><td>srcData</td><td>Source dataset</td></tr>
+    <tr><td>templateOption</td><td>Template engine options</td></tr>
+  </table>
+</body>
+</html>

--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -1,11 +1,27 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <title>DBUnit CLI Help</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 1rem; }
+    a { display: block; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem; text-decoration: none; color: inherit; transition: background 0.15s; }
+    a:hover { background: #f3f4f6; }
+    .cmd-name { font-size: 1.1rem; font-weight: 600; color: #4f46e5; }
+    .cmd-desc { font-size: 0.9rem; color: #6b7280; margin-top: 0.25rem; }
+  </style>
 </head>
 <body>
   <h1>DBUnit CLI Help</h1>
-  <p>Coming soon.</p>
+  <ul>
+    <li><a href="convert.html"><div class="cmd-name">Convert</div><div class="cmd-desc">Convert data between formats</div></a></li>
+    <li><a href="compare.html"><div class="cmd-name">Compare</div><div class="cmd-desc">Compare datasets and detect differences</div></a></li>
+    <li><a href="generate.html"><div class="cmd-name">Generate</div><div class="cmd-desc">Generate files from templates</div></a></li>
+    <li><a href="run.html"><div class="cmd-name">Run</div><div class="cmd-desc">Execute SQL or scripts</div></a></li>
+    <li><a href="parameterize.html"><div class="cmd-name">Parameterize</div><div class="cmd-desc">Batch process with parameters</div></a></li>
+  </ul>
 </body>
 </html>

--- a/tauri/public/help/parameterize.html
+++ b/tauri/public/help/parameterize.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Help - Parameterize</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; Back to Help</a></p>
+  <h1>Parameterize</h1>
+  <p>Batch process with parameters. Executes a target command repeatedly, driven by rows from a parameter dataset.</p>
+
+  <h2>Options</h2>
+  <table>
+    <tr><th>Option</th><th>Description</th></tr>
+    <tr><td>unit</td><td>Pass parameter to template by row, table, or dataset</td></tr>
+    <tr><td>parameterize</td><td>Whether cmdParam is a template populated by parameters</td></tr>
+    <tr><td>ignoreFail</td><td>Continue other commands when compare finds unexpected differences</td></tr>
+    <tr><td>cmd</td><td>Data-driven target command</td></tr>
+    <tr><td>cmdParam</td><td>Parameter file for command; dynamically set filename from parameter dataset</td></tr>
+    <tr><td>template</td><td>Default template file (ignored when cmdParam exists)</td></tr>
+    <tr><td>paramData</td><td>Parameter dataset source</td></tr>
+    <tr><td>templateOption</td><td>Template engine options</td></tr>
+  </table>
+</body>
+</html>

--- a/tauri/public/help/run.html
+++ b/tauri/public/help/run.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Help - Run</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; Back to Help</a></p>
+  <h1>Run</h1>
+  <p>Execute SQL or scripts. Runs SQL statements, ANT scripts, or batch files against a data source.</p>
+
+  <h2>Options</h2>
+  <table>
+    <tr><th>Option</th><th>Description</th></tr>
+    <tr><td>scriptType</td><td>Type of script to execute (SQL, ANT, batch)</td></tr>
+    <tr><td>srcData</td><td>Source dataset</td></tr>
+    <tr><td>templateOption</td><td>Template engine options</td></tr>
+    <tr><td>jdbcOption</td><td>JDBC connection settings</td></tr>
+  </table>
+</body>
+</html>

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -1,25 +1,78 @@
+import { useEffect, useRef, useState } from "react";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { ButtonIcon } from "../../components/element/ButtonIcon";
 import { HelpIcon } from "../../components/element/Icon";
 
+const helpCommands = [
+	{ command: "convert", label: "Convert", description: "Convert data between formats" },
+	{ command: "compare", label: "Compare", description: "Compare datasets and detect differences" },
+	{ command: "generate", label: "Generate", description: "Generate files from templates" },
+	{ command: "run", label: "Run", description: "Execute SQL or scripts" },
+	{ command: "parameterize", label: "Parameterize", description: "Batch process with parameters" },
+] as const;
+
+async function openHelpWindow(command: string, label: string) {
+	const windowLabel = `help-${command}`;
+	const existing = await WebviewWindow.getByLabel(windowLabel);
+	if (existing !== null) {
+		await existing.setFocus();
+		return;
+	}
+	const webview = new WebviewWindow(windowLabel, {
+		url: `/help/${command}.html`,
+		title: `Help - ${label}`,
+		width: 900,
+		height: 700,
+	});
+	webview.once("tauri://error", console.error);
+}
+
 export default function SidebarHelpLink() {
-	const handleOpenHelp = async () => {
-		const existing = await WebviewWindow.getByLabel("help");
-		if (existing !== null) {
-			await existing.setFocus();
+	const [showMenu, setShowMenu] = useState(false);
+	const wrapperRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!showMenu) {
 			return;
 		}
-		const webview = new WebviewWindow("help", {
-			url: "/help/index.html",
-			title: "Help",
-			width: 900,
-			height: 700,
-		});
-		webview.once("tauri://error", console.error);
-	};
+		function handleClickOutside(event: Event) {
+			if (
+				wrapperRef.current &&
+				!wrapperRef.current.contains(event.target as HTMLElement)
+			) {
+				setShowMenu(false);
+			}
+		}
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, [showMenu]);
+
 	return (
-		<ButtonIcon title="Help" handleClick={handleOpenHelp}>
-			<HelpIcon />
-		</ButtonIcon>
+		<div ref={wrapperRef} className="relative">
+			<ButtonIcon title="Help" handleClick={() => setShowMenu((prev) => !prev)}>
+				<HelpIcon />
+			</ButtonIcon>
+			{showMenu && (
+				<div className="absolute bottom-full left-0 mb-1 z-50 p-2 bg-white border border-gray-100 rounded-lg shadow-md w-64">
+					<ul className="space-y-1">
+						{helpCommands.map((item) => (
+							<li key={item.command}>
+								<button
+									type="button"
+									className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 transition duration-100 ring-indigo-300 focus-visible:ring-3"
+									onClick={() => {
+										openHelpWindow(item.command, item.label);
+										setShowMenu(false);
+									}}
+								>
+									<span className="block text-sm font-semibold text-gray-700">{item.label}</span>
+									<span className="block text-xs text-gray-500">{item.description}</span>
+								</button>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { Button } from "../../components/element/Button";
 import { ButtonIcon } from "../../components/element/ButtonIcon";
 import { HelpIcon } from "../../components/element/Icon";
 
@@ -57,17 +58,19 @@ export default function SidebarHelpLink() {
 					<ul className="space-y-1">
 						{helpCommands.map((item) => (
 							<li key={item.command}>
-								<button
-									type="button"
-									className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 transition duration-100 ring-indigo-300 focus-visible:ring-3"
-									onClick={() => {
+								<Button
+									buttonstyle="w-full text-left px-3 py-2"
+									bgcolor="hover:bg-gray-100"
+									textstyle=""
+									border="outline-hidden"
+									handleClick={() => {
 										openHelpWindow(item.command, item.label);
 										setShowMenu(false);
 									}}
 								>
 									<span className="block text-sm font-semibold text-gray-700">{item.label}</span>
 									<span className="block text-xs text-gray-500">{item.description}</span>
-								</button>
+								</Button>
 							</li>
 						))}
 					</ul>


### PR DESCRIPTION
## Summary
Transformed the help system from a single help window into a dropdown menu with command-specific documentation pages. Users can now access targeted help for Convert, Compare, Generate, Run, and Parameterize commands directly from the sidebar.

## Key Changes
- **Refactored SidebarHelpLink component**: Converted from a simple button that opens a single help window into an interactive dropdown menu with click-outside detection
- **Added help command menu**: Implemented a dropdown menu displaying five core commands (Convert, Compare, Generate, Run, Parameterize) with descriptions
- **Created command-specific help pages**: Added individual HTML documentation pages for each command with options tables and descriptions
- **Updated main help index**: Replaced placeholder content with a styled landing page linking to all command-specific help pages
- **Improved UX**: Added state management for menu visibility and click-outside handling to close the menu when clicking elsewhere

## Implementation Details
- Used React hooks (`useState`, `useRef`, `useEffect`) for menu state and click-outside detection
- Extracted help window creation into a reusable `openHelpWindow()` function that prevents duplicate windows
- Applied consistent styling across all help pages with a professional design using Tailwind-compatible CSS
- Each help page includes an options table documenting command-specific parameters
- Help windows are labeled by command (e.g., `help-convert`) to allow independent window management

https://claude.ai/code/session_01L5BaBtyEeHkHhZZdKmUtfW