### PR TITLE
Refactor hooks to use module-level functions and fix typo

### DIFF
--- a/tauri/.claude/rules/hooks-design.md
+++ b/tauri/.claude/rules/hooks-design.md
@@ -1,0 +1,74 @@
+# hooks/ 設計規約
+
+## useEffect 内で使う非同期処理はモジュールレベル関数で書く
+
+`useEffect` 内から呼ぶ非同期 API 関数は、**フックではなくモジュールレベルの `async function`** として定義する。
+
+### なぜか
+
+フックが返すクロージャは毎レンダーで新しい参照になる。
+`useEffect` の依存配列に含めると、effect 内の `setState` → 再レンダー → 新しいクロージャ → effect 再発火 の無限ループが起きる。
+
+モジュールレベル関数は参照が安定しているため依存配列に入れる必要がなく、ループが起きない。
+
+### OK: モジュールレベル関数 + apiUrl を deps に含める
+
+```typescript
+// hooks/useXxx.ts
+
+// モジュールレベル関数 — 参照が安定
+async function fetchXxx(apiUrl: string, param: Param): Promise<Result> {
+    ...
+}
+
+export const useXxx = (param: Param) => {
+    const { apiUrl } = useEnviroment();
+    const [data, setData] = useState<Result | null>(null);
+
+    useEffect(() => {
+        let isMounted = true;
+        fetchXxx(apiUrl, param).then((result) => {
+            if (isMounted) { setData(result); }
+        });
+        return () => { isMounted = false; };
+    }, [apiUrl, param]);  // fetchXxx は deps 不要
+
+    return data;
+};
+```
+
+### NG: フックが返すクロージャを deps に含める
+
+```typescript
+// 毎レンダーで新しい関数参照 → 無限ループ
+const loadData = useLoadDataApi();  // フックが返すクロージャ
+useEffect(() => {
+    setLoading(true);               // 再レンダー → 新クロージャ → effect 再発火
+    loadData(param).then(...);
+}, [loadData, param]);              // NG: loadData が deps にある
+```
+
+### イベントハンドラ用フックはそのままでよい
+
+ボタンクリックなど **`useEffect` 外から呼ぶだけ** の関数はフックが返すクロージャでも問題ない。
+deps に含めないので無限ループは起きない。
+
+```typescript
+// イベントハンドラとして使うだけなら OK
+const save = useSaveXxx();
+<button onClick={() => save(input)} />
+```
+
+## isMounted ガード
+
+非同期処理が完了する前にコンポーネントがアンマウントされる可能性がある場合は必ず `isMounted` ガードを付ける。
+
+```typescript
+useEffect(() => {
+    let isMounted = true;
+    fetchXxx(apiUrl, param).then((result) => {
+        if (isMounted) { setData(result); }
+    });
+    return () => { isMounted = false; };
+}, [apiUrl, param]);
+```

--- a/tauri/src/context/EnvironmentProvider.tsx
+++ b/tauri/src/context/EnvironmentProvider.tsx
@@ -2,15 +2,15 @@ import { getMatches } from "@tauri-apps/plugin-cli";
 import type { ReactNode } from "react";
 import { createContext, Suspense, use } from "react";
 
