### PR TITLE
Add help documentation and dialog help buttons for XLSX schema

### DIFF
--- a/tauri/public/help/xlsx-cell-setting.html
+++ b/tauri/public/help/xlsx-cell-setting.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Xlsx Cell Setting</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Xlsx Cell Setting</h1>
+  <p>Xlsx シート上の任意のセル位置から値を拾い集めてテーブルを構成するための設定を編集するダイアログです。帳票・フォーマット化された Xlsx など、行方向に整列していないデータの抽出に利用します。全体構成は <a href="xlsx-schema.html">Xlsx Schema</a> を参照してください。</p>
+
+  <h2>設定項目</h2>
+  <table>
+    <tr><th>フィールド</th><th>説明</th></tr>
+    <tr><td>sheetName</td><td>抽出対象の Xlsx シート名。データセットがロード済みの場合、候補がデータリストから選択できます。</td></tr>
+    <tr><td>tableName</td><td>抽出結果に付与する論理テーブル名。</td></tr>
+    <tr><td>header</td><td>カラム名の並び。カンマ区切りで指定します。各レコードのセルアドレスと同じ順序で対応させます。</td></tr>
+    <tr><td>rows</td><td>1 レコード分のセルアドレスをカンマ区切りで指定します。行を追加することで複数レコードを定義できます。</td></tr>
+    <tr><td>addFileInfo</td><td>元ファイル名などのファイル情報カラムを結果に追加するかどうか。</td></tr>
+  </table>
+
+  <h2>記述例</h2>
+  <p><strong>帳票の見出しセルから 1 レコードを抽出</strong></p>
+  <table>
+    <tr><th>フィールド</th><th>値</th></tr>
+    <tr><td>sheetName</td><td>Invoice</td></tr>
+    <tr><td>tableName</td><td>invoice_header</td></tr>
+    <tr><td>header</td><td><code>invoice_no,issue_date,customer_name,total</code></td></tr>
+    <tr><td>rows</td><td><code>B2,B3,B4,F10</code></td></tr>
+  </table>
+  <p>複数の帳票が 1 シートに並ぶ場合は <code>rows</code> に行を追加し、それぞれの帳票のセルアドレスをカンマ区切りで指定します。</p>
+
+  <h2>注意事項</h2>
+  <ol>
+    <li><code>sheetName</code> と <code>tableName</code> の両方が入力されていない行は保存対象から除外されます。</li>
+    <li><code>header</code> と各 <code>rows</code> のセルアドレス数は一致させてください。</li>
+    <li>セルアドレスは Xlsx の <code>A1</code> 形式で指定します。</li>
+  </ol>
+</body>
+</html>

--- a/tauri/public/help/xlsx-row-setting.html
+++ b/tauri/public/help/xlsx-row-setting.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Xlsx Row Setting</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Xlsx Row Setting</h1>
+  <p>Xlsx シートから行方向に整列したデータをテーブルとして抽出するための設定を編集するダイアログです。全体構成は <a href="xlsx-schema.html">Xlsx Schema</a> を参照してください。</p>
+
+  <h2>設定項目</h2>
+  <table>
+    <tr><th>フィールド</th><th>説明</th></tr>
+    <tr><td>sheetName</td><td>抽出対象の Xlsx シート名。データセットがロード済みの場合、候補がデータリストから選択できます。</td></tr>
+    <tr><td>tableName</td><td>抽出結果に付与する論理テーブル名。</td></tr>
+    <tr><td>header</td><td>カラム名の並び。カンマ区切りで指定し、<code>columnIndex</code> で指定した列の順序と対応させます。</td></tr>
+    <tr><td>dataStart</td><td>データ開始位置をセルアドレスで指定します（例: <code>A2</code>）。ヘッダ行の直下など、最初のレコードがあるセルを指定します。</td></tr>
+    <tr><td>columnIndex</td><td>各カラムが格納されている列をカンマ区切りで指定します（例: <code>A,B,D</code>）。<code>header</code> と同じ並びで対応させます。</td></tr>
+    <tr><td>breakKey</td><td>連続データの区切り判定に利用するカラム名をカンマ区切りで指定します。指定したキーで値が変わったタイミングをレコード境界とみなします。</td></tr>
+    <tr><td>addFileInfo</td><td>元ファイル名などのファイル情報カラムを結果に追加するかどうか。</td></tr>
+  </table>
+
+  <h2>記述例</h2>
+  <p><strong>A 列〜D 列に並んだ注文明細表の抽出</strong></p>
+  <table>
+    <tr><th>フィールド</th><th>値</th></tr>
+    <tr><td>sheetName</td><td>Orders</td></tr>
+    <tr><td>tableName</td><td>orders</td></tr>
+    <tr><td>header</td><td><code>order_id,customer,item,amount</code></td></tr>
+    <tr><td>dataStart</td><td><code>A2</code></td></tr>
+    <tr><td>columnIndex</td><td><code>A,B,C,D</code></td></tr>
+  </table>
+
+  <h2>注意事項</h2>
+  <ol>
+    <li><code>sheetName</code> と <code>tableName</code> の両方が入力されていない行は保存対象から除外されます。</li>
+    <li><code>header</code> と <code>columnIndex</code> は要素数を一致させてください。</li>
+    <li><code>dataStart</code> は Xlsx のセルアドレス表記（<code>A1</code> 形式）で指定します。</li>
+  </ol>
+</body>
+</html>

