### PR TITLE
Localize help documentation to Japanese

### DIFF
--- a/tauri/public/help/compare.html
+++ b/tauri/public/help/compare.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Help - Compare</title>
+  <title>ヘルプ - Compare</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -16,21 +16,21 @@
   </style>
 </head>
 <body>
-  <p><a href="index.html">&larr; Back to Help</a></p>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
   <h1>Compare</h1>
-  <p>Compare datasets and detect differences. Compares old and new data sources and reports any discrepancies found.</p>
+  <p>データセットを比較して差分を検出します。旧データと新データを突き合わせ、差分があれば出力します。</p>
 
-  <h2>Options</h2>
+  <h2>オプション</h2>
   <table>
-    <tr><th>Option</th><th>Description</th></tr>
-    <tr><td>targetType</td><td>Type of comparison target</td></tr>
-    <tr><td>setting</td><td>File comparison settings</td></tr>
-    <tr><td>settingEncoding</td><td>Settings file encoding</td></tr>
-    <tr><td>oldData</td><td>Original (old) dataset source</td></tr>
-    <tr><td>newData</td><td>New dataset source to compare against</td></tr>
-    <tr><td>expectData</td><td>Expected result dataset</td></tr>
-    <tr><td>imageOption</td><td>Image comparison options</td></tr>
-    <tr><td>convertResult</td><td>Output format and destination settings</td></tr>
+    <tr><th>オプション</th><th>説明</th></tr>
+    <tr><td>targetType</td><td>比較対象の種類</td></tr>
+    <tr><td>setting</td><td>ファイル比較の設定</td></tr>
+    <tr><td>settingEncoding</td><td>設定ファイルのエンコーディング</td></tr>
+    <tr><td>oldData</td><td>比較元（旧）データセット</td></tr>
+    <tr><td>newData</td><td>比較対象となる新データセット</td></tr>
+    <tr><td>expectData</td><td>期待値データセット</td></tr>
+    <tr><td>imageOption</td><td>画像比較のオプション</td></tr>
+    <tr><td>convertResult</td><td>出力形式と出力先の設定</td></tr>
   </table>
 </body>
 </html>

--- a/tauri/public/help/convert.html
+++ b/tauri/public/help/convert.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Help - Convert</title>
+  <title>ヘルプ - Convert</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -16,15 +16,15 @@
   </style>
 </head>
 <body>
-  <p><a href="index.html">&larr; Back to Help</a></p>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
   <h1>Convert</h1>
-  <p>Convert data between formats. Reads data from a source dataset and writes it to the specified output format (CSV, Excel, SQL, etc.).</p>
+  <p>データ形式を変換します。ソースとなるデータセットを読み込み、指定した出力形式（CSV・Excel・SQL など）で書き出します。</p>
 
-  <h2>Options</h2>
+  <h2>オプション</h2>
   <table>
-    <tr><th>Option</th><th>Description</th></tr>
-    <tr><td>srcData</td><td>Source dataset to convert from</td></tr>
-    <tr><td>convertResult</td><td>Output format and destination settings</td></tr>
+    <tr><th>オプション</th><th>説明</th></tr>
+    <tr><td>srcData</td><td>変換元のデータセット</td></tr>
+    <tr><td>convertResult</td><td>出力形式と出力先の設定</td></tr>
   </table>
 </body>
 </html>

--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Help - Generate</title>
+  <title>ヘルプ - Generate</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -16,21 +16,21 @@
   </style>
 </head>
 <body>
-  <p><a href="index.html">&larr; Back to Help</a></p>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
   <h1>Generate</h1>
-  <p>Generate files from templates. Uses source data and a template engine to produce output files such as SQL, CSV, or other formats.</p>
+  <p>テンプレートからファイルを生成します。ソースデータとテンプレートエンジンを用いて、SQL や CSV などの出力ファイルを作成します。</p>
 
-  <h2>Options</h2>
+  <h2>オプション</h2>
   <table>