-export type Enviroment = {
+export type Environment = {
 	apiUrl: string;
 	workspace: string;
 	dataset_base: string;
 	result_base: string;
 };
-export const enviromentContext = createContext<Enviroment>({} as Enviroment);
-export default function EnviromentProvider(props: { children: ReactNode }) {
-	const getEnviroment = async () => {
+export const environmentContext = createContext<Environment>({} as Environment);
+export default function EnvironmentProvider(props: { children: ReactNode }) {
+	const getEnvironment = async () => {
 		const matches = await getMatches();
 		const port = matches.args.port.value ? matches.args.port.value : "8080";
 		const workspace = matches.args.workspace.value
@@ -31,19 +31,19 @@ export default function EnviromentProvider(props: { children: ReactNode }) {
 	};
 	return (
 		<Suspense fallback={<div>Loading...</div>}>
-			<CreateContext promise={getEnviroment()}>{props.children}</CreateContext>
+			<CreateContext promise={getEnvironment()}>{props.children}</CreateContext>
 		</Suspense>
 	);
 }
 function CreateContext(props: {
-	promise: Promise<Enviroment>;
+	promise: Promise<Environment>;
 	children: ReactNode;
 }) {
-	const enviroment = use(props.promise);
+	const environment = use(props.promise);
 	return (
-		<enviromentContext.Provider value={enviroment}>
+		<environmentContext.Provider value={environment}>
 			{props.children}
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
-export const useEnviroment = () => use(enviromentContext);
+export const useEnvironment = () => use(environmentContext);

--- a/tauri/src/context/WorkspaceResourcesProvider.tsx
+++ b/tauri/src/context/WorkspaceResourcesProvider.tsx
@@ -7,7 +7,7 @@ import {
 	type WorkspaceResources,
 } from "../model/WorkspaceResources";
 import { fetchData, getErrorMessage, handleFetchError } from "../utils/fetchUtils";
-import { useEnviroment } from "./EnviromentProvider";
+import { useEnvironment } from "./EnvironmentProvider";
 
 const workspaceContext = createContext<WorkspaceContext>(
 	{} as WorkspaceContext,
@@ -28,7 +28,7 @@ const setResourcesSettingsContext = createContext<
 export default function WorkspaceResourcesProvider(props: {
 	children: ReactNode;
 }) {
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	const workspaceReload = async () => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl}workspace/resources`,

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useJdbcConnectionState } from "../context/JdbcConnectionProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
@@ -11,67 +11,62 @@ import {
 import type { ResourcesSettings } from "../model/WorkspaceResources";
 import { fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
 
-export const useDatasetTableNamesApi = () => {
-	const { apiUrl } = useEnviroment();
-	return async (
-		info: DatasetSrcInfo,
-		jdbcValues: Record<string, string>,
-	): Promise<string[]> => {
-		if (!info.srcPath) {
-			return [];
-		}
-		const fetchParams = {
-			endpoint: `${apiUrl}dataset-setting/table-names`,
-			options: {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					setting: info.setting ?? "",
-					srcType: info.srcType,
-					src: info.srcPath,
-					regTableInclude: info.regTableInclude,
-					regTableExclude: info.regTableExclude,
-					recursive: info.recursive === "true",
-					regInclude: info.regInclude,
-					regExclude: info.regExclude,
-					extension: info.extension,
-					xlsxSchema: info.xlsxSchema,
-					fixedLength: info.fixedLength,
-					regHeaderSplit: info.regHeaderSplit,
-					regDataSplit: info.regDataSplit,
-					encoding: info.encoding,
-					delimiter: info.delimiter,
-					ignoreQuoted: info.ignoreQuoted,
-					headerName: info.headerName,
-					startRow: info.startRow,
-					addFileInfo: info.addFileInfo,
-					jdbcUrl: jdbcValues.jdbcUrl ?? "",
-					jdbcUser: jdbcValues.jdbcUser ?? "",
-					jdbcPass: jdbcValues.jdbcPass ?? "",
-					jdbcProperties: jdbcValues.jdbcProperties ?? "",
-				}),
-			},
-		};
-		return fetchData(fetchParams)
-			.then((r) => r.json())
-			.catch(() => []);
+async function fetchTableNames(
+	apiUrl: string,
+	info: DatasetSrcInfo,
+	jdbcValues: Record<string, string>,
+): Promise<string[]> {
+	if (!info.srcPath) {
+		return [];
+	}
+	const fetchParams = {
+		endpoint: `${apiUrl}dataset-setting/table-names`,
+		options: {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				setting: info.setting ?? "",
+				srcType: info.srcType,
+				src: info.srcPath,
+				regTableInclude: info.regTableInclude,
+				regTableExclude: info.regTableExclude,
+				recursive: info.recursive === "true",
+				regInclude: info.regInclude,
+				regExclude: info.regExclude,
+				extension: info.extension,
+				xlsxSchema: info.xlsxSchema,
+				fixedLength: info.fixedLength,
+				regHeaderSplit: info.regHeaderSplit,
+				regDataSplit: info.regDataSplit,
+				encoding: info.encoding,
+				delimiter: info.delimiter,
+				ignoreQuoted: info.ignoreQuoted,
+				headerName: info.headerName,
+				startRow: info.startRow,
+				addFileInfo: info.addFileInfo,
+				jdbcUrl: jdbcValues.jdbcUrl ?? "",
+				jdbcUser: jdbcValues.jdbcUser ?? "",
+				jdbcPass: jdbcValues.jdbcPass ?? "",
+				jdbcProperties: jdbcValues.jdbcProperties ?? "",
+			}),
+		},
 	};
-};
+	return fetchData(fetchParams)
+		.then((r) => r.json())
+		.catch(() => []);
+}
 
 export const useDatasetTableNames = (
 	srcInfo: DatasetSrcInfo,
 ): { tableNames: string[]; loading: boolean } => {
 	const [tableNames, setTableNames] = useState<string[]>([]);
 	const [loading, setLoading] = useState(false);
+	const { apiUrl } = useEnviroment();
 	const { jdbcValues, connectionOk } = useJdbcConnectionState();
-	const loadTableNames = useDatasetTableNamesApi();
 
 	const srcPath = srcInfo.srcPath;
 	const srcType = srcInfo.srcType;
 	const sqlNotReady = srcType === "sql" && !connectionOk;
-
-	const loadTableNamesRef = useRef(loadTableNames);
-	loadTableNamesRef.current = loadTableNames;
 
 	useEffect(() => {
 		if (!srcPath || !srcType || srcType === "none" || sqlNotReady) {
@@ -81,7 +76,7 @@ export const useDatasetTableNames = (
 		}
 		let isMounted = true;
 		setLoading(true);
-		loadTableNamesRef.current(srcInfo, jdbcValues).then((names) => {
+		fetchTableNames(apiUrl, srcInfo, jdbcValues).then((names) => {
 			if (isMounted) {
 				setTableNames(names);
 				setLoading(false);
@@ -90,7 +85,7 @@ export const useDatasetTableNames = (
 		return () => {
 			isMounted = false;
 		};
-	}, [srcPath, srcType, srcInfo, sqlNotReady, jdbcValues]);
+	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues]);
 
 	return { tableNames, loading };
 };

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -1,6 +1,5 @@
-import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import { useJdbcConnectionState } from "../context/JdbcConnectionProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../model/CommandOption";
@@ -8,8 +7,7 @@ import {
 	DatasetSettings,
 	type DatasetSettingsBuilder,
 } from "../model/DatasetSettings";
-import type { ResourcesSettings } from "../model/WorkspaceResources";
-import { fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
+import { fetchAndUpdate, fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
 
 async function fetchTableNames(
 	apiUrl: string,
@@ -61,7 +59,7 @@ export const useDatasetTableNames = (
 ): { tableNames: string[]; loading: boolean } => {
 	const [tableNames, setTableNames] = useState<string[]>([]);
 	const [loading, setLoading] = useState(false);
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const { jdbcValues, connectionOk } = useJdbcConnectionState();
 
 	const srcPath = srcInfo.srcPath;
@@ -91,34 +89,35 @@ export const useDatasetTableNames = (
 };
 
 export const useDeleteDatasetSettings = () => {
-	const environment = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string) => {
-		return deleteDatasetSettings(
-			environment.apiUrl,
-			name,
-			setResourcesSettings,
+	return async (name: string): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}dataset-setting/delete`,
+				options: { method: "POST", headers: { "Content-Type": "text/plain" }, body: name },
+			},
+			(settings) => setResourcesSettings((current) => current.with({ datasetSettings: settings })),
 		);
-	};
 };
 
 export const useSaveDatasetSettings = () => {
-	const environment = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string, input: DatasetSettings) => {
-		return saveDatasetSettings(
-			environment.apiUrl,
-			name,
-			input,
-			setResourcesSettings,
+	return async (name: string, input: DatasetSettings): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}dataset-setting/save`,
+				options: { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, input }) },
+			},
+			(settings) => setResourcesSettings((current) => current.with({ datasetSettings: settings })),
 		);
-	};
 };
 
 export const useDatasetSettingsData = (
 	fileName: string,
 ): { settings: DatasetSettings; loading: boolean } => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const [settings, setSettings] = useState(DatasetSettings.create());
 	const [loading, setLoading] = useState(fileName !== "");
 
@@ -165,62 +164,5 @@ async function loadDatasetSettings(
 		.catch((ex) => {
 			handleFetchError(getErrorMessage(ex), fetchParams);
 			return DatasetSettings.create();
-		});
-}
-
-async function saveDatasetSettings(
-	apiUrl: string,
-	name: string,
-	input: DatasetSettings,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}dataset-setting/save`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ name, input }),
-		},
-	};
-
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((settings: string[]) => {
-			setResourcesSettings((current) =>
-				current.with({ datasetSettings: settings }),
-			);
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
-		});
-}
-
-async function deleteDatasetSettings(
-	apiUrl: string,
-	name: string,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}dataset-setting/delete`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "text/plain" },
-			body: name,
-		},
-	};
-
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((settings: string[]) => {
-			setResourcesSettings((current) =>
-				current.with({ datasetSettings: settings }),
-			);
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
 		});
 }

--- a/tauri/src/hooks/useJdbc.ts
+++ b/tauri/src/hooks/useJdbc.ts
@@ -1,41 +1,6 @@
-import type { Dispatch, SetStateAction } from "react";
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
-import type { ResourcesSettings } from "../model/WorkspaceResources";
-import { fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
-
-export const useDeleteJdbcProperties = () => {
-	const { apiUrl } = useEnviroment();
-	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string): Promise<OperationResult> => {
-		return deleteJdbcProperties(apiUrl, name, setResourcesSettings);
-	};
-};
-
-async function deleteJdbcProperties(
-	apiUrl: string,
-	name: string,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}jdbc/delete`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "text/plain" },
-			body: name,
-		},
-	};
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((files: string[]) => {
-			setResourcesSettings((current) => current.with({ jdbcFiles: files }));
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
-		});
-}
+import { fetchAndUpdate, fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
 
 function toJdbcRequestBody(jdbcValues: Record<string, string>) {
 	return {
@@ -46,8 +11,21 @@ function toJdbcRequestBody(jdbcValues: Record<string, string>) {
 	};
 }
 
+export const useDeleteJdbcProperties = () => {
+	const { apiUrl } = useEnvironment();
+	const setResourcesSettings = useSetResourcesSettings();
+	return async (name: string): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}jdbc/delete`,
+				options: { method: "POST", headers: { "Content-Type": "text/plain" }, body: name },
+			},
+			(files) => setResourcesSettings((current) => current.with({ jdbcFiles: files })),
+		);
+};
+
 export const useJdbcTables = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	return async (jdbcValues: Record<string, string>): Promise<string[]> => {
 		const params = {
 			endpoint: `${apiUrl}jdbc/tables`,
@@ -68,7 +46,7 @@ export const useJdbcTables = () => {
 };
 
 export const useJdbcConnectionTest = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	return async (
 		jdbcValues: Record<string, string>,
 	): Promise<{ success: boolean; message: string } | null> => {
@@ -91,39 +69,14 @@ export const useJdbcConnectionTest = () => {
 };
 
 export const useJdbcSaveProperties = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (
-		name: string,
-		jdbcValues: Record<string, string>,
-	): Promise<OperationResult> => {
-		return saveJdbcProperties(apiUrl, name, jdbcValues, setResourcesSettings);
-	};
+	return async (name: string, jdbcValues: Record<string, string>): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}jdbc/save-properties`,
+				options: { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, input: toJdbcRequestBody(jdbcValues) }) },
+			},
+			(files) => setResourcesSettings((current) => current.with({ jdbcFiles: files })),
+		);
 };