--- a/tauri/public/help/xlsx-schema.html
+++ b/tauri/public/help/xlsx-schema.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Xlsx Schema</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Xlsx Schema</h1>
+  <p>Xlsx ファイルをデータセットとして読み込む際のマッピング定義を編集するダイアログです。1 つの Xlsx ファイルから複数の論理テーブルを抽出するための設定を、2 種類のマッピング形式で記述します。</p>
+
+  <h2>Rows Mapping Tables</h2>
+  <p>シート上に行方向に整列したデータ（ヘッダ行 + 連続するデータ行）をテーブルとして抽出します。通常の表形式データはこちらで定義します。</p>
+  <p>1 行が 1 レコードとなるテーブルを定義します。各行の編集ダイアログの詳細は <a href="xlsx-row-setting.html">Xlsx Row Setting</a> を参照してください。</p>
+
+  <h2>Random Cell Mapping Tables</h2>
+  <p>シート上の任意のセル位置から値を拾い集めてテーブルを構成します。帳票やフォーマット化された Xlsx など、行方向に整列していないデータの抽出に利用します。</p>
+  <p>指定したセルアドレスごとに 1 レコードを生成します。各行の編集ダイアログの詳細は <a href="xlsx-cell-setting.html">Xlsx Cell Setting</a> を参照してください。</p>
+
+  <h2>共通の考え方</h2>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>sheetName</td><td>抽出対象となる Xlsx のシート名。</td></tr>
+    <tr><td>tableName</td><td>抽出結果に付与する論理テーブル名。<code>DatasetSetting</code> 等から参照する名前になります。</td></tr>
+    <tr><td>header</td><td>カラム名の並び。1 行 1 カラム定義で、Xlsx 上のカラム並びと対応させます。</td></tr>
+    <tr><td>addFileInfo</td><td>抽出結果に元ファイル情報のカラムを追加するかどうか。</td></tr>
+  </table>
+
+  <h2>保存</h2>
+  <p>ダイアログ下部のファイル名を指定して保存すると、設定内容が JSON ファイルとして書き出されます。<code>sheetName</code> と <code>tableName</code> が共に入力されている行のみが保存対象です。</p>
+</body>
+</html>

--- a/tauri/src/app/form/section/dialog/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxCellSettingDialog.tsx
@@ -2,17 +2,15 @@ import { useState } from "react";
 import {
 	Arrays,
 	Check,
+	DialogHelpButton,
 	Fieldset,
 	SettingDialog,
 	Text,
 } from "../../../../components/dialog";
-import { ButtonIcon } from "../../../../components/element/ButtonIcon";
-import { HelpIcon } from "../../../../components/element/Icon";
 import { ResourceDatalist } from "../../../../components/element/Input";
 import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../../../hooks/useXlsxSchema";
 import type { CellSetting } from "../../../../model/XlsxSchema";
