### PR TITLE
Add help pages for Template, Image, and JDBC options

### DIFF
--- a/tauri/public/help/dataset-load-form.html
+++ b/tauri/public/help/dataset-load-form.html
@@ -323,8 +323,8 @@ SQL (joinQuery.sql):
     <tr><th>項目</th><th>説明</th></tr>
     <tr><td>src</td><td>入力元のパス。Source Type によって意味が異なる: ファイル・ディレクトリ（<code>csv</code> / <code>fixed</code> / <code>reg</code> / <code>xls</code> / <code>xlsx</code> / <code>file</code> / <code>dir</code>）、SQL ファイル（<code>sql</code> / <code>csvq</code>）、テーブル名リストファイル（<code>table</code>）</td></tr>
     <tr><td>encoding</td><td>テキスト系入力の文字コード</td></tr>
-    <tr><td>jdbcProperties</td><td>Table / SQL を選んだ場合の JDBC 接続情報（URL・ユーザ・パスワードなど）</td></tr>
-    <tr><td>templateGroup</td><td>テンプレート処理を行う場合の補助設定</td></tr>
+    <tr><td>jdbcProperties</td><td>Table / SQL を選んだ場合の <a href="jdbc.html">JDBC 接続情報</a>（URL・ユーザ・パスワードなど）</td></tr>
+    <tr><td>templateGroup</td><td><a href="template.html">テンプレート処理</a>を行う場合の補助設定</td></tr>
   </table>
   <h3>traversal option</h3>
   <p>ディレクトリを <code>src</code> に指定した際の走査条件です。<code>traversal option</code> の展開ボタンから設定します。</p>