-
-async function saveJdbcProperties(
-	apiUrl: string,
-	name: string,
-	jdbcValues: Record<string, string>,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}jdbc/save-properties`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ name, input: toJdbcRequestBody(jdbcValues) }),
-		},
-	};
-
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((files: string[]) => {
-			setResourcesSettings((current) => current.with({ jdbcFiles: files }));
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
-		});
-}

--- a/tauri/src/hooks/useQueryDatasource.ts
+++ b/tauri/src/hooks/useQueryDatasource.ts
@@ -1,4 +1,4 @@
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import type {
 	QueryDatasource,
 	QueryDatasourceType,
@@ -11,7 +11,7 @@ import {
 } from "../utils/fetchUtils";
 
 export const useDeleteDataSource = (type: QueryDatasourceType) => {
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (name: string) => {
 		return postDataSource(environment.apiUrl, "query-datasource/delete", {
 			type,
@@ -20,13 +20,13 @@ export const useDeleteDataSource = (type: QueryDatasourceType) => {
 	};
 };
 export const useSaveDataSource = () => {
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (input: QueryDatasource) => {
 		return postDataSource(environment.apiUrl, "query-datasource/save", input);
 	};
 };
 export const useLoadDataSource = () => {
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (name: string) => {
 		return loadDataSource(environment.apiUrl, name);
 	};

--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -1,4 +1,4 @@
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import {
 	useSelectParameter,
 	useSetSelectParameterState,
@@ -20,7 +20,7 @@ export type Running = {
 
 export const useLoadSelectParameter = () => {
 	const setParameter = useSetSelectParameterState();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (command: Command, name: string) => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl + command.toLowerCase()}/load`,
