### PR TITLE
Add Dataset Load Form help documentation and update help index

### DIFF
--- a/tauri/public/help/compare.html
+++ b/tauri/public/help/compare.html
@@ -32,5 +32,6 @@
     <tr><td>imageOption</td><td>画像比較のオプション</td></tr>
     <tr><td>convertResult</td><td>出力形式と出力先の設定</td></tr>
   </table>
+  <p><code>oldData</code> / <code>newData</code> / <code>expectData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/convert.html
+++ b/tauri/public/help/convert.html
@@ -26,5 +26,6 @@
     <tr><td>srcData</td><td>変換元のデータセット</td></tr>
     <tr><td>convertResult</td><td>出力形式と出力先の設定</td></tr>
   </table>
+  <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/dataset-load-form.html
+++ b/tauri/public/help/dataset-load-form.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Dataset Load Form</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Dataset Load Form</h1>
+  <p>各コマンドで「データセットの入力」を指定するための共通フォームです。<a href="compare.html">Compare</a> の <code>oldData</code> / <code>newData</code> / <code>expectData</code>、<a href="convert.html">Convert</a> / <a href="generate.html">Generate</a> / <a href="run.html">Run</a> の <code>srcData</code>、<a href="parameterize.html">Parameterize</a> の <code>paramData</code> は、いずれもこのフォームによって構成されます。</p>
+  <p>1 つの入力は、以下の 4 つの領域から構成されます。</p>
+  <ul>
+    <li><strong>Source Type 選択</strong> — 入力の形式（CSV / Table / SQL / Regex / Fixed / Xls / Xlsx）</li>
+    <li><strong>Source</strong> — 入力元ファイル・SQL、文字コード、ディレクトリ走査条件</li>
+    <li><strong>Data Load</strong> — ヘッダ・開始行・メタデータなど、読み込み時の挙動</li>
+    <li><strong>Setting</strong> — Dataset Settings ファイルによるテーブル単位のメタデータ指定</li>
+  </ul>
+
+  <h2>Source Type 選択</h2>
+  <p>入力データの形式を選択します。選択した形式に応じて、固有の設定項目がフォーム下部に表示されます。</p>
+  <table>
+    <tr><th>形式</th><th>説明</th></tr>
+    <tr><td>csv</td><td>CSV / TSV など区切り文字付きテキスト。区切り文字・囲み文字などを指定</td></tr>
+    <tr><td>table</td><td>データベースのテーブル。JDBC 接続設定が必要</td></tr>
+    <tr><td>sql</td><td>SQL クエリの実行結果。JDBC 接続設定と SQL 本文を指定</td></tr>
+    <tr><td>reg</td><td>正規表現でテキスト行をパースして抽出</td></tr>
+    <tr><td>fixed</td><td>固定長テキスト。カラム幅を指定して列に分割</td></tr>
+    <tr><td>xls / xlsx</td><td>Excel ファイル。シート / セル構造の定義に <a href="xlsx-schema.html">Xlsx Schema</a> を使用</td></tr>
+  </table>
+  <p>Xls / Xlsx を選択した場合、シートごとの列定義や任意セルの抽出定義を <code>xlsxSchema</code> ファイルで与えます。詳細は <a href="xlsx-schema.html">Xlsx Schema</a> を参照してください。</p>
+
+  <h2>Source</h2>
+  <p>入力元となるファイルやクエリ、補助的なオプションを指定します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>src</td><td>入力元のファイル・ディレクトリのパス。SQL / Table 系を選んでいる場合は SQL 本文の指定</td></tr>
+    <tr><td>encoding</td><td>テキスト系入力の文字コード</td></tr>
+    <tr><td>jdbcProperties</td><td>Table / SQL を選んだ場合の JDBC 接続情報（URL・ユーザ・パスワードなど）</td></tr>
+    <tr><td>templateGroup</td><td>テンプレート処理を行う場合の補助設定</td></tr>
+  </table>
+  <h3>traversal option</h3>
+  <p>ディレクトリを <code>src</code> に指定した際の走査条件です。<code>traversal option</code> の展開ボタンから設定します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>extension</td><td>対象とするファイル拡張子</td></tr>
+    <tr><td>recursive</td><td>サブディレクトリを再帰的に走査するか</td></tr>
+    <tr><td>regInclude</td><td>対象ファイル名の包含条件（正規表現）</td></tr>
+    <tr><td>regExclude</td><td>対象ファイル名の除外条件（正規表現）</td></tr>
+  </table>
+
+  <h2>Data Load</h2>
+  <p>読み込んだデータをどのようにテーブル化するかを指定します。<code>data load option</code> の展開ボタンから設定します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>headerName</td><td>ヘッダ行のカラム名を上書きする場合の指定</td></tr>
+    <tr><td>startRow</td><td>データ読み込みを開始する行番号（ヘッダをスキップする場合など）</td></tr>
+    <tr><td>addFileInfo</td><td>元ファイル名をカラムとして追加するか</td></tr>
+    <tr><td>loadData</td><td>実データを読み込むか（メタデータのみが必要な場合に OFF）</td></tr>
+    <tr><td>includeMetaData</td><td>メタデータカラムを含めるか</td></tr>
+    <tr><td>regTableInclude</td><td>処理対象とするテーブル名の正規表現</td></tr>
+    <tr><td>regTableExclude</td><td>処理対象から除外するテーブル名の正規表現</td></tr>
+  </table>
+
+  <h2>Setting</h2>
+  <p>Dataset Settings ファイルを指定することで、テーブルごとの主キー・ソート順・フィルタなどのメタデータを与えます。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>setting</td><td>Dataset Settings ファイルのパス。書式は <a href="dataset-settings.html">Dataset Settings</a> を参照</td></tr>
+    <tr><td>settingEncoding</td><td>Dataset Settings ファイルの文字コード</td></tr>
+  </table>
+  <p>テキストボックス横の編集ボタンから <a href="dataset-setting.html">Dataset Setting</a> ダイアログを開き、テーブルごとの設定を GUI で編集できます。</p>
+
+  <h2>関連ページ</h2>
+  <ul>
+    <li><a href="dataset-settings.html">Dataset Settings</a> — 設定ファイル全体（<code>settings</code> / <code>commonSettings</code> / <code>import</code>）の書式</li>
+    <li><a href="dataset-setting.html">Dataset Setting</a> — テーブル単位の設定ダイアログ</li>
+    <li><a href="xlsx-schema.html">Xlsx Schema</a> — Xlsx 入力のマッピング定義</li>
+    <li><a href="xlsx-row-setting.html">Xlsx Row Setting</a> — Rows Mapping の行単位設定</li>
+    <li><a href="xlsx-cell-setting.html">Xlsx Cell Setting</a> — Random Cell Mapping のセル単位設定</li>
+  </ul>
+</body>
+</html>