--- a/tauri/public/help/image.html
+++ b/tauri/public/help/image.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Image Option</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Image Option</h1>
+  <p><a href="compare.html">Compare</a> で <code>targetType</code> に <strong>image</strong> または <strong>pdf</strong> を選択した場合に表示される、画像差分オプションです。比較エンジンには <a href="https://github.com/romankh3/image-comparison">image-comparison</a> ライブラリを使用します。</p>
+  <p>入力には <a href="dataset-load-form.html#srctype-file">Source Type = file</a> を用いてディレクトリを走査し、拡張子フィルタ（例: <code>.png</code>、<code>.pdf</code>）で対象ファイルを絞り込みます。Compare は <code>oldData</code> と <code>newData</code> のファイルを 1 対 1 で突き合わせ、差分画像と判定結果を出力します。</p>
+
+  <h2 id="section-fields">設定項目</h2>
+  <p>フォームの <code>image</code> セクションに表示される項目の一覧です。すべて任意で、未指定時は以下の既定値が使われます。</p>
+
+  <h3>比較しきい値</h3>
+  <table>
+    <tr><th>項目</th><th>型</th><th>説明</th><th>既定</th></tr>
+    <tr><td>threshold</td><td>整数</td><td>2 ピクセルが異なるとみなす RGB 距離のしきい値。大きくするほど差分に寛容</td><td>5</td></tr>
+    <tr><td>pixelToleranceLevel</td><td>小数 (0.0–1.0)</td><td>ピクセル単位の許容レベル。例: <code>0.1</code> は 10% の差まで同一とみなす</td><td>0.01</td></tr>
+    <tr><td>allowingPercentOfDifferentPixels</td><td>小数 (0.0–1.0)</td><td>画像全体で MATCH 判定を維持できる差分ピクセル比率。これを超えると MISMATCH になる</td><td>0.01</td></tr>
+  </table>
+
+  <h3>差分矩形の描画</h3>
+  <p>差分があった領域は、出力される差分画像上で矩形として強調描画されます。</p>
+  <table>
+    <tr><th>項目</th><th>型</th><th>説明</th><th>既定</th></tr>
+    <tr><td>rectangleLineWidth</td><td>整数 (px)</td><td>矩形枠線の幅</td><td>1</td></tr>
+    <tr><td>minimalRectangleSize</td><td>整数 (px)</td><td>描画する矩形の最小サイズ。小さな差分を無視したいときに利用</td><td>1</td></tr>
+    <tr><td>maximalRectangleCount</td><td>整数</td><td>描画する矩形の最大数。<code>-1</code> は無制限</td><td>-1</td></tr>
+    <tr><td>fillDifferenceRectangles</td><td>真偽値</td><td>差分矩形を塗りつぶす（枠だけでなく中を塗る）</td><td>false</td></tr>
+    <tr><td>percentOpacityDifferenceRectangles</td><td>小数 (0–100)</td><td>差分矩形の塗りの不透明度（%）</td><td>20.0</td></tr>
+    <tr><td>differenceRectangleColor</td><td>色</td><td>差分矩形の色（後述「色の指定」参照）</td><td>red</td></tr>
+  </table>
+
+  <h3>除外領域</h3>
+  <p>比較から特定の矩形領域を除外できます。タイムスタンプや動的に変わる UI パーツなど、差分を許容したい領域を指定するのに使います。</p>
+  <table>
+    <tr><th>項目</th><th>型</th><th>説明</th><th>既定</th></tr>
+    <tr><td>excludedAreas</td><td>文字列</td><td>除外する矩形のリスト。書式は <code>[x1,y1,x2,y2]</code> を 0 個以上連結（後述）</td><td>空（除外なし）</td></tr>
+    <tr><td>drawExcludedRectangles</td><td>真偽値</td><td>除外矩形の枠線を差分画像に描画する</td><td>true</td></tr>
+    <tr><td>fillExcludedRectangles</td><td>真偽値</td><td>除外矩形を塗りつぶす</td><td>false</td></tr>
+    <tr><td>percentOpacityExcludedRectangles</td><td>小数 (0–100)</td><td>除外矩形の塗りの不透明度（%）</td><td>20.0</td></tr>
+    <tr><td>excludedRectangleColor</td><td>色</td><td>除外矩形の色</td><td>green</td></tr>
+  </table>
+
+  <h3 id="section-excluded-areas-format"><code>excludedAreas</code> の書式</h3>
+  <p>1 つの矩形は <code>[x1,y1,x2,y2]</code>（画像の左上原点、<code>x1,y1</code> は左上隅、<code>x2,y2</code> は右下隅、単位はピクセル）で表します。複数指定する場合は区切り文字なしで連結します。</p>
+  <pre>例: 2 つの矩形を除外する
+  [10,20,100,150][200,50,300,200]
+
+意味:
+  (10,20)-(100,150)  の矩形と (200,50)-(300,200) の矩形を除外</pre>
+
+  <h3 id="section-color-format">色の指定</h3>
+  <p>色は Java の <code>Color.getColor()</code> が解釈する形式で指定します。代表的な書き方は 16 進リテラル（例: <code>0xFF0000</code> で赤、<code>0x00FF00</code> で緑、<code>0x0000FF</code> で青）です。未指定または解釈に失敗した場合は、差分矩形は <code>red</code>、除外矩形は <code>green</code> にフォールバックします。</p>
+
+  <h2 id="section-output">出力イメージ</h2>
+  <p>Compare の差分レポートには、以下 3 種類の矩形が重ねて描画された差分画像が含まれます。</p>
+  <ul>
+    <li><strong>差分矩形</strong> — 実際にピクセルが異なる領域（既定: 赤枠）</li>
+    <li><strong>除外矩形</strong> — <code>excludedAreas</code> で指定した無視領域（既定: 緑枠）</li>
+    <li>各矩形は <code>fill*Rectangles</code> と <code>percentOpacity*</code> の組み合わせで半透明に塗りつぶし可能</li>
+  </ul>
+
+  <h2>関連ページ</h2>
+  <ul>
+    <li><a href="compare.html">Compare</a> — 画像・PDF 比較のコマンド</li>
+    <li><a href="dataset-load-form.html#srctype-file">Dataset Load Form</a> — <code>file</code> 形式で画像ファイルを入力する</li>
+  </ul>
+</body>
+</html>

--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -29,6 +29,9 @@
   <ul>
     <li><a href="dataset-load-form.html"><div class="cmd-name">Dataset Load Form</div><div class="cmd-desc">データセット入力フォームの構成</div></a></li>
     <li><a href="dataset-settings.html"><div class="cmd-name">Dataset Settings</div><div class="cmd-desc">Dataset Settings ファイルの書式</div></a></li>
+    <li><a href="image.html"><div class="cmd-name">Image Option</div><div class="cmd-desc">Compare の画像・PDF 差分オプション</div></a></li>
+    <li><a href="jdbc.html"><div class="cmd-name">JDBC</div><div class="cmd-desc">JDBC 接続設定と URL Builder</div></a></li>
+    <li><a href="template.html"><div class="cmd-name">Template</div><div class="cmd-desc">StringTemplate 4 によるテンプレート設定</div></a></li>
     <li><a href="xlsx-schema.html"><div class="cmd-name">Xlsx Schema</div><div class="cmd-desc">Xlsx 入力のマッピング定義</div></a></li>
   </ul>
 </body>