-    <tr><th>Option</th><th>Description</th></tr>
-    <tr><td>generateType</td><td>Type of generation output</td></tr>
-    <tr><td>unit</td><td>Generate by row, table, or dataset</td></tr>
-    <tr><td>template</td><td>Template file</td></tr>
-    <tr><td>result</td><td>Directory to place result files</td></tr>
-    <tr><td>resultPath</td><td>Result file relative path from result directory</td></tr>
-    <tr><td>outputEncoding</td><td>Output file encoding</td></tr>
-    <tr><td>srcData</td><td>Source dataset</td></tr>
-    <tr><td>templateOption</td><td>Template engine options</td></tr>
+    <tr><th>オプション</th><th>説明</th></tr>
+    <tr><td>generateType</td><td>生成出力の種類</td></tr>
+    <tr><td>unit</td><td>行・テーブル・データセット単位で生成</td></tr>
+    <tr><td>template</td><td>テンプレートファイル</td></tr>
+    <tr><td>result</td><td>生成結果ファイルを配置するディレクトリ</td></tr>
+    <tr><td>resultPath</td><td>result ディレクトリからの相対パス</td></tr>
+    <tr><td>outputEncoding</td><td>出力ファイルのエンコーディング</td></tr>
+    <tr><td>srcData</td><td>ソースデータセット</td></tr>
+    <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
   </table>
 </body>
 </html>

--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>DBUnit CLI Help</title>
+  <title>DBUnit CLI ヘルプ</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -15,13 +15,13 @@
   </style>
 </head>
 <body>
-  <h1>DBUnit CLI Help</h1>
+  <h1>DBUnit CLI ヘルプ</h1>
   <ul>
-    <li><a href="convert.html"><div class="cmd-name">Convert</div><div class="cmd-desc">Convert data between formats</div></a></li>
-    <li><a href="compare.html"><div class="cmd-name">Compare</div><div class="cmd-desc">Compare datasets and detect differences</div></a></li>
-    <li><a href="generate.html"><div class="cmd-name">Generate</div><div class="cmd-desc">Generate files from templates</div></a></li>
-    <li><a href="run.html"><div class="cmd-name">Run</div><div class="cmd-desc">Execute SQL or scripts</div></a></li>
-    <li><a href="parameterize.html"><div class="cmd-name">Parameterize</div><div class="cmd-desc">Batch process with parameters</div></a></li>
+    <li><a href="convert.html"><div class="cmd-name">Convert</div><div class="cmd-desc">データ形式を変換する</div></a></li>
+    <li><a href="compare.html"><div class="cmd-name">Compare</div><div class="cmd-desc">データセットを比較して差分を検出する</div></a></li>
+    <li><a href="generate.html"><div class="cmd-name">Generate</div><div class="cmd-desc">テンプレートからファイルを生成する</div></a></li>
+    <li><a href="run.html"><div class="cmd-name">Run</div><div class="cmd-desc">SQL やスクリプトを実行する</div></a></li>
+    <li><a href="parameterize.html"><div class="cmd-name">Parameterize</div><div class="cmd-desc">パラメータでバッチ処理する</div></a></li>
   </ul>
 </body>
 </html>

--- a/tauri/public/help/parameterize.html
+++ b/tauri/public/help/parameterize.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Help - Parameterize</title>
+  <title>ヘルプ - Parameterize</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -16,21 +16,21 @@
   </style>
 </head>
 <body>
-  <p><a href="index.html">&larr; Back to Help</a></p>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
   <h1>Parameterize</h1>
-  <p>Batch process with parameters. Executes a target command repeatedly, driven by rows from a parameter dataset.</p>
+  <p>パラメータでバッチ処理します。パラメータデータセットの各行を入力として、対象コマンドを繰り返し実行します。</p>
 
-  <h2>Options</h2>
+  <h2>オプション</h2>
   <table>
