### PR TITLE
Add mockFetchAndUpdate to test utilities for API mocking

### DIFF
--- a/tauri/src/tests/hooks/useDatasetSettings.test.tsx
+++ b/tauri/src/tests/hooks/useDatasetSettings.test.tsx
@@ -45,7 +45,6 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 	<MockProvider>{children}</MockProvider>
 );
 
-// API呼び出しのモック
 const { mockFetchData, mockFetchAndUpdate } = vi.hoisted(() => {
 	const mockFetchData = vi.fn((params: FetchParams) => {
 		if (params.endpoint.includes("/workspace/resources")) {
@@ -81,7 +80,6 @@ const { mockFetchData, mockFetchAndUpdate } = vi.hoisted(() => {
 	return { mockFetchData, mockFetchAndUpdate };
 });
 
-// 必要なモジュールをモック化
 vi.mock("../../utils/fetchUtils", () => ({
 	fetchData: mockFetchData,
 	fetchAndUpdate: mockFetchAndUpdate,

--- a/tauri/src/tests/hooks/useDatasetSettings.test.tsx
+++ b/tauri/src/tests/hooks/useDatasetSettings.test.tsx
@@ -46,37 +46,45 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 // API呼び出しのモック
-const { mockFetchData } = vi.hoisted(() => {
-	return {
-		mockFetchData: vi.fn((params: FetchParams) => {
-			if (params.endpoint.includes("/workspace/resources")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockWorkspaceResources)),
-				);
-			}
-			if (params.endpoint.includes("/dataset-setting/load")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockDatasetSettingsResponse)),
-				);
-			}
-			if (params.endpoint.includes("/dataset-setting/save")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockUpdatedSettings)),
-				);
-			}
-			if (params.endpoint.includes("/dataset-setting/delete")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockRemainingSettings)),
-				);
-			}
-			return Promise.resolve(new Response());
-		}),
-	};
+const { mockFetchData, mockFetchAndUpdate } = vi.hoisted(() => {
+	const mockFetchData = vi.fn((params: FetchParams) => {
+		if (params.endpoint.includes("/workspace/resources")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockWorkspaceResources)),
+			);
+		}
+		if (params.endpoint.includes("/dataset-setting/load")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockDatasetSettingsResponse)),
+			);
+		}
+		if (params.endpoint.includes("/dataset-setting/save")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockUpdatedSettings)),
+			);
+		}
+		if (params.endpoint.includes("/dataset-setting/delete")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockRemainingSettings)),
+			);
+		}
+		return Promise.resolve(new Response());
+	});
+	const mockFetchAndUpdate = vi.fn(
+		async (params: FetchParams, onSuccess: (data: unknown) => void) => {
+			const response = await mockFetchData(params);
+			const data = await response.json();
+			onSuccess(data);
+			return "success" as const;
+		},
+	);
+	return { mockFetchData, mockFetchAndUpdate };
 });
 
 // 必要なモジュールをモック化
 vi.mock("../../utils/fetchUtils", () => ({
 	fetchData: mockFetchData,
+	fetchAndUpdate: mockFetchAndUpdate,
 }));
 
 describe("DatasetSettingsProviderのテスト", () => {

--- a/tauri/src/tests/hooks/useXlsxSchema.test.tsx
+++ b/tauri/src/tests/hooks/useXlsxSchema.test.tsx
@@ -61,34 +61,42 @@ const mockUpdatedSettings = ["test-setting", "other-setting"];
 const mockRemainingSettings = [] as string[];
 
 // API呼び出しのモック
-const { mockFetchData } = vi.hoisted(() => {
-	return {
-		mockFetchData: vi.fn((params: FetchParams) => {
-			if (params.endpoint.includes("/workspace/resources")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockWorkspaceResources)),
-				);
-			}
-			if (params.endpoint.includes("/xlsx-schema/load")) {
-				return Promise.resolve(new Response(JSON.stringify(mockXlsxSchema)));
-			}
-			if (params.endpoint.includes("/xlsx-schema/save")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockUpdatedSettings)),
-				);
-			}
-			if (params.endpoint.includes("/xlsx-schema/delete")) {
-				return Promise.resolve(
-					new Response(JSON.stringify(mockRemainingSettings)),
-				);
-			}
-			return Promise.resolve(new Response());
-		}),
-	};
+const { mockFetchData, mockFetchAndUpdate } = vi.hoisted(() => {
+	const mockFetchData = vi.fn((params: FetchParams) => {
+		if (params.endpoint.includes("/workspace/resources")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockWorkspaceResources)),
+			);
+		}
+		if (params.endpoint.includes("/xlsx-schema/load")) {
+			return Promise.resolve(new Response(JSON.stringify(mockXlsxSchema)));
+		}
+		if (params.endpoint.includes("/xlsx-schema/save")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockUpdatedSettings)),
+			);
+		}
+		if (params.endpoint.includes("/xlsx-schema/delete")) {
+			return Promise.resolve(
+				new Response(JSON.stringify(mockRemainingSettings)),
+			);
+		}
+		return Promise.resolve(new Response());
+	});
+	const mockFetchAndUpdate = vi.fn(
+		async (params: FetchParams, onSuccess: (data: unknown) => void) => {
+			const response = await mockFetchData(params);
+			const data = await response.json();
+			onSuccess(data);
+			return "success" as const;
+		},
+	);
+	return { mockFetchData, mockFetchAndUpdate };
 });
 
 vi.mock("../../utils/fetchUtils", () => ({
 	fetchData: mockFetchData,
+	fetchAndUpdate: mockFetchAndUpdate,
 }));
 
 describe("XlsxSchemaProviderのテスト", () => {

--- a/tauri/src/tests/hooks/useXlsxSchema.test.tsx
+++ b/tauri/src/tests/hooks/useXlsxSchema.test.tsx
@@ -60,7 +60,6 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 const mockUpdatedSettings = ["test-setting", "other-setting"];
 const mockRemainingSettings = [] as string[];
 
-// API呼び出しのモック
 const { mockFetchData, mockFetchAndUpdate } = vi.hoisted(() => {
 	const mockFetchData = vi.fn((params: FetchParams) => {
 		if (params.endpoint.includes("/workspace/resources")) {


### PR DESCRIPTION
## Summary
Updated test files to include a new `mockFetchAndUpdate` mock function alongside the existing `mockFetchData` mock. This enhances the test utilities to better support testing of async data fetching operations with success callbacks.

## Key Changes
- **useDatasetSettings.test.tsx**: 
  - Refactored `vi.hoisted()` mock setup to extract `mockFetchData` as a standalone function
  - Added `mockFetchAndUpdate` mock that wraps `mockFetchData` and invokes a success callback with parsed response data
  - Updated the `fetchUtils` mock to export both `fetchData` and `fetchAndUpdate`

- **useXlsxSchema.test.tsx**:
  - Applied identical refactoring pattern as useDatasetSettings.test.tsx
  - Extracted `mockFetchData` function and added `mockFetchAndUpdate` implementation
  - Updated the `fetchUtils` mock to export both functions

## Implementation Details
The `mockFetchAndUpdate` function:
- Accepts `FetchParams` and an `onSuccess` callback
- Delegates the actual fetch to `mockFetchData`
- Parses the response JSON and invokes the success callback with the data
- Returns a constant `"success"` string to indicate completion

This change improves test coverage by allowing tests to verify callback-based async operations in the dataset settings and XLSX schema providers.

https://claude.ai/code/session_01HymhDDaet5bdJkxKykZysx