--- a/tauri/public/help/jdbc.html
+++ b/tauri/public/help/jdbc.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - JDBC</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>JDBC</h1>
+  <p>データベースへ接続するための設定を指定します。以下の場面で必要になります。</p>
+  <ul>
+    <li><a href="dataset-load-form.html#srctype-table">Source Type = table</a>（テーブル名リストから読み込む）</li>
+    <li><a href="dataset-load-form.html#srctype-sql">Source Type = sql</a>（SQL クエリ結果を読み込む）</li>
+    <li>Result Type = table（<a href="compare.html">Compare</a> / <a href="convert.html">Convert</a> / <a href="generate.html">Generate</a> の結果をテーブルに出力）</li>
+    <li><a href="run.html">Run</a> の Script Type = sql（SQL スクリプトを DB で実行）</li>
+  </ul>
+
+  <h2 id="section-fields">設定項目</h2>
+  <p>フォームの <code>jdbc option</code> 展開ボタンから設定します。各項目は個別に入力しても、<code>jdbcProperties</code> に保存済みの <code>.properties</code> ファイルを選んでも構いません。両方が指定された場合、<strong><code>jdbcUrl</code> / <code>jdbcUser</code> / <code>jdbcPass</code> が <code>jdbcProperties</code> の同名キーを上書き</strong>します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th></tr>
+    <tr><td>jdbcProperties</td><td>接続情報を記述した <code>.properties</code> ファイルのパス。中身は <code>url=</code> / <code>user=</code> / <code>pass=</code> の 3 行。ワークスペースの <code>jdbc/</code> ディレクトリ配下を既定の参照先とします。</td></tr>
+    <tr><td>jdbcUrl</td><td>JDBC 接続 URL（例: <code>jdbc:postgresql://localhost:5432/mydb</code>）。<code>jdbcProperties</code> の <code>url</code> を上書きします。</td></tr>
+    <tr><td>jdbcUser</td><td>ログインユーザ名。<code>jdbcProperties</code> の <code>user</code> を上書きします。</td></tr>
+    <tr><td>jdbcPass</td><td>ログインパスワード。<code>jdbcProperties</code> の <code>pass</code> を上書きします。</td></tr>
+    <tr><td>useJdbcMetaData</td><td>DBUnit のメタデータ取得経路を切り替えるフラグ（<a href="dataset-load-form.html#srctype-table">table</a> / <a href="dataset-load-form.html#srctype-sql">sql</a> の Data Load オプション）。デフォルトは OFF。詳細は Dataset Load Form の table の節を参照。</td></tr>
+  </table>
+
+  <h3>.properties ファイルの書式</h3>
+  <p>Java 標準の Properties 形式。以下 3 つのキーを定義します。</p>
+  <pre>url=jdbc:postgresql://localhost:5432/mydb
+user=app_user
+pass=app_password</pre>
+
+  <h2 id="section-url-builder">JDBC URL Builder</h2>
+  <p><code>jdbcUrl</code> テキストボックス横の編集ボタンから開くダイアログです。代表的な RDB の URL テンプレートに従って URL を組み立てます。Host / Port / Service Name (Database Name) を入力すると、下部の Preview に完成 URL が表示され、Apply で <code>jdbcUrl</code> に反映されます。</p>
+  <table>
+    <tr><th>Database</th><th>既定ポート</th><th>URL テンプレート</th></tr>
+    <tr><td>oracle</td><td>1521</td><td>jdbc:oracle:thin:@//{host}:{port}/{serviceName}</td></tr>
+    <tr><td>postgres</td><td>5432</td><td>jdbc:postgresql://{host}:{port}/{serviceName}</td></tr>
+    <tr><td>h2</td><td>9092</td><td>jdbc:h2:tcp://{host}:{port}/{serviceName}</td></tr>
+  </table>
+  <p>Database ラベル（Service Name / Database Name）は RDB 種別に応じて切り替わります（Oracle は Service Name、PostgreSQL / H2 は Database Name）。既存 URL を開いた場合、Builder はその URL を解析してフォーム項目を初期値に復元します。</p>
+
+  <h2 id="section-connection-test">Connection Test</h2>
+  <p>フォーム下部の <code>Connection Test</code> ボタンを押すと sidecar 経由で実際の接続を試し、結果（成功 / 失敗メッセージ）を隣に表示します。以下のいずれかが揃っていると押下可能です。</p>
+  <ul>
+    <li><code>jdbcUrl</code> + <code>jdbcUser</code> + <code>jdbcPass</code> がすべて入力されている</li>
+    <li><code>jdbcProperties</code> が選択されている</li>
+  </ul>
+  <p>フォーム値を変更すると接続 OK 状態は解除され、再度テストが必要になります。</p>
+
+  <h2 id="section-save-properties">Save as Properties</h2>
+  <p>現在入力中の URL / User / Pass を新規 <code>.properties</code> ファイルとしてワークスペースの <code>jdbc/</code> に保存します。保存後は <code>jdbcProperties</code> で再利用できます。ダイアログには保存される内容のプレビュー（Pass はマスク）とファイル名入力欄が表示されます。</p>
+
+  <h2>関連ページ</h2>
+  <ul>
+    <li><a href="dataset-load-form.html">Dataset Load Form</a> — <code>srcType</code> に応じた JDBC の要否と <code>useJdbcMetaData</code> の詳細</li>
+    <li><a href="run.html">Run</a> — <code>scriptType = sql</code> で JDBC を使用</li>
+    <li><a href="compare.html">Compare</a> / <a href="convert.html">Convert</a> / <a href="generate.html">Generate</a> — 結果を DB テーブルに出力する場合に JDBC を使用</li>
+  </ul>
+</body>
+</html>