@@ -41,7 +41,7 @@ export const useLoadSelectParameter = () => {
 
 export const useRefreshSelectParameter = (command: string) => {
 	const setParameter = useSetSelectParameterState();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (values: { [k: string]: FormDataEntryValue }) => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl + command.toLowerCase()}/refresh`,
@@ -82,7 +82,7 @@ const parseResponse = async (
 
 const useParameterAction = () => {
 	const parameter = useSelectParameter();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (
 		action: ParameterAction,
 		extraBody: Record<string, unknown>,
@@ -139,7 +139,7 @@ export const useSaveShell = () => {
 export const useParameterizeFrom = () => {
 	const setParameter = useSetSelectParameterState();
 	const setParameterList = useSetParameterList();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (sourceCommand: string, name: string) => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl + sourceCommand.toLowerCase()}/parameterize`,

--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import {
+	fetchAndUpdate,
 	fetchData,
 	getErrorMessage,
 	handleFetchError,
@@ -9,7 +10,7 @@ import {
 } from "../utils/fetchUtils";
 
 export const useTemplateData = (name: string): { content: string; loading: boolean } => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const [content, setContent] = useState("");
 	const [loading, setLoading] = useState(name !== "");
 
@@ -36,55 +37,29 @@ export const useTemplateData = (name: string): { content: string; loading: boole
 };
 
 export const useDeleteTemplate = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string): Promise<OperationResult> => {
-		const params = {
-			endpoint: `${apiUrl}template/delete`,
-			options: {
-				method: "POST",
-				headers: { "Content-Type": "text/plain" },
-				body: name,
+	return async (name: string): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}template/delete`,
+				options: { method: "POST", headers: { "Content-Type": "text/plain" }, body: name },
 			},
-		};
-		try {
-			const response = await fetchData(params);
-			const settings = (await response.json()) as string[];
-			setResourcesSettings((current) =>
-				current.with({ templateFiles: settings }),
-			);
-			return "success";
-		} catch (e) {
-			handleFetchError(getErrorMessage(e), params);
-			return "failed";
-		}
-	};
+			(settings) => setResourcesSettings((current) => current.with({ templateFiles: settings })),
+		);
 };
 
 export const useTemplateSaveContent = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string, content: string): Promise<OperationResult> => {
-		const params = {
-			endpoint: `${apiUrl}template/save`,
-			options: {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ name, input: { content } }),
+	return async (name: string, content: string): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}template/save`,
+				options: { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, input: { content } }) },
 			},
-		};
-		try {
-			const response = await fetchData(params);
-			const settings = (await response.json()) as string[];
-			setResourcesSettings((current) =>
-				current.with({ templateFiles: settings }),
-			);
-			return "success";
-		} catch (e) {
-			handleFetchError(getErrorMessage(e), params);
-			return "failed";
-		}
-	};
+			(settings) => setResourcesSettings((current) => current.with({ templateFiles: settings })),
+		);
 };
 
 async function loadTemplateContent(apiUrl: string, name: string): Promise<string> {

--- a/tauri/src/hooks/useWorkspaceResources.ts
+++ b/tauri/src/hooks/useWorkspaceResources.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, sep } from "@tauri-apps/api/path";
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import {
 	useSelectParameter,
 	useSetSelectParameter,
@@ -23,7 +23,7 @@ export const useWorkspaceUpdate = () => {
 	const setContext = useSetWorkspaceContext();
 	const setParameterList = useSetParameterList();
 	const setResourcesSettings = useSetResourcesSettings();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async (workspace: string, datasetBase: string, resultBase: string) => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl}workspace/update`,
@@ -52,7 +52,7 @@ export const useWorkspaceUpdate = () => {
 
 export const useAddParameter = (command: string) => {
 	const setParameter = useSetParameterList();
-	const environment = useEnviroment();
+	const environment = useEnvironment();
 	return async () => {
 		const fetchParams = {
 			endpoint: `${environment.apiUrl + command.toLowerCase()}/add`,
@@ -74,7 +74,7 @@ export const useAddParameter = (command: string) => {
 
 export const useParameterActions = (command: string, name: string) => {
 	const setParameterList = useSetParameterList();
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const parameter = useSelectParameter();
 	const setParameter = useSetSelectParameter();
 
@@ -129,7 +129,7 @@ export const useParameterActions = (command: string, name: string) => {
 };
 
 export const useResolveAbsolutePath = () => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const context = useWorkspaceContext();
 	return async (path: string, attribute: Attribute): Promise<string> => {
 		const fetchParams = {

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -175,15 +175,7 @@ export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 			return;
 		}
 		let isMounted = true;
-		fetchSheets(apiUrl, {
-			srcPath,
-			regTableInclude,
-			regTableExclude,
-			recursive,
-			regInclude,
-			regExclude,
-			extension,
-		}).then((names) => {
+		fetchSheets(apiUrl, srcInfo).then((names) => {
 			if (isMounted) {
 				setSheetNames(names);
 			}

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,37 +1,40 @@
-import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
-import { useEnviroment } from "../context/EnviromentProvider";
+import { useEnvironment } from "../context/EnvironmentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { SrcInfo } from "../model/CommandOption";
-import type { ResourcesSettings } from "../model/WorkspaceResources";
 import { XlsxSchema, type XlsxSchemaBuilder } from "../model/XlsxSchema";
-import { fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
+import { fetchAndUpdate, fetchData, getErrorMessage, handleFetchError, type OperationResult } from "../utils/fetchUtils";
 
 export const useDeleteXlsxSchema = () => {
-	const environment = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string) => {
-		return deleteXlsxSchema(environment.apiUrl, name, setResourcesSettings);
-	};
+	return async (name: string): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}xlsx-schema/delete`,
+				options: { method: "POST", headers: { "Content-Type": "text/plain" }, body: name },
+			},
+			(schemas) => setResourcesSettings((current) => current.with({ xlsxSchemas: schemas })),
+		);
 };
 
 export const useSaveXlsxSchema = () => {
-	const environment = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const setResourcesSettings = useSetResourcesSettings();
-	return async (name: string, input: XlsxSchema) => {
-		return saveXlsxSchema(
-			environment.apiUrl,
-			name,
-			input,
-			setResourcesSettings,
+	return async (name: string, input: XlsxSchema): Promise<OperationResult> =>
+		fetchAndUpdate<string[]>(
+			{
+				endpoint: `${apiUrl}xlsx-schema/save`,
+				options: { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, input }) },
+			},
+			(schemas) => setResourcesSettings((current) => current.with({ xlsxSchemas: schemas })),
 		);
-	};
 };
 
 export const useXlsxSchemaData = (
 	fileName: string,
 ): { schema: XlsxSchema; loading: boolean } => {
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const [schema, setSchema] = useState(XlsxSchema.create());
 	const [loading, setLoading] = useState(fileName !== "");
 
@@ -81,59 +84,6 @@ async function loadXlsxSchema(
 		});
 }
 
