### PR TITLE
Mock isAbortError in SelectParameterProvider tests

### DIFF
--- a/tauri/src/tests/context/SelectParameterProvider.test.tsx
+++ b/tauri/src/tests/context/SelectParameterProvider.test.tsx
@@ -123,6 +123,7 @@ vi.mock("../../utils/fetchUtils", () => ({
 	getErrorMessage: vi.fn((error: unknown) =>
 		error instanceof Error ? error.message : String(error),
 	),
+	isAbortError: vi.fn(() => false),
 }));
 
 const mockEnviroment: Enviroment = { ...enviromentFixture };


### PR DESCRIPTION
## Summary
Added a mock implementation for the `isAbortError` utility function in the SelectParameterProvider test suite to ensure consistent test behavior.

## Key Changes
- Added `isAbortError: vi.fn(() => false)` to the `fetchUtils` mock in SelectParameterProvider.test.tsx
- This mock ensures that abort errors are not detected during test execution, providing predictable test behavior

## Implementation Details
The mock function returns `false` by default, which is appropriate for the test context where abort scenarios are not being specifically tested. This prevents any unexpected behavior from unhandled abort error checks during test execution.

https://claude.ai/code/session_016j6Ma9tvavgegYL6vB9Fcu