-import { openHelpWindow } from "../../../../utils/helpWindow";
 
 export default function XlsxCellSettingDialog(props: {
 	setting: CellSetting;
@@ -29,16 +27,10 @@ export default function XlsxCellSettingDialog(props: {
 			handleDialogClose={props.handleDialogClose}
 			handleCommit={props.handleCommit}
 		>
-			<div className="flex justify-end px-4 pt-2">
-				<ButtonIcon
-					title="Help"
-					handleClick={() => {
-						openHelpWindow("xlsx-cell-setting", "Xlsx Cell Setting");
-					}}
-				>
-					<HelpIcon />
-				</ButtonIcon>
-			</div>
+			<DialogHelpButton
+				command="xlsx-cell-setting"
+				label="Xlsx Cell Setting"
+			/>
 			<Fieldset>
 				<Text
 					name="sheetName"

--- a/tauri/src/app/form/section/dialog/XlsxCellSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxCellSettingDialog.tsx
@@ -6,10 +6,13 @@ import {
 	SettingDialog,
 	Text,
 } from "../../../../components/dialog";
+import { ButtonIcon } from "../../../../components/element/ButtonIcon";
+import { HelpIcon } from "../../../../components/element/Icon";
 import { ResourceDatalist } from "../../../../components/element/Input";
 import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../../../hooks/useXlsxSchema";
 import type { CellSetting } from "../../../../model/XlsxSchema";
+import { openHelpWindow } from "../../../../utils/helpWindow";
 
 export default function XlsxCellSettingDialog(props: {
 	setting: CellSetting;
@@ -26,6 +29,16 @@ export default function XlsxCellSettingDialog(props: {
 			handleDialogClose={props.handleDialogClose}
 			handleCommit={props.handleCommit}
 		>
+			<div className="flex justify-end px-4 pt-2">
+				<ButtonIcon
+					title="Help"
+					handleClick={() => {
+						openHelpWindow("xlsx-cell-setting", "Xlsx Cell Setting");
+					}}
+				>
+					<HelpIcon />
+				</ButtonIcon>
+			</div>
 			<Fieldset>
 				<Text
 					name="sheetName"

--- a/tauri/src/app/form/section/dialog/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxRowSettingDialog.tsx
@@ -5,10 +5,13 @@ import {
 	SettingDialog,
 	Text,
 } from "../../../../components/dialog";
+import { ButtonIcon } from "../../../../components/element/ButtonIcon";
+import { HelpIcon } from "../../../../components/element/Icon";
 import { ResourceDatalist } from "../../../../components/element/Input";
 import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../../../hooks/useXlsxSchema";
 import type { RowSetting } from "../../../../model/XlsxSchema";
+import { openHelpWindow } from "../../../../utils/helpWindow";
 
 export default function XlsxRowSettingDialog(props: {
 	setting: RowSetting;
@@ -25,6 +28,16 @@ export default function XlsxRowSettingDialog(props: {
 			handleDialogClose={props.handleDialogClose}
 			handleCommit={props.handleCommit}
 		>
+			<div className="flex justify-end px-4 pt-2">
+				<ButtonIcon
+					title="Help"
+					handleClick={() => {
+						openHelpWindow("xlsx-row-setting", "Xlsx Row Setting");
+					}}
+				>
+					<HelpIcon />
+				</ButtonIcon>
+			</div>
 			<Fieldset>
 				<Text
 					name="sheetName"

--- a/tauri/src/app/form/section/dialog/XlsxRowSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxRowSettingDialog.tsx
@@ -1,17 +1,15 @@
 import { useState } from "react";
 import {
 	Check,
+	DialogHelpButton,
 	Fieldset,
 	SettingDialog,
 	Text,
 } from "../../../../components/dialog";
-import { ButtonIcon } from "../../../../components/element/ButtonIcon";
-import { HelpIcon } from "../../../../components/element/Icon";
 import { ResourceDatalist } from "../../../../components/element/Input";
 import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
 import { useSrcInfoSheets } from "../../../../hooks/useXlsxSchema";
 import type { RowSetting } from "../../../../model/XlsxSchema";
-import { openHelpWindow } from "../../../../utils/helpWindow";
 
 export default function XlsxRowSettingDialog(props: {
 	setting: RowSetting;
@@ -28,16 +26,10 @@ export default function XlsxRowSettingDialog(props: {
 			handleDialogClose={props.handleDialogClose}
 			handleCommit={props.handleCommit}
 		>
-			<div className="flex justify-end px-4 pt-2">
-				<ButtonIcon
-					title="Help"
-					handleClick={() => {
-						openHelpWindow("xlsx-row-setting", "Xlsx Row Setting");
-					}}
-				>
-					<HelpIcon />
-				</ButtonIcon>
-			</div>
+			<DialogHelpButton
+				command="xlsx-row-setting"
+				label="Xlsx Row Setting"
+			/>
 			<Fieldset>
 				<Text
 					name="sheetName"

--- a/tauri/src/app/form/section/dialog/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxSchemaDialog.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { SettingDialog, SettingTable } from "../../../../components/dialog";
+import { ButtonIcon } from "../../../../components/element/ButtonIcon";
+import { HelpIcon } from "../../../../components/element/Icon";
 import {
 	useDeleteXlsxSchema,
 	useSaveXlsxSchema,
@@ -12,6 +14,7 @@ import {
 	XlsxSchema,
 } from "../../../../model/XlsxSchema";
 import { saveOnSuccess } from "../../../../utils/fetchUtils";
+import { openHelpWindow } from "../../../../utils/helpWindow";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,
@@ -57,6 +60,16 @@ function Dialog(props: {
 				)
 			}
 		>
+			<div className="flex justify-end px-4 pt-2">
+				<ButtonIcon
+					title="Help"
+					handleClick={() => {
+						openHelpWindow("xlsx-schema", "Xlsx Schema");
+					}}
+				>
+					<HelpIcon />
+				</ButtonIcon>
+			</div>
 			<SettingTable<RowSetting>
 				caption="Rows Mapping Tables"
 				settings={xlsxSchema.rows}

--- a/tauri/src/app/form/section/dialog/XlsxSchemaDialog.tsx
+++ b/tauri/src/app/form/section/dialog/XlsxSchemaDialog.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import { SettingDialog, SettingTable } from "../../../../components/dialog";
-import { ButtonIcon } from "../../../../components/element/ButtonIcon";
-import { HelpIcon } from "../../../../components/element/Icon";
+import {
+	DialogHelpButton,
+	SettingDialog,
+	SettingTable,
+} from "../../../../components/dialog";
 import {
 	useDeleteXlsxSchema,
 	useSaveXlsxSchema,
@@ -14,7 +16,6 @@ import {
 	XlsxSchema,
 } from "../../../../model/XlsxSchema";
 import { saveOnSuccess } from "../../../../utils/fetchUtils";
-import { openHelpWindow } from "../../../../utils/helpWindow";
 import ResourceEditButton, {
 	RemoveResource,
 	type ResourceEditButtonProp,
@@ -60,16 +61,7 @@ function Dialog(props: {
 				)
 			}
 		>
-			<div className="flex justify-end px-4 pt-2">
-				<ButtonIcon
-					title="Help"
-					handleClick={() => {
-						openHelpWindow("xlsx-schema", "Xlsx Schema");
-					}}
-				>
-					<HelpIcon />
-				</ButtonIcon>
-			</div>
+			<DialogHelpButton command="xlsx-schema" label="Xlsx Schema" />
 			<SettingTable<RowSetting>
 				caption="Rows Mapping Tables"
 				settings={xlsxSchema.rows}

--- a/tauri/src/components/dialog/DialogHelpButton.tsx
+++ b/tauri/src/components/dialog/DialogHelpButton.tsx
@@ -1,0 +1,18 @@
+import { ButtonIcon } from "../element/ButtonIcon";
+import { HelpIcon } from "../element/Icon";
+import { openHelpWindow } from "../../utils/helpWindow";
+
+export function DialogHelpButton(props: { command: string; label: string }) {
+	return (
+		<div className="flex justify-end px-4 pt-2">
+			<ButtonIcon
+				title="Help"
+				handleClick={() => {
+					openHelpWindow(props.command, props.label);
+				}}
+			>
+				<HelpIcon />
+			</ButtonIcon>
+		</div>
+	);
+}

--- a/tauri/src/components/dialog/index.ts
+++ b/tauri/src/components/dialog/index.ts
@@ -1,3 +1,4 @@
+export { DialogHelpButton } from "./DialogHelpButton";
 export type { SettingDialogProps } from "./SettingDialog";
 export {
 	Arrays,


### PR DESCRIPTION
## Summary
This PR adds comprehensive help documentation for XLSX data extraction features and integrates help buttons into the relevant configuration dialogs.

## Key Changes
- **Added three new help documentation pages** (`public/help/`):
  - `xlsx-schema.html` - Overview of XLSX schema mapping with links to detailed guides
  - `xlsx-row-setting.html` - Documentation for row-based data extraction configuration
  - `xlsx-cell-setting.html` - Documentation for cell-based (random cell) data extraction configuration

- **Created new `DialogHelpButton` component** (`src/components/dialog/DialogHelpButton.tsx`):
  - Reusable button component that opens help windows from dialogs
  - Accepts `command` and `label` props to specify which help page to display
  - Uses existing `openHelpWindow` utility and `HelpIcon` component

- **Integrated help buttons into three dialogs**:
  - `XlsxSchemaDialog` - Main schema configuration dialog
  - `XlsxRowSettingDialog` - Row mapping configuration dialog
  - `XlsxCellSettingDialog` - Cell mapping configuration dialog

- **Updated component exports** in `src/components/dialog/index.ts` to include the new `DialogHelpButton`

## Implementation Details
- All help pages follow a consistent HTML structure with unified styling (Tailwind-inspired CSS)
- Help pages are written in Japanese and include field descriptions, usage examples, and important notes
- The `DialogHelpButton` is positioned at the top of each dialog for easy access
- Help documentation covers field definitions, practical examples, and validation requirements for each configuration type

https://claude.ai/code/session_01EG87Ydk9uvyABc6raPH85u