### PR TITLE
Add retry logic and improve error handling in fetchData

### DIFF
--- a/tauri/src/utils/fetchUtils.ts
+++ b/tauri/src/utils/fetchUtils.ts
@@ -79,14 +79,21 @@ export async function fetchAndUpdate<T>(
 }
 
 export const fetchData = async ({ endpoint, options, signal }: FetchParams) => {
-	const response = await fetch(endpoint, { ...options, signal: signal ?? options.signal });
+	const mergedOptions = { ...options, signal: signal ?? options.signal };
+	let response: Response;
+	try {
+		response = await fetch(endpoint, mergedOptions);
+	} catch (ex) {
+		if (isAbortError(ex)) {
+			throw ex;
+		}
+		// reqwest のコネクションプールに残った stale keep-alive 接続が原因で
+		// 接続エラーになる場合があるため、1 回だけリトライする
+		response = await fetch(endpoint, mergedOptions);
+	}
 	if (!response.ok) {
 		throw new Error(
-			`
-				An error occurred
-				Status: ${response.status}
-				Details: ${response.statusText || "Fetch request failed"}
-					`.trim(),
+			`Status: ${response.status}\nDetails: ${response.statusText || "Fetch request failed"}`,
 		);
 	}
 	return response;


### PR DESCRIPTION
## Summary
Enhanced the `fetchData` function in `fetchUtils.ts` to include automatic retry logic for connection errors and improved error message formatting.

## Key Changes
- **Retry mechanism**: Added try-catch block to automatically retry fetch requests once if a non-abort error occurs, addressing stale keep-alive connection issues from the reqwest connection pool
- **Abort error handling**: Abort errors are now properly re-thrown without retry to preserve cancellation semantics
- **Error message formatting**: Simplified and improved the error message format by removing unnecessary whitespace and using newline separators instead of multiple lines
- **Code organization**: Extracted merged options into a variable for better readability and reusability

## Implementation Details
- The retry logic specifically handles connection errors while preserving abort behavior
- Added Japanese comment explaining the rationale for the retry mechanism (stale keep-alive connections)
- Error messages are now more concise and easier to parse

https://claude.ai/code/session_012ocqBJyL2TsLUQVvaHykvS