--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -32,5 +32,6 @@
     <tr><td>srcData</td><td>ソースデータセット</td></tr>
     <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
   </table>
+  <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -6,6 +6,7 @@
   <style>
     body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
     h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
     ul { list-style: none; padding: 0; }
     li { margin-bottom: 1rem; }
     a { display: block; padding: 1rem; border: 1px solid #e5e7eb; border-radius: 0.5rem; text-decoration: none; color: inherit; transition: background 0.15s; }
@@ -16,12 +17,19 @@
 </head>
 <body>
   <h1>DBUnit CLI ヘルプ</h1>
+  <h2>コマンド</h2>
   <ul>
     <li><a href="convert.html"><div class="cmd-name">Convert</div><div class="cmd-desc">データ形式を変換する</div></a></li>
     <li><a href="compare.html"><div class="cmd-name">Compare</div><div class="cmd-desc">データセットを比較して差分を検出する</div></a></li>
     <li><a href="generate.html"><div class="cmd-name">Generate</div><div class="cmd-desc">テンプレートからファイルを生成する</div></a></li>
     <li><a href="run.html"><div class="cmd-name">Run</div><div class="cmd-desc">SQL やスクリプトを実行する</div></a></li>
     <li><a href="parameterize.html"><div class="cmd-name">Parameterize</div><div class="cmd-desc">パラメータでバッチ処理する</div></a></li>
+  </ul>
+  <h2>リファレンス</h2>
+  <ul>
+    <li><a href="dataset-load-form.html"><div class="cmd-name">Dataset Load Form</div><div class="cmd-desc">データセット入力フォームの構成</div></a></li>
+    <li><a href="dataset-settings.html"><div class="cmd-name">Dataset Settings</div><div class="cmd-desc">Dataset Settings ファイルの書式</div></a></li>
+    <li><a href="xlsx-schema.html"><div class="cmd-name">Xlsx Schema</div><div class="cmd-desc">Xlsx 入力のマッピング定義</div></a></li>
   </ul>
 </body>
 </html>

--- a/tauri/public/help/parameterize.html
+++ b/tauri/public/help/parameterize.html
@@ -32,5 +32,6 @@
     <tr><td>paramData</td><td>パラメータデータセットのソース</td></tr>
     <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
   </table>
+  <p><code>paramData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/run.html
+++ b/tauri/public/help/run.html
@@ -28,5 +28,6 @@
     <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
     <tr><td>jdbcOption</td><td>JDBC 接続設定</td></tr>
   </table>
+  <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Added comprehensive help documentation for the Dataset Load Form component and reorganized the help index to include a new "Reference" section.

## Key Changes
- **New help page**: Created `dataset-load-form.html` with detailed documentation covering:
  - Overview of the form's purpose and structure (4 main areas)
  - Source Type selection options (CSV, Table, SQL, Regex, Fixed, Xls, Xlsx)
  - Source configuration (file paths, encoding, JDBC properties, traversal options)
  - Data Load settings (headers, start row, metadata handling, table filtering)
  - Dataset Settings configuration
  - Related reference links

- **Updated help index**: Reorganized `index.html` to:
  - Add section headers ("コマンド" and "リファレンス")
  - Create new "Reference" section with links to Dataset Load Form, Dataset Settings, and Xlsx Schema
  - Improve navigation structure

- **Cross-references**: Added links to Dataset Load Form documentation in command help pages:
  - `compare.html`: References for `oldData`, `newData`, `expectData`
  - `convert.html`: Reference for `srcData`
  - `generate.html`: Reference for `srcData`
  - `parameterize.html`: Reference for `paramData`
  - `run.html`: Reference for `srcData`

## Implementation Details
- Consistent styling with existing help pages (system-ui font, Indigo color scheme)
- Comprehensive tables documenting all form fields and options
- Clear hierarchical structure with h2/h3 headings
- Related links section for navigation between related documentation pages

https://claude.ai/code/session_01MhycEubjp9MdAgiUo6Ey2u