### PR TITLE
Make DatasetSettingDialog mode change handler async

### DIFF
--- a/tauri/src/app/form/section/dialog/DatasetSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/DatasetSettingDialog.tsx
@@ -75,7 +75,7 @@ export default function DatasetSettingDialog(props: {
 				<Select
 					name="mode"
 					defaultValue={target.mode()}
-					handleOnChange={(v) =>
+					handleOnChange={async (v) =>
 						setTarget((cur) => cur.withMode(v as DatasetSettingMode))
 					}
 				>


### PR DESCRIPTION
## Summary
Updated the `handleOnChange` callback in the DatasetSettingDialog's mode Select component to be an async function.

## Changes
- Modified the `handleOnChange` prop callback to be declared as `async` in the Select component for the "mode" field
- This allows the callback to handle asynchronous operations when the dataset mode is changed

## Implementation Details
The change is minimal and focused - the handler now supports async/await patterns while maintaining the same functionality of updating the target's mode via `setTarget((cur) => cur.withMode(v as DatasetSettingMode))`. This may be in preparation for future async operations or to align with a broader pattern of async handlers in the codebase.

https://claude.ai/code/session_01ELpkPZknhieR5oFsjXoeLf