### PR TITLE
Add Dataset Settings help documentation and refactor help window utility

### DIFF
--- a/tauri/public/help/dataset-settings.html
+++ b/tauri/public/help/dataset-settings.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Dataset Settings</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Dataset Settings</h1>
+  <p>テーブルごとのメタデータ（主キー・カラム選択・ソート・フィルタなど）を定義する設定ファイルです。<code>settings</code> 配列で個別のテーブル設定を、<code>commonSettings</code> 配列で複数テーブル共通の設定を記述します。</p>
+
+  <h2>settings のフィールド</h2>
+  <table>
+    <tr><th>フィールド</th><th>説明</th></tr>
+    <tr><td>name</td><td>対象テーブル名。スキーマを含める場合は <code>schema.table</code> 形式</td></tr>
+    <tr><td>keys</td><td>主キーのカラム名（複数指定可）</td></tr>
+    <tr><td>include</td><td>処理対象にするカラム</td></tr>
+    <tr><td>exclude</td><td>除外するカラム</td></tr>
+    <tr><td>order</td><td>ソート順に使うカラム</td></tr>
+    <tr><td>filter</td><td>データ選択条件（JExl 式）</td></tr>
+    <tr><td>distinct</td><td>重複除去フラグ</td></tr>
+  </table>
+
+  <h2>commonSettings</h2>
+  <p><code>settings</code> と同じ形式で、複数テーブルに適用される共通設定を定義します。</p>
+  <h3>上書きルール</h3>
+  <ol>
+    <li><code>settings</code> の設定が優先されます</li>
+    <li>配列（<code>include</code>、<code>exclude</code> など）は結合されます</li>
+    <li>フラグ（<code>distinct</code>）は上書きされます</li>
+  </ol>
+
+  <h2>import</h2>
+  <p>外部の設定ファイルを読み込んで再利用できます。</p>
+  <pre>{
+  "import": [
+    { "path": "./common/base.json" },
+    { "path": "/abs/path/conf.json" }
+  ]
+}</pre>
+  <h3>パス解決の優先順位</h3>
+  <ol>
+    <li>絶対パス</li>
+    <li>設定ファイルからの相対パス</li>
+    <li>カレントディレクトリからの相対パス</li>
+  </ol>
+
+  <h2>記述例</h2>
+  <pre>{
+  "settings": [
+    {
+      "name": "users",
+      "keys": ["id"],
+      "exclude": ["created_at", "updated_at"],
+      "order": ["id"]
+    }
+  ],
+  "commonSettings": [
+    {
+      "exclude": ["created_at", "updated_at"]
+    }
+  ]
+}</pre>
+</body>
+</html>

--- a/tauri/src/app/form/section/dialog/DatasetSettingsDialog.tsx
+++ b/tauri/src/app/form/section/dialog/DatasetSettingsDialog.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { SettingDialog, SettingTable } from "../../../../components/dialog";
+import { ButtonIcon } from "../../../../components/element/ButtonIcon";
+import { HelpIcon } from "../../../../components/element/Icon";
 import {
 	useDatasetSettingsData,
 	useDeleteDatasetSettings,
@@ -11,6 +13,7 @@ import {
 	newDatasetSetting,
 } from "../../../../model/DatasetSettings";
 import { saveOnSuccess } from "../../../../utils/fetchUtils";
+import { openHelpWindow } from "../../../../utils/helpWindow";
 import DatasetSettingDialog from "./DatasetSettingDialog";
 import ResourceEditButton, {
 	RemoveResource,
@@ -55,6 +58,16 @@ function Dialog(props: {
 				)
 			}
 		>
+			<div className="flex justify-end px-4 pt-2">
+				<ButtonIcon
+					title="Help"
+					handleClick={() => {
+						openHelpWindow("dataset-settings", "Dataset Settings");
+					}}
+				>
+					<HelpIcon />
+				</ButtonIcon>
+			</div>
 			<SettingTable<DatasetSetting>
 				caption="Add Metadata Settings"
 				settings={dataSettings.settings}

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { Button } from "../../components/element/Button";
 import { ButtonIcon } from "../../components/element/ButtonIcon";
 import { HelpIcon } from "../../components/element/Icon";
+import { openHelpWindow } from "../../utils/helpWindow";
 
 const helpCommands = [
 	{ command: "convert", label: "Convert", description: "Convert data between formats" },
@@ -11,22 +11,6 @@ const helpCommands = [
 	{ command: "run", label: "Run", description: "Execute SQL or scripts" },
 	{ command: "parameterize", label: "Parameterize", description: "Batch process with parameters" },
 ] as const;
-
-async function openHelpWindow(command: string, label: string) {
-	const windowLabel = `help-${command}`;
-	const existing = await WebviewWindow.getByLabel(windowLabel);
-	if (existing !== null) {
-		await existing.setFocus();
-		return;
-	}
-	const webview = new WebviewWindow(windowLabel, {
-		url: `/help/${command}.html`,
-		title: `Help - ${label}`,
-		width: 900,
-		height: 700,
-	});
-	webview.once("tauri://error", console.error);
-}
 
 export default function SidebarHelpLink() {
 	const [showMenu, setShowMenu] = useState(false);

--- a/tauri/src/utils/helpWindow.ts
+++ b/tauri/src/utils/helpWindow.ts
@@ -1,0 +1,17 @@
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+
+export async function openHelpWindow(command: string, label: string) {
+	const windowLabel = `help-${command}`;
+	const existing = await WebviewWindow.getByLabel(windowLabel);
+	if (existing !== null) {
+		await existing.setFocus();
+		return;
+	}
+	const webview = new WebviewWindow(windowLabel, {
+		url: `/help/${command}.html`,
+		title: `Help - ${label}`,
+		width: 900,
+		height: 700,
+	});
+	webview.once("tauri://error", console.error);
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive help documentation for Dataset Settings and refactors the help window opening logic into a reusable utility function.

## Key Changes
- **New help documentation**: Added `dataset-settings.html` with detailed documentation covering:
  - Settings and commonSettings field descriptions
  - Import functionality and path resolution rules
  - Configuration examples and override rules
  
- **Refactored help window utility**: Extracted `openHelpWindow()` function from `SidebarHelpLink.tsx` into a new `helpWindow.ts` utility module for reusability across the application

- **Enhanced Dataset Settings Dialog**: Added a help button to the `DatasetSettingsDialog` component that opens the new Dataset Settings help documentation

## Implementation Details
- The help window utility maintains the existing behavior: checks for existing windows by label, focuses if present, or creates a new window with standard dimensions (900x700)
- The help documentation follows the existing HTML/CSS styling conventions used in other help pages
- The help button is positioned in the top-right corner of the dialog using flexbox utilities

https://claude.ai/code/session_01M1qaLEt5eZRfUiQKxgBNXF