### PR TITLE
Support workspace path as fallback for relative path resolution

### DIFF
--- a/tauri/src/app/form/section/element/Chooser.tsx
+++ b/tauri/src/app/form/section/element/Chooser.tsx
@@ -15,10 +15,26 @@ function useChooserHandler(prop: FileProp, directory?: boolean) {
 	const resolveAbsolutePath = useResolveAbsolutePath();
 	return () => {
 		const basePath = context.getPath(prop.element.attribute.defaultPath);
+		const workspacePath = context.workspace;
 		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
 			open({ defaultPath, directory }).then((files) => {
 				if (files) {
-					prop.setPath((files as string).replace(basePath + sep(), ""));
+					const fullPath = files as string;
+					const primaryPrefix = basePath + sep();
+					const secondaryPrefix = workspacePath + sep();
+					let relative: string;
+					if (fullPath.startsWith(primaryPrefix)) {
+						relative = fullPath.slice(primaryPrefix.length);
+					} else if (
+						workspacePath !== "" &&
+						workspacePath !== basePath &&
+						fullPath.startsWith(secondaryPrefix)
+					) {
+						relative = fullPath.slice(secondaryPrefix.length);
+					} else {
+						relative = fullPath;
+					}
+					prop.setPath(relative);
 					prop.onSelect?.();
 				}
 			}),

--- a/tauri/src/app/form/section/element/Text.tsx
+++ b/tauri/src/app/form/section/element/Text.tsx
@@ -30,6 +30,9 @@ export default function Text({
 	const basePath = showDefaulePath
 		? context.getPath(element.attribute.defaultPath)
 		: "";
+	const workspacePath = context.workspace;
+	const showWorkspaceAsSecondary =
+		showDefaulePath && workspacePath !== "" && workspacePath !== basePath;
 
 	const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue = ev.target.value;
@@ -62,6 +65,9 @@ export default function Text({
 						)}
 						{!hidden && showDefaulePath && (
 							<p className="text-xs text-gray-400 truncate">{basePath}</p>
+						)}
+						{!hidden && showWorkspaceAsSecondary && (
+							<p className="text-xs text-gray-400 truncate">{workspacePath}</p>
 						)}
 					</div>
 					{!hidden &&


### PR DESCRIPTION
## Summary
Enhanced the file chooser and text input components to support workspace path as a secondary fallback when resolving relative paths. This allows files selected from the workspace directory to be stored as relative paths when they don't fall under the primary base path.

## Key Changes
- **Chooser.tsx**: Updated path resolution logic to check both the primary base path and workspace path when converting absolute paths to relative paths
  - Added workspace path as a secondary prefix to try when the selected file doesn't match the primary base path
  - Maintains backward compatibility by only using workspace path if it's defined and differs from the base path
  
- **Text.tsx**: Added display of workspace path as a secondary hint in the UI
  - Shows workspace path below the primary base path when appropriate
  - Only displays when workspace path is configured, non-empty, and different from the base path

## Implementation Details
- The fallback logic prioritizes the primary base path first, then checks the workspace path, and finally falls back to the absolute path if neither prefix matches
- Workspace path is only used as a secondary option when it's explicitly set and distinct from the base path, preventing redundant display
- Changes maintain existing behavior for cases where workspace path is not configured or matches the base path

https://claude.ai/code/session_01VoyPVNYmVVQTVXeabdBSq6