--- a/tauri/public/help/template.html
+++ b/tauri/public/help/template.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Template</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    h3 { font-size: 1rem; margin-top: 1rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+    ol, ul { color: #4b5563; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Template</h1>
+  <p>テンプレート処理のための設定です。テンプレートエンジンは <strong>StringTemplate 4 (ST4)</strong>。式は既定で <code>$...$</code> の記法を用い、入力データセットの各行をパラメータとして埋め込みます。以下の場面で利用されます。</p>
+  <ul>
+    <li><a href="generate.html">Generate</a> — 入力データセットをもとにファイル（SQL / テキスト / xlsx / 設定ファイル等）を生成</li>
+    <li><a href="run.html">Run</a> — SQL / ANT スクリプトを実行する前にテンプレートとしてレンダリング</li>
+    <li><a href="parameterize.html">Parameterize</a> — パラメータごとにコマンド引数や設定をレンダリング</li>
+    <li><a href="dataset-load-form.html#section-source">Dataset Load Form</a> の <code>templateGroup</code> — 入力読み込み時にテンプレートを適用（任意）</li>
+  </ul>
+
+  <h2 id="section-fields">設定項目</h2>
+  <p>フォームの <code>template option</code> 展開ボタンから設定します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
+    <tr><td>encoding</td><td>テンプレートファイルの文字コード。Generate の <code>template</code> ファイル等に適用</td><td>システム既定の文字コード</td></tr>
+    <tr><td>templateGroup</td><td>StringTemplate グループファイル（<code>.stg</code>）のパス。共通マクロ（サブテンプレート）を別ファイルにまとめて読み込みます。ワークスペースの <code>template/</code> ディレクトリを基準に解決</td><td>空（グループなし）</td></tr>
+    <tr><td>templateParameterAttribute</td><td>テンプレート内で入力行にアクセスする属性名。例えば <code>param</code> を指定すると、テンプレートに渡されたレコードは <code>$param.columnName$</code> で参照できます。空文字を指定した場合は属性でラップせず、カラム名で直接参照します</td><td>param</td></tr>
+    <tr><td>templateVarStart</td><td>テンプレート式の開始文字（1 文字）</td><td>$</td></tr>
+    <tr><td>templateVarStop</td><td>テンプレート式の終了文字（1 文字）</td><td>$</td></tr>
+  </table>
+
+  <h3 id="section-xlsx-options">xlsx 出力時の追加オプション</h3>
+  <p><a href="generate.html">Generate</a> で <code>generateType = xlsx</code> を選んだ場合に適用される数式処理系のオプションです（内部的に Apache POI で処理）。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
+    <tr><td>formulaProcess</td><td>xlsx 出力時に数式セルを処理するか。<code>false</code> にすると低メモリで動作しますが、数式内のセル参照が行追加にあわせて更新されません</td><td>true</td></tr>
+    <tr><td>evaluateFormulas</td><td><code>formulaProcess</code> が有効なときに Excel 数式を評価するか</td><td>true</td></tr>
+    <tr><td>forceFormulaRecalc</td><td>出力ファイルを Excel で開いたときに自動再計算させるフラグを立てる</td><td>false</td></tr>
+    <tr><td>fastFormulaProcess</td><td>高速な数式プロセッサを使用する</td><td>false</td></tr>
+    <tr><td>deleteBlankCells</td><td>数式評価後に空セルを削除する</td><td>false</td></tr>
+  </table>
+
+  <h2 id="section-parameter-binding">パラメータのバインド</h2>
+  <p>入力データセットの各行は、テンプレートに対して <code>templateParameterAttribute</code> で指定した属性名のオブジェクトとして渡されます。</p>
+  <p><strong>例 1: <code>templateParameterAttribute = param</code>（既定）</strong></p>
+  <pre>入力行 (1 件):
+  tableName = USERS
+  columnNames = id, name
+  values = 1, 'Alice'
+
+テンプレート (insert.sql):
+  INSERT INTO $param.tableName$ ($param.columnNames$) VALUES ($param.values$);
+
+レンダリング結果:
+  INSERT INTO USERS (id, name) VALUES (1, 'Alice');</pre>
+  <p><strong>例 2: <code>templateParameterAttribute</code> を空に指定（直接バインド）</strong></p>
+  <pre>テンプレート (insert.sql):
+  INSERT INTO $tableName$ ($columnNames$) VALUES ($values$);
+
+レンダリング結果:
+  INSERT INTO USERS (id, name) VALUES (1, 'Alice');</pre>
+  <p><strong>例 3: <code>templateVarStart</code> / <code>templateVarStop</code> を変更</strong></p>
+  <p>テンプレートに <code>$</code> を多く含む SQL（PostgreSQL の <code>$$</code> 区切り等）を扱うときに、式の区切り文字を別の文字に変更できます。</p>
+  <pre>指定:
+  templateVarStart = &lt;
+  templateVarStop  = &gt;
+
+テンプレート:
+  CREATE FUNCTION f() RETURNS void AS $$ ... $$ LANGUAGE sql;
+  -- &lt;param.tableName&gt; をここで使える
+
+結果:
+  区切りが &lt;...&gt; に切り替わるため、$$ はそのまま出力される</pre>
+
+  <h2 id="section-template-group">templateGroup（共通マクロ）</h2>
+  <p>StringTemplate のグループファイル（<code>.stg</code>）に再利用可能なサブテンプレートを定義し、本体テンプレートから呼び出せます。</p>
+  <pre>グループファイル (macros.stg):
+  quote(s) ::= &lt;&lt;'&lt;s&gt;'&gt;&gt;
+
+本体テンプレート (insert.sql):
+  INSERT INTO $param.tableName$ VALUES ($param.name:quote()$);
+
+レンダリング結果:
+  INSERT INTO USERS VALUES ('Alice');</pre>
+
+  <h2>関連ページ</h2>
+  <ul>
+    <li><a href="generate.html">Generate</a> — テンプレートを使ったファイル生成の主要コマンド</li>
+    <li><a href="run.html">Run</a> — SQL / ANT スクリプトの前処理として使用</li>
+    <li><a href="parameterize.html">Parameterize</a> — パラメータごとに設定をレンダリング</li>
+    <li><a href="dataset-load-form.html#section-source">Dataset Load Form</a> — Source の <code>templateGroup</code> による入力前処理</li>
+  </ul>
+</body>
+</html>

--- a/tauri/src/app/form/CompareForm.tsx
+++ b/tauri/src/app/form/CompareForm.tsx
@@ -1,3 +1,4 @@
+import { SectionHelpButton } from "../../components/dialog";
 import { DatasetSrcInfoProvider } from "../../context/DatasetSrcInfoProvider";
 import { buildDatasetSrcInfo } from "../../model/CommandOption";
 import type { CompareOptions } from "../../model/SelectParameter";
@@ -53,6 +54,7 @@ export function CompareForm(prop: {
 			{prop.compare.imageOption && (
 				<fieldset className="border border-gray-200 p-3">
 					<legend>image</legend>
+					<SectionHelpButton command="image" label="Image Option" />
 					<ImageOptionFormSection imageOption={imageOption} />
 				</fieldset>
 			)}

--- a/tauri/src/app/form/section/JdbcFormSection.tsx
+++ b/tauri/src/app/form/section/JdbcFormSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHelpButton } from "../../../components/dialog";
 import { BlueButton } from "../../../components/element/Button";
 import { ExpandButton } from "../../../components/element/ButtonIcon";
 import { useSetJdbcConnectionState } from "../../../context/JdbcConnectionProvider";
@@ -44,11 +45,14 @@ export default function JdbcFormSection({
 	return (
 		<fieldset className="border border-gray-200 p-3">
 			<legend>jdbc</legend>
-			<ExpandButton
-				toggleOptional={toggleOptional}
-				showOptional={showOptional}
-				caption="jdbc option"
-			/>
+			<div className="flex items-center gap-2">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="jdbc option"
+				/>
+				<SectionHelpButton command="jdbc" label="JDBC" />
+			</div>
 			<JdbcPropertiesTextField
 				prefix={prefix}
 				element={jdbcOption.jdbcProperties}

--- a/tauri/src/app/form/section/TemplateFormSection.tsx
+++ b/tauri/src/app/form/section/TemplateFormSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionHelpButton } from "../../../components/dialog";
 import { ExpandButton } from "../../../components/element/ButtonIcon";
 import type {
 	CommandOption,
@@ -21,11 +22,14 @@ export default function TemplateFormSection({
 	return (
 		<fieldset className="border border-gray-200 p-3">
 			<legend>template</legend>
-			<ExpandButton
-				toggleOptional={toggleOptional}
-				showOptional={showOptional}
-				caption="template option"
-			/>
+			<div className="flex items-center gap-2">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="template option"
+				/>
+				<SectionHelpButton command="template" label="Template" />
+			</div>
 			{templateOption.encoding && showEncoding && (
 				<PlainText
 					prefix={templateOption.prefix}

--- a/tauri/src/components/dialog/DialogHelpButton.tsx
+++ b/tauri/src/components/dialog/DialogHelpButton.tsx
@@ -2,17 +2,23 @@ import { ButtonIcon } from "../element/ButtonIcon";
 import { HelpIcon } from "../element/Icon";
 import { openHelpWindow } from "../../utils/helpWindow";
 
+export function SectionHelpButton(props: { command: string; label: string }) {
+	return (
+		<ButtonIcon
+			title="Help"
+			handleClick={() => {
+				openHelpWindow(props.command, props.label);
+			}}
+		>
+			<HelpIcon />
+		</ButtonIcon>
+	);
+}
+
 export function DialogHelpButton(props: { command: string; label: string }) {
 	return (
 		<div className="flex justify-end px-4 pt-2">
-			<ButtonIcon
-				title="Help"
-				handleClick={() => {
-					openHelpWindow(props.command, props.label);
-				}}
-			>
-				<HelpIcon />
-			</ButtonIcon>
+			<SectionHelpButton command={props.command} label={props.label} />
 		</div>
 	);
 }

--- a/tauri/src/components/dialog/index.ts
+++ b/tauri/src/components/dialog/index.ts
@@ -1,4 +1,4 @@
-export { DialogHelpButton } from "./DialogHelpButton";
+export { DialogHelpButton, SectionHelpButton } from "./DialogHelpButton";
 export type { SettingDialogProps } from "./SettingDialog";
 export {
 	Arrays,


### PR DESCRIPTION
## Summary
This PR adds comprehensive help documentation for three key configuration sections and improves the UI by adding contextual help buttons to form sections.

## Key Changes

### New Help Pages
- **template.html** - Documents StringTemplate 4 (ST4) configuration including:
  - Template encoding, groups, parameter attributes, and delimiter customization
  - Parameter binding examples with different configurations
  - xlsx-specific formula processing options
  
- **image.html** - Documents image/PDF comparison options including:
  - Threshold and tolerance settings for pixel-level comparison
  - Difference rectangle drawing and styling options
  - Excluded areas configuration with coordinate format specification
  - Color specification using Java Color format

- **jdbc.html** - Documents JDBC connection configuration including:
  - Connection properties and .properties file format
  - JDBC URL Builder for common databases (Oracle, PostgreSQL, H2)
  - Connection testing functionality
  - Properties file saving feature

### UI Improvements
- **DialogHelpButton.tsx** - Extracted `SectionHelpButton` component to allow help buttons in form sections (not just dialogs)
- **JdbcFormSection.tsx** - Added help button next to "jdbc option" expand button
- **TemplateFormSection.tsx** - Added help button next to "template option" expand button
- **CompareForm.tsx** - Added help button for image options section
- **index.html** - Updated help index to link to new help pages

### Implementation Details
- Help buttons are positioned inline with section headers using flexbox layout
- All new help pages follow consistent styling with existing help documentation
- Help pages include cross-references to related pages for better navigation
- The `SectionHelpButton` component is exported from the dialog components index for reuse across forms

https://claude.ai/code/session_01X5mrTVzgrmUa3xBCBFe4oZ