-    <tr><th>Option</th><th>Description</th></tr>
-    <tr><td>unit</td><td>Pass parameter to template by row, table, or dataset</td></tr>
-    <tr><td>parameterize</td><td>Whether cmdParam is a template populated by parameters</td></tr>
-    <tr><td>ignoreFail</td><td>Continue other commands when compare finds unexpected differences</td></tr>
-    <tr><td>cmd</td><td>Data-driven target command</td></tr>
-    <tr><td>cmdParam</td><td>Parameter file for command; dynamically set filename from parameter dataset</td></tr>
-    <tr><td>template</td><td>Default template file (ignored when cmdParam exists)</td></tr>
-    <tr><td>paramData</td><td>Parameter dataset source</td></tr>
-    <tr><td>templateOption</td><td>Template engine options</td></tr>
+    <tr><th>オプション</th><th>説明</th></tr>
+    <tr><td>unit</td><td>テンプレートへのパラメータ受け渡し単位（行・テーブル・データセット）</td></tr>
+    <tr><td>parameterize</td><td>cmdParam をパラメータで展開するテンプレートとして扱うかどうか</td></tr>
+    <tr><td>ignoreFail</td><td>compare で想定外の差分が出た場合も他のコマンドを続行する</td></tr>
+    <tr><td>cmd</td><td>データ駆動で実行する対象コマンド</td></tr>
+    <tr><td>cmdParam</td><td>コマンド用パラメータファイル。ファイル名はパラメータデータセットから動的に決定</td></tr>
+    <tr><td>template</td><td>既定のテンプレートファイル（cmdParam がある場合は無視）</td></tr>
+    <tr><td>paramData</td><td>パラメータデータセットのソース</td></tr>
+    <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
   </table>
 </body>
 </html>

--- a/tauri/public/help/run.html
+++ b/tauri/public/help/run.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Help - Run</title>
+  <title>ヘルプ - Run</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
@@ -16,17 +16,17 @@
   </style>
 </head>
 <body>
-  <p><a href="index.html">&larr; Back to Help</a></p>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
   <h1>Run</h1>
-  <p>Execute SQL or scripts. Runs SQL statements, ANT scripts, or batch files against a data source.</p>
+  <p>SQL やスクリプトを実行します。データソースに対して SQL 文・ANT スクリプト・バッチファイルを実行します。</p>
 
-  <h2>Options</h2>
+  <h2>オプション</h2>
   <table>
-    <tr><th>Option</th><th>Description</th></tr>
-    <tr><td>scriptType</td><td>Type of script to execute (SQL, ANT, batch)</td></tr>
-    <tr><td>srcData</td><td>Source dataset</td></tr>
-    <tr><td>templateOption</td><td>Template engine options</td></tr>
-    <tr><td>jdbcOption</td><td>JDBC connection settings</td></tr>
+    <tr><th>オプション</th><th>説明</th></tr>
+    <tr><td>scriptType</td><td>実行するスクリプトの種類（SQL・ANT・バッチ）</td></tr>
+    <tr><td>srcData</td><td>ソースデータセット</td></tr>
+    <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
+    <tr><td>jdbcOption</td><td>JDBC 接続設定</td></tr>
   </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Translated all help documentation files from English to Japanese to support Japanese-speaking users of the DBUnit CLI application.

## Changes Made
- Changed HTML language attribute from `en` to `ja` across all help files
- Translated page titles in `<title>` tags to Japanese
- Translated all user-facing content including:
  - Navigation links ("Back to Help" → "ヘルプ一覧に戻る")
  - Section headings ("Options" → "オプション")
  - Table headers ("Option"/"Description" → "オプション"/"説明")
  - Command descriptions and option explanations
- Updated files:
  - `tauri/public/help/index.html` - Main help index page
  - `tauri/public/help/convert.html` - Convert command help
  - `tauri/public/help/compare.html` - Compare command help
  - `tauri/public/help/generate.html` - Generate command help
  - `tauri/public/help/run.html` - Run command help
  - `tauri/public/help/parameterize.html` - Parameterize command help

## Implementation Details
- All HTML structure and styling remain unchanged; only text content was translated
- Command names (Convert, Compare, Generate, Run, Parameterize) were kept in English as they are technical identifiers
- Translations maintain the original meaning and context of technical documentation

https://claude.ai/code/session_01NBSkc9jhCwhy48nEWNuNEK