-async function saveXlsxSchema(
-	apiUrl: string,
-	name: string,
-	input: XlsxSchema,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}xlsx-schema/save`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ name, input }),
-		},
-	};
-
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((schemas: string[]) => {
-			setResourcesSettings((current) => current.with({ xlsxSchemas: schemas }));
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
-		});
-}
-
-async function deleteXlsxSchema(
-	apiUrl: string,
-	name: string,
-	setResourcesSettings: Dispatch<SetStateAction<ResourcesSettings>>,
-): Promise<OperationResult> {
-	const fetchParams = {
-		endpoint: `${apiUrl}xlsx-schema/delete`,
-		options: {
-			method: "POST",
-			headers: { "Content-Type": "text/plain" },
-			body: name,
-		},
-	};
-
-	return await fetchData(fetchParams)
-		.then((response) => response.json())
-		.then((schemas: string[]) => {
-			setResourcesSettings((current) => current.with({ xlsxSchemas: schemas }));
-			return "success" as OperationResult;
-		})
-		.catch((ex) => {
-			handleFetchError(getErrorMessage(ex), fetchParams);
-			return "failed" as OperationResult;
-		});
-}
-
 async function fetchSheets(apiUrl: string, srcInfo: SrcInfo): Promise<string[]> {
 	if (!srcInfo.srcPath) {
 		return [];
@@ -161,7 +111,7 @@ async function fetchSheets(apiUrl: string, srcInfo: SrcInfo): Promise<string[]> 
 
 export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 	const [sheetNames, setSheetNames] = useState<string[]>([]);
-	const { apiUrl } = useEnviroment();
+	const { apiUrl } = useEnvironment();
 	const srcPath = srcInfo.srcPath;
 	const regTableInclude = srcInfo.regTableInclude;
 	const regTableExclude = srcInfo.regTableExclude;

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useEnviroment } from "../context/EnviromentProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { SrcInfo } from "../model/CommandOption";
@@ -134,37 +134,34 @@ async function deleteXlsxSchema(
 		});
 }
 
-export const useXlsxSheets = () => {
-	const { apiUrl } = useEnviroment();
-	return async (srcInfo: SrcInfo): Promise<string[]> => {
-		if (!srcInfo.srcPath) {
-			return [];
-		}
-		const fetchParams = {
-			endpoint: `${apiUrl}xlsx-schema/sheets`,
-			options: {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					src: srcInfo.srcPath,
-					regTableInclude: srcInfo.regTableInclude,
-					regTableExclude: srcInfo.regTableExclude,
-					recursive: srcInfo.recursive === "true",
-					regInclude: srcInfo.regInclude,
-					regExclude: srcInfo.regExclude,
-					extension: srcInfo.extension,
-				}),
-			},
-		};
-		return fetchData(fetchParams)
-			.then((r) => r.json())
-			.catch(() => []);
+async function fetchSheets(apiUrl: string, srcInfo: SrcInfo): Promise<string[]> {
+	if (!srcInfo.srcPath) {
+		return [];
+	}
+	const fetchParams = {
+		endpoint: `${apiUrl}xlsx-schema/sheets`,
+		options: {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				src: srcInfo.srcPath,
+				regTableInclude: srcInfo.regTableInclude,
+				regTableExclude: srcInfo.regTableExclude,
+				recursive: srcInfo.recursive === "true",
+				regInclude: srcInfo.regInclude,
+				regExclude: srcInfo.regExclude,
+				extension: srcInfo.extension,
+			}),
+		},
 	};
-};
+	return fetchData(fetchParams)
+		.then((r) => r.json())
+		.catch(() => []);
+}
 
 export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 	const [sheetNames, setSheetNames] = useState<string[]>([]);
-	const loadSheets = useXlsxSheets();
+	const { apiUrl } = useEnviroment();
 	const srcPath = srcInfo.srcPath;
 	const regTableInclude = srcInfo.regTableInclude;
 	const regTableExclude = srcInfo.regTableExclude;
@@ -173,15 +170,12 @@ export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 	const regExclude = srcInfo.regExclude;
 	const extension = srcInfo.extension;
 
-	const loadSheetsRef = useRef(loadSheets);
-	loadSheetsRef.current = loadSheets;
-
 	useEffect(() => {
 		if (!srcPath) {
 			return;
 		}
 		let isMounted = true;
-		loadSheetsRef.current({
+		fetchSheets(apiUrl, {
 			srcPath,
 			regTableInclude,
 			regTableExclude,
@@ -198,6 +192,7 @@ export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 			isMounted = false;
 		};
 	}, [
+		apiUrl,
 		srcPath,
 		regTableInclude,
 		regTableExclude,

--- a/tauri/src/main.tsx
+++ b/tauri/src/main.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
 import Layout from "./app/main/Layout";
 import StartupForm from "./app/startup/StartupForm";
-import EnviromentProvider from "./context/EnviromentProvider";
+import EnvironmentProvider from "./context/EnvironmentProvider";
 import WorkspaceResourcesProvider from "./context/WorkspaceResourcesProvider";
 
 const App: React.FC = () => {
@@ -16,7 +16,7 @@ const App: React.FC = () => {
 
 	return (
 		<React.StrictMode>
-			<EnviromentProvider>
+			<EnvironmentProvider>
 				<WorkspaceResourcesProvider>
 					{isStartupFormVisible ? (
 						<StartupForm onSelect={handleSelect} />
@@ -24,7 +24,7 @@ const App: React.FC = () => {
 						<Layout />
 					)}
 				</WorkspaceResourcesProvider>
-			</EnviromentProvider>
+			</EnvironmentProvider>
 		</React.StrictMode>
 	);
 };

--- a/tauri/src/tests/app/form/CompareForm.test.tsx
+++ b/tauri/src/tests/app/form/CompareForm.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CompareForm } from "../../../app/form/CompareForm";
 import type { CompareOptions } from "../../../model/SelectParameter";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import {
 	compareLoadResponseFixture,
 	compareRefreshExpectSrcTypeCsvResponseFixture,
@@ -23,8 +23,8 @@ vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
 }));
-vi.mock("../../../context/EnviromentProvider", () => ({
-	useEnviroment: () => enviromentFixture,
+vi.mock("../../../context/EnvironmentProvider", () => ({
+	useEnvironment: () => environmentFixture,
 }));
 
 // JDBC API フックのモック

--- a/tauri/src/tests/app/form/ConvertForm.test.tsx
+++ b/tauri/src/tests/app/form/ConvertForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ConvertForm } from "../../../app/form/ConvertForm";
 import type { ConvertOptions } from "../../../model/SelectParameter";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import {
 	convertLoadResponseFixture,
 	convertRefreshResultTypeXlsxResponseFixture,
@@ -24,8 +24,8 @@ vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
 }));
-vi.mock("../../../context/EnviromentProvider", () => ({
-	useEnviroment: () => enviromentFixture,
+vi.mock("../../../context/EnvironmentProvider", () => ({
+	useEnvironment: () => environmentFixture,
 }));
 
 // JDBC API フックのモック（クリック時のみ API を呼ぶ）

--- a/tauri/src/tests/app/form/GenerateForm.test.tsx
+++ b/tauri/src/tests/app/form/GenerateForm.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GenerateForm } from "../../../app/form/GenerateForm";
 import type { GenerateOptions } from "../../../model/SelectParameter";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import {
 	generateLoadResponseFixture,
 	generateRefreshSrcTypeTableResponseFixture,
@@ -21,8 +21,8 @@ vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
 }));
-vi.mock("../../../context/EnviromentProvider", () => ({
-	useEnviroment: () => enviromentFixture,
+vi.mock("../../../context/EnvironmentProvider", () => ({
+	useEnvironment: () => environmentFixture,
 }));
 
 // JDBC API フックのモック

--- a/tauri/src/tests/app/form/ParameterizeForm.test.tsx
+++ b/tauri/src/tests/app/form/ParameterizeForm.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ParameterizeForm } from "../../../app/form/ParameterizeForm";
 import type { ParameterizeOptions } from "../../../model/SelectParameter";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import { parameterizeLoadResponseFixture } from "./fixtures";
 
 // Tauri API モック
@@ -18,8 +18,8 @@ vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
 }));
-vi.mock("../../../context/EnviromentProvider", () => ({
-	useEnviroment: () => enviromentFixture,
+vi.mock("../../../context/EnvironmentProvider", () => ({
+	useEnvironment: () => environmentFixture,
 }));
 
 // JDBC API フックのモック

--- a/tauri/src/tests/app/form/RunForm.test.tsx
+++ b/tauri/src/tests/app/form/RunForm.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { RunForm } from "../../../app/form/RunForm";
 import type { RunOptions } from "../../../model/SelectParameter";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import {
 	runLoadResponseFixture,
 	runRefreshScriptTypeCmdResponseFixture,
@@ -20,8 +20,8 @@ vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
 }));
-vi.mock("../../../context/EnviromentProvider", () => ({
-	useEnviroment: () => enviromentFixture,
+vi.mock("../../../context/EnvironmentProvider", () => ({
+	useEnvironment: () => environmentFixture,
 }));
 
 vi.mock("../../../hooks/useJdbc", () => ({

--- a/tauri/src/tests/app/main/Header.test.tsx
+++ b/tauri/src/tests/app/main/Header.test.tsx
@@ -4,23 +4,23 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import Header from "../../../app/main/Header";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../../context/EnvironmentProvider";
 import SelectParameterProvider from "../../../context/SelectParameterProvider";
 import WorkspaceResourcesProvider from "../../../context/WorkspaceResourcesProvider";
 import type { FetchParams } from "../../../utils/fetchUtils";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 function MockProvider({ children }: { children: ReactNode }) {
 	return (
-		<enviromentContext.Provider value={mockEnviroment}>
+		<environmentContext.Provider value={mockEnvironment}>
 			<WorkspaceResourcesProvider>
 				<SelectParameterProvider>{children}</SelectParameterProvider>
 			</WorkspaceResourcesProvider>
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
 const wrapper = ({ children }: { children: ReactNode }) => (

--- a/tauri/src/tests/app/startup/StartupForm.test.tsx
+++ b/tauri/src/tests/app/startup/StartupForm.test.tsx
@@ -9,20 +9,20 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import StartupForm from "../../../app/startup/StartupForm";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../../context/EnvironmentProvider";
 import WorkspaceResourcesProvider from "../../../context/WorkspaceResourcesProvider";
 import type { FetchParams } from "../../../utils/fetchUtils";
-import { enviromentFixture, workspaceResourcesFixture } from "../../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 function MockProvider({ children }: { children: React.ReactNode }) {
 	return (
-		<enviromentContext.Provider value={mockEnviroment}>
+		<environmentContext.Provider value={mockEnvironment}>
 			<WorkspaceResourcesProvider>{children}</WorkspaceResourcesProvider>
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/tauri/src/tests/context/EnvironmentProvider.test.tsx
+++ b/tauri/src/tests/context/EnvironmentProvider.test.tsx
@@ -1,9 +1,9 @@
 import { act, render, renderHook, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import EnviromentProvider, {
-	useEnviroment,
-} from "../../context/EnviromentProvider";
+import EnvironmentProvider, {
+	useEnvironment,
+} from "../../context/EnvironmentProvider";
 
 // Tauri Plugin CLIのモック
 const mockArgs: {
@@ -35,12 +35,12 @@ const TestComponent = () => {
 
 // カスタムラッパーコンポーネント
 const wrapper = ({ children }: { children: ReactNode }) => (
-	<EnviromentProvider>{children}</EnviromentProvider>
+	<EnvironmentProvider>{children}</EnvironmentProvider>
 );
 
-describe("EnviromentProviderのテスト", () => {
+describe("EnvironmentProviderのテスト", () => {
 	it("環境設定が正しく読み込まれることを確認", async () => {
-		const { result, rerender } = renderHook(() => useEnviroment(), { wrapper });
+		const { result, rerender } = renderHook(() => useEnvironment(), { wrapper });
 
 		await act(async () => {
 			rerender();
@@ -61,7 +61,7 @@ describe("EnviromentProviderのテスト", () => {
 			"dataset.base": { value: "" },
 			"result.base": { value: "" },
 		};
-		const { result, rerender } = renderHook(() => useEnviroment(), { wrapper });
+		const { result, rerender } = renderHook(() => useEnvironment(), { wrapper });
 
 		await act(async () => {
 			rerender();

--- a/tauri/src/tests/context/SelectParameterProvider.test.tsx
+++ b/tauri/src/tests/context/SelectParameterProvider.test.tsx
@@ -2,9 +2,9 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../context/EnvironmentProvider";
 import SelectParameterProvider, {
 	useSelectParameter,
 	useSetSelectParameter,
@@ -23,7 +23,7 @@ import type {
 } from "../../model/SelectParameter";
 import { SelectParameter } from "../../model/SelectParameter";
 import type { FetchParams } from "../../utils/fetchUtils";
-import { enviromentFixture, makeMinimalParam } from "../setup";
+import { environmentFixture, makeMinimalParam } from "../setup";
 
 // モックデータ
 const createDatasetSource = (prefix: string) =>
@@ -126,13 +126,13 @@ vi.mock("../../utils/fetchUtils", () => ({
 	isAbortError: vi.fn(() => false),
 }));
 
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 // カスタムラッパーコンポーネント
 const wrapper = ({ children }: { children: ReactNode }) => (
-	<enviromentContext.Provider value={mockEnviroment}>
+	<environmentContext.Provider value={mockEnvironment}>
 		<SelectParameterProvider>{children}</SelectParameterProvider>
-	</enviromentContext.Provider>
+	</environmentContext.Provider>
 );
 
 describe("SelectParameterProviderのテスト", () => {

--- a/tauri/src/tests/context/WorkspaceResourcesProvider.test.tsx
+++ b/tauri/src/tests/context/WorkspaceResourcesProvider.test.tsx
@@ -7,9 +7,9 @@ import {
 } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../context/EnvironmentProvider";
 import WorkspaceResourcesProvider, {
 	useParameterList,
 	useResourcesSettings,
@@ -27,18 +27,18 @@ import {
 	WorkspaceContext,
 } from "../../model/WorkspaceResources";
 import type { FetchParams } from "../../utils/fetchUtils";
-import { enviromentFixture, workspaceResourcesFixture } from "../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../setup";
 
 // モックデータ
 const mockWorkspaceResources: WorkspaceResources = {
 	...workspaceResourcesFixture,
 };
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 function MockProvider({ children }: { children: React.ReactNode }) {
 	return (
-		<enviromentContext.Provider value={mockEnviroment}>
+		<environmentContext.Provider value={mockEnvironment}>
 			<WorkspaceResourcesProvider>{children}</WorkspaceResourcesProvider>
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/tauri/src/tests/hooks/useDatasetSettings.test.tsx
+++ b/tauri/src/tests/hooks/useDatasetSettings.test.tsx
@@ -1,9 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../context/EnvironmentProvider";
 import WorkspaceResourcesProvider, {
 	useResourcesSettings,
 } from "../../context/WorkspaceResourcesProvider";
@@ -15,7 +15,7 @@ import {
 import { DatasetSettings } from "../../model/DatasetSettings";
 import type { WorkspaceResources } from "../../model/WorkspaceResources";
 import type { FetchParams } from "../../utils/fetchUtils";
-import { enviromentFixture, workspaceResourcesFixture } from "../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../setup";
 
 // モックデータ
 const mockDatasetSettingsResponse: {
@@ -32,13 +32,13 @@ const mockRemainingSettings = [] as string[];
 const mockWorkspaceResources: WorkspaceResources = {
 	...workspaceResourcesFixture,
 };
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 function MockProvider({ children }: { children: React.ReactNode }) {
 	return (
-		<enviromentContext.Provider value={mockEnviroment}>
+		<environmentContext.Provider value={mockEnvironment}>
 			<WorkspaceResourcesProvider>{children}</WorkspaceResourcesProvider>
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/tauri/src/tests/hooks/useQueryDatasource.test.tsx
+++ b/tauri/src/tests/hooks/useQueryDatasource.test.tsx
@@ -1,9 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../context/EnvironmentProvider";
 import {
 	useDeleteDataSource,
 	useLoadDataSource,
@@ -11,7 +11,7 @@ import {
 } from "../../hooks/useQueryDatasource";
 import type { QueryDatasource } from "../../model/QueryDatasource";
 import type { FetchParams } from "../../utils/fetchUtils";
-import { enviromentFixture } from "../setup";
+import { environmentFixture } from "../setup";
 
 // モックデータ
 const mockQueryDatasource: QueryDatasource = {
@@ -19,12 +19,12 @@ const mockQueryDatasource: QueryDatasource = {
 	contents: "SELECT * FROM test_table;",
 };
 
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-	<enviromentContext.Provider value={mockEnviroment}>
+	<environmentContext.Provider value={mockEnvironment}>
 		{children}
-	</enviromentContext.Provider>
+	</environmentContext.Provider>
 );
 
 const mockLoadedContents = "SELECT * FROM test_table WHERE id = 1;";
@@ -69,7 +69,7 @@ describe("QueryDatasourceProviderのテスト", () => {
 			);
 			expect(saveResult).toBe("success");
 			expect(mockFetchData).toHaveBeenCalledWith({
-				endpoint: `${mockEnviroment.apiUrl}query-datasource/save`,
+				endpoint: `${mockEnvironment.apiUrl}query-datasource/save`,
 				options: {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
@@ -87,7 +87,7 @@ describe("QueryDatasourceProviderのテスト", () => {
 			const deleteResult = await act(async () => result.current("test-query"));
 			expect(deleteResult).toBe("success");
 			expect(mockFetchData).toHaveBeenCalledWith({
-				endpoint: `${mockEnviroment.apiUrl}query-datasource/delete`,
+				endpoint: `${mockEnvironment.apiUrl}query-datasource/delete`,
 				options: {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },

--- a/tauri/src/tests/hooks/useXlsxSchema.test.tsx
+++ b/tauri/src/tests/hooks/useXlsxSchema.test.tsx
@@ -1,9 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
-	type Enviroment,
-	enviromentContext,
-} from "../../context/EnviromentProvider";
+	type Environment,
+	environmentContext,
+} from "../../context/EnvironmentProvider";
 import WorkspaceResourcesProvider, {
 	useResourcesSettings,
 } from "../../context/WorkspaceResourcesProvider";
@@ -16,7 +16,7 @@ import type { WorkspaceResources } from "../../model/WorkspaceResources";
 import type { XlsxSchemaBuilder } from "../../model/XlsxSchema";
 import { XlsxSchema } from "../../model/XlsxSchema";
 import type { FetchParams } from "../../utils/fetchUtils";
-import { enviromentFixture, workspaceResourcesFixture } from "../setup";
+import { environmentFixture, workspaceResourcesFixture } from "../setup";
 
 // モックデータ
 const mockXlsxSchema: XlsxSchemaBuilder = {
@@ -44,13 +44,13 @@ const mockXlsxSchema: XlsxSchemaBuilder = {
 const mockWorkspaceResources: WorkspaceResources = {
 	...workspaceResourcesFixture,
 };
-const mockEnviroment: Enviroment = { ...enviromentFixture };
+const mockEnvironment: Environment = { ...environmentFixture };
 
 function MockProvider({ children }: { children: React.ReactNode }) {
 	return (
-		<enviromentContext.Provider value={mockEnviroment}>
+		<environmentContext.Provider value={mockEnvironment}>
 			<WorkspaceResourcesProvider>{children}</WorkspaceResourcesProvider>
-		</enviromentContext.Provider>
+		</environmentContext.Provider>
 	);
 }
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/tauri/src/tests/setup.tsx
+++ b/tauri/src/tests/setup.tsx
@@ -1,7 +1,7 @@
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { afterEach, vi } from "vitest";
-import type { Enviroment } from "../context/EnviromentProvider";
+import type { Environment } from "../context/EnvironmentProvider";
 import type { CommandOption } from "../model/CommandOption";
 import {
 	ParameterList,
@@ -50,7 +50,7 @@ export const workspaceResourcesFixture: WorkspaceResources = {
 	}),
 };
 
-export const enviromentFixture: Enviroment = {
+export const environmentFixture: Environment = {
 	apiUrl: "http://localhost:8080/",
 	workspace: "",
 	dataset_base: "",

--- a/tauri/src/utils/fetchUtils.ts
+++ b/tauri/src/utils/fetchUtils.ts
@@ -62,6 +62,22 @@ export async function saveOnSuccess(
 export const isAbortError = (error: unknown): boolean =>
 	error instanceof DOMException && error.name === "AbortError";
 
+export async function fetchAndUpdate<T>(
+	fetchParams: FetchParams,
+	onSuccess: (data: T) => void,
+): Promise<OperationResult> {
+	return fetchData(fetchParams)
+		.then((r) => r.json())
+		.then((data: T) => {
+			onSuccess(data);
+			return "success" as OperationResult;
+		})
+		.catch((ex) => {
+			handleFetchError(getErrorMessage(ex), fetchParams);
+			return "failed" as OperationResult;
+		});
+}
+
 export const fetchData = async ({ endpoint, options, signal }: FetchParams) => {
 	const response = await fetch(endpoint, { ...options, signal: signal ?? options.signal });
 	if (!response.ok) {


### PR DESCRIPTION
## Summary
This PR refactors the hooks architecture to follow a cleaner pattern and fixes a pervasive typo throughout the codebase. The main changes involve extracting async API calls from hooks into stable module-level functions to prevent infinite loops in `useEffect`, and renaming `Enviroment` to `Environment` across all files.

## Key Changes

### Architecture Refactoring
- **Extracted async functions from hooks**: Moved API calls like `fetchTableNames`, `fetchSheets`, and `saveDatasetSettings` from hook closures to module-level `async function` declarations. This prevents infinite loops caused by unstable function references in `useEffect` dependency arrays.
- **Introduced `fetchAndUpdate` utility**: Created a new helper function in `fetchUtils.ts` that standardizes the pattern of fetching data, calling a callback on success, and returning an `OperationResult`. This eliminates boilerplate code across multiple hooks.
- **Simplified hook implementations**: Hooks now directly call module-level functions instead of returning closures, making the code more straightforward and easier to test.

### Naming Corrections
- **Fixed typo**: Renamed `Enviroment` → `Environment` and `useEnviroment` → `useEnvironment` throughout the codebase
- **Updated context**: Renamed `EnviromentProvider.tsx` → `EnvironmentProvider.tsx` and `enviromentContext` → `environmentContext`
- **Updated all imports and usages**: Fixed references in hooks, providers, tests, and main entry point

### Affected Hooks
- `useDatasetSettings.ts`: Extracted `fetchTableNames`, removed `useDatasetTableNamesApi`, simplified `useDeleteDatasetSettings` and `useSaveDatasetSettings` using `fetchAndUpdate`
- `useXlsxSchema.ts`: Extracted `fetchSheets`, simplified `useDeleteXlsxSchema` and `useSaveXlsxSchema` using `fetchAndUpdate`
- `useJdbc.ts`: Simplified `useDeleteJdbcProperties` and `useJdbcSaveProperties` using `fetchAndUpdate`
- `useTemplate.ts`: Simplified `useDeleteTemplate` and `useTemplateSaveContent` using `fetchAndUpdate`

### Documentation
- Added `hooks-design.md` design rules documenting the pattern of using module-level functions in `useEffect` to avoid infinite loops and explaining when to use hooks vs. module-level functions

## Implementation Details
- Module-level functions receive `apiUrl` as a parameter instead of accessing it via hooks, ensuring stable references
- `useEffect` dependency arrays now include `apiUrl` instead of function references
- All async operations maintain the `isMounted` guard pattern to prevent state updates on unmounted components
- The `fetchAndUpdate` utility handles the common fetch-then-update-state pattern consistently across the codebase

https://claude.ai/code/session_01KAPAbRGf1FqaWLXhfRJ1Bj