### PR TITLE
Add JXLS template options form section for Excel generation

### DIFF
--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -24,23 +24,11 @@
   <table>
     <tr><th>値</th><th>説明</th></tr>
     <tr><td>txt</td><td>StringTemplate 4 を使ったテキストファイル生成（SQL・CSV 等）。<a href="template.html">Template</a> オプションが適用されます</td></tr>
-    <tr><td>xlsx</td><td>jxls を使った xlsx テンプレートへのデータ埋め込み。<strong>jxls option</strong> セクションが表示されます</td></tr>
-    <tr><td>xls</td><td>jxls を使った xls テンプレートへのデータ埋め込み。<strong>jxls option</strong> セクションが表示されます</td></tr>
+    <tr><td>xlsx</td><td>jxls を使った xlsx テンプレートへのデータ埋め込み。<a href="jxls.html">Jxls</a> オプションが適用されます</td></tr>
+    <tr><td>xls</td><td>jxls を使った xls テンプレートへのデータ埋め込み。<a href="jxls.html">Jxls</a> オプションが適用されます</td></tr>
     <tr><td>settings</td><td>データセット設定ファイルのひな型を生成</td></tr>
     <tr><td>sql</td><td>INSERT / UPDATE / DELETE / CLEAN_INSERT SQL ファイルを生成</td></tr>
     <tr><td>xlsxTemplate</td><td>jxls テンプレートのひな型 xlsx を生成</td></tr>
-  </table>
-
-  <h2 id="section-jxls">jxls オプション（xlsx / xls）</h2>
-  <p><code>generateType</code> が <code>xlsx</code> または <code>xls</code> のとき、<strong>jxls option</strong> 展開ボタンから以下のオプションを設定できます。</p>
-  <table>
-    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
-    <tr><td>templateParameterAttribute</td><td>テンプレート内でデータ行にアクセスする属性名。空にするとカラム名で直接参照</td><td>param</td></tr>
-    <tr><td>formulaProcess</td><td>（xlsx のみ）数式セルを処理するか。<code>false</code> にすると低メモリで動作しますが、行追加時のセル参照更新が行われません</td><td>true</td></tr>
-    <tr><td>evaluateFormulas</td><td>Excel 数式を評価するか</td><td>true</td></tr>
-    <tr><td>forceFormulaRecalc</td><td>Excel で開いたときに自動再計算させるフラグを立てる</td><td>false</td></tr>
-    <tr><td>fastFormulaProcess</td><td>高速な数式プロセッサを使用する</td><td>false</td></tr>
-    <tr><td>deleteBlankCells</td><td>数式評価後に空セルを削除する</td><td>false</td></tr>
   </table>
 
   <h2>その他のオプション</h2>
@@ -53,6 +41,6 @@
     <tr><td>outputEncoding</td><td>出力ファイルのエンコーディング（txt タイプのみ）</td></tr>
   </table>
   <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。<br>
-  <code>txt</code> タイプの template オプション詳細は <a href="template.html">Template</a> を参照してください。</p>
+  <code>txt</code> タイプのテンプレートオプションは <a href="template.html">Template (StringTemplate 4)</a>、<code>xlsx</code> / <code>xls</code> タイプのオプションは <a href="jxls.html">Jxls</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -20,18 +20,39 @@
   <h1>Generate</h1>
   <p>テンプレートからファイルを生成します。ソースデータとテンプレートエンジンを用いて、SQL や CSV などの出力ファイルを作成します。</p>
 
-  <h2>オプション</h2>
+  <h2>generateType</h2>
+  <table>
+    <tr><th>値</th><th>説明</th></tr>
+    <tr><td>txt</td><td>StringTemplate 4 を使ったテキストファイル生成（SQL・CSV 等）。<a href="template.html">Template</a> オプションが適用されます</td></tr>
+    <tr><td>xlsx</td><td>jxls を使った xlsx テンプレートへのデータ埋め込み。<strong>jxls option</strong> セクションが表示されます</td></tr>
+    <tr><td>xls</td><td>jxls を使った xls テンプレートへのデータ埋め込み。<strong>jxls option</strong> セクションが表示されます</td></tr>
+    <tr><td>settings</td><td>データセット設定ファイルのひな型を生成</td></tr>
+    <tr><td>sql</td><td>INSERT / UPDATE / DELETE / CLEAN_INSERT SQL ファイルを生成</td></tr>
+    <tr><td>xlsxTemplate</td><td>jxls テンプレートのひな型 xlsx を生成</td></tr>
+  </table>
+
+  <h2 id="section-jxls">jxls オプション（xlsx / xls）</h2>
+  <p><code>generateType</code> が <code>xlsx</code> または <code>xls</code> のとき、<strong>jxls option</strong> 展開ボタンから以下のオプションを設定できます。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
+    <tr><td>templateParameterAttribute</td><td>テンプレート内でデータ行にアクセスする属性名。空にするとカラム名で直接参照</td><td>param</td></tr>
+    <tr><td>formulaProcess</td><td>（xlsx のみ）数式セルを処理するか。<code>false</code> にすると低メモリで動作しますが、行追加時のセル参照更新が行われません</td><td>true</td></tr>
+    <tr><td>evaluateFormulas</td><td>Excel 数式を評価するか</td><td>true</td></tr>
+    <tr><td>forceFormulaRecalc</td><td>Excel で開いたときに自動再計算させるフラグを立てる</td><td>false</td></tr>
+    <tr><td>fastFormulaProcess</td><td>高速な数式プロセッサを使用する</td><td>false</td></tr>
+    <tr><td>deleteBlankCells</td><td>数式評価後に空セルを削除する</td><td>false</td></tr>
+  </table>
+
+  <h2>その他のオプション</h2>
   <table>
     <tr><th>オプション</th><th>説明</th></tr>
-    <tr><td>generateType</td><td>生成出力の種類</td></tr>
     <tr><td>unit</td><td>行・テーブル・データセット単位で生成</td></tr>
     <tr><td>template</td><td>テンプレートファイル</td></tr>
     <tr><td>result</td><td>生成結果ファイルを配置するディレクトリ</td></tr>
     <tr><td>resultPath</td><td>result ディレクトリからの相対パス</td></tr>
-    <tr><td>outputEncoding</td><td>出力ファイルのエンコーディング</td></tr>
-    <tr><td>srcData</td><td>ソースデータセット</td></tr>
-    <tr><td>templateOption</td><td>テンプレートエンジンのオプション</td></tr>
+    <tr><td>outputEncoding</td><td>出力ファイルのエンコーディング（txt タイプのみ）</td></tr>
   </table>
-  <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。</p>
+  <p><code>srcData</code> の入力フォーム詳細は <a href="dataset-load-form.html">Dataset Load Form</a> を参照してください。<br>
+  <code>txt</code> タイプの template オプション詳細は <a href="template.html">Template</a> を参照してください。</p>
 </body>
 </html>

--- a/tauri/public/help/index.html
+++ b/tauri/public/help/index.html
@@ -31,6 +31,7 @@
     <li><a href="dataset-settings.html"><div class="cmd-name">Dataset Settings</div><div class="cmd-desc">Dataset Settings ファイルの書式</div></a></li>
     <li><a href="image.html"><div class="cmd-name">Image Option</div><div class="cmd-desc">Compare の画像・PDF 差分オプション</div></a></li>
     <li><a href="jdbc.html"><div class="cmd-name">JDBC</div><div class="cmd-desc">JDBC 接続設定と URL Builder</div></a></li>
+    <li><a href="jxls.html"><div class="cmd-name">Jxls</div><div class="cmd-desc">xlsx / xls テンプレート（jxls）のオプション設定</div></a></li>
     <li><a href="template.html"><div class="cmd-name">Template</div><div class="cmd-desc">StringTemplate 4 によるテンプレート設定</div></a></li>
     <li><a href="xlsx-schema.html"><div class="cmd-name">Xlsx Schema</div><div class="cmd-desc">Xlsx 入力のマッピング定義</div></a></li>
   </ul>

--- a/tauri/public/help/jxls.html
+++ b/tauri/public/help/jxls.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ヘルプ - Jxls</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; line-height: 1.6; }
+    h1 { font-size: 1.5rem; border-bottom: 2px solid #4f46e5; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.2rem; margin-top: 1.5rem; color: #374151; }
+    p { color: #4b5563; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+    th { background: #f9fafb; font-weight: 600; color: #374151; }
+    td:first-child { font-family: monospace; white-space: nowrap; color: #4f46e5; }
+    a { color: #4f46e5; }
+    pre { background: #f9fafb; padding: 0.75rem; border-radius: 0.375rem; overflow-x: auto; font-size: 0.85rem; }
+    code { font-family: monospace; color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <p><a href="index.html">&larr; ヘルプ一覧に戻る</a></p>
+  <h1>Jxls</h1>
+  <p><a href="generate.html">Generate</a> で <code>generateType = xlsx</code> または <code>xls</code> を選んだ場合に使用するテンプレートエンジンです。Excel ファイル（<code>.xlsx</code> / <code>.xls</code>）をテンプレートとして、入力データセットの各行を埋め込んで出力します。</p>
+  <p>テンプレートには jxls のコメント記法（セルのコメントに <code>jx:each</code> 等のディレクティブを記述）を使います。</p>
+
+  <h2 id="section-fields">設定項目</h2>
+  <p>フォームの <strong>jxls option</strong> 展開ボタンから設定します。</p>
+  <table>
+    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
+    <tr><td>templateParameterAttribute</td><td>テンプレート内でデータ行にアクセスする属性名。例えば <code>param</code> を指定すると <code>param.columnName</code> で参照できます。空にするとカラム名で直接参照します</td><td>param</td></tr>
+    <tr><td>formulaProcess</td><td>（xlsx のみ）数式セルを処理するか。<code>false</code> にすると低メモリで動作しますが、行追加時にセル参照が更新されません</td><td>true</td></tr>
+    <tr><td>evaluateFormulas</td><td>Excel 数式を評価するか</td><td>true</td></tr>
+    <tr><td>forceFormulaRecalc</td><td>出力ファイルを Excel で開いたときに自動再計算させるフラグを立てる</td><td>false</td></tr>
+    <tr><td>fastFormulaProcess</td><td>高速な数式プロセッサを使用する</td><td>false</td></tr>
+    <tr><td>deleteBlankCells</td><td>数式評価後に空セルを削除する</td><td>false</td></tr>
+  </table>
+
+  <h2 id="section-template">テンプレートの書き方</h2>
+  <p>Excel のセルコメントにディレクティブを記述します。各行のデータは <code>templateParameterAttribute</code> で指定した名前のオブジェクトとして参照します（既定: <code>param</code>）。</p>
+  <pre>セル A1 のコメント:
+  jx:each(items="items" var="param" lastCell="C1")
+
+セル A1: $[param.id]
+セル B1: $[param.name]
+セル C1: $[param.value]</pre>
+  <p>データセットの各行が <code>items</code> として渡され、行ごとに展開されます。</p>
+
+  <h2>関連ページ</h2>
+  <ul>
+    <li><a href="generate.html">Generate</a> — generateType の選択と generate コマンド全体の設定</li>
+    <li><a href="template.html">Template (StringTemplate 4)</a> — <code>generateType = txt</code> で使うテンプレートエンジン</li>
+  </ul>
+</body>
+</html>

--- a/tauri/public/help/template.html
+++ b/tauri/public/help/template.html
@@ -24,7 +24,7 @@
   <h1>Template</h1>
   <p>テンプレート処理のための設定です。テンプレートエンジンは <strong>StringTemplate 4 (ST4)</strong>。式は既定で <code>$...$</code> の記法を用い、入力データセットの各行をパラメータとして埋め込みます。以下の場面で利用されます。</p>
   <ul>
-    <li><a href="generate.html">Generate</a> — 入力データセットをもとにファイル（SQL / テキスト / xlsx / 設定ファイル等）を生成</li>
+    <li><a href="generate.html">Generate</a> — <code>generateType = txt</code> でテキストファイル（SQL・CSV 等）を生成。xlsx / xls 出力は <a href="jxls.html">Jxls</a> を参照</li>
     <li><a href="run.html">Run</a> — SQL / ANT スクリプトを実行する前にテンプレートとしてレンダリング</li>
     <li><a href="parameterize.html">Parameterize</a> — パラメータごとにコマンド引数や設定をレンダリング</li>
     <li><a href="dataset-load-form.html#section-source">Dataset Load Form</a> の <code>templateGroup</code> — 入力読み込み時にテンプレートを適用（任意）</li>

--- a/tauri/public/help/template.html
+++ b/tauri/public/help/template.html
@@ -41,16 +41,8 @@
     <tr><td>templateVarStop</td><td>テンプレート式の終了文字（1 文字）</td><td>$</td></tr>
   </table>
 
-  <h3 id="section-xlsx-options">xlsx 出力時の追加オプション</h3>
-  <p><a href="generate.html">Generate</a> で <code>generateType = xlsx</code> を選んだ場合に適用される数式処理系のオプションです（内部的に Apache POI で処理）。</p>
-  <table>
-    <tr><th>項目</th><th>説明</th><th>既定</th></tr>
-    <tr><td>formulaProcess</td><td>xlsx 出力時に数式セルを処理するか。<code>false</code> にすると低メモリで動作しますが、数式内のセル参照が行追加にあわせて更新されません</td><td>true</td></tr>
-    <tr><td>evaluateFormulas</td><td><code>formulaProcess</code> が有効なときに Excel 数式を評価するか</td><td>true</td></tr>
-    <tr><td>forceFormulaRecalc</td><td>出力ファイルを Excel で開いたときに自動再計算させるフラグを立てる</td><td>false</td></tr>
-    <tr><td>fastFormulaProcess</td><td>高速な数式プロセッサを使用する</td><td>false</td></tr>
-    <tr><td>deleteBlankCells</td><td>数式評価後に空セルを削除する</td><td>false</td></tr>
-  </table>
+  <h3 id="section-xlsx-options">xlsx / xls 出力時の追加オプション</h3>
+  <p><a href="generate.html">Generate</a> で <code>generateType = xlsx</code> または <code>xls</code> を選んだ場合は jxls オプションが適用されます。詳細は <a href="generate.html#section-jxls">Generate — jxls オプション</a> を参照してください。<code>formulaProcess</code> は xlsx 専用です。</p>
 
   <h2 id="section-parameter-binding">パラメータのバインド</h2>
   <p>入力データセットの各行は、テンプレートに対して <code>templateParameterAttribute</code> で指定した属性名のオブジェクトとして渡されます。</p>

--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -13,6 +13,9 @@ export function GenerateForm(prop: {
 }) {
 	const generate = prop.generate;
 	const srcData = generate.srcData;
+	const generateTypeValue = generate.generateType.value;
+	const isExcelGenerate =
+		generateTypeValue === "xlsx" || generateTypeValue === "xls";
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
@@ -33,23 +36,18 @@ export function GenerateForm(prop: {
 					<FileText prefix="" element={generate.template} />
 				)}
 				{prop.generate.templateOption &&
-					generate.generateType.value === "txt" && (
+					generateTypeValue === "txt" && (
 						<TemplateFormSection
 							templateOption={prop.generate.templateOption}
 							showEncoding={true}
 							handleValueChange={() => (_: string) => {}}
 						/>
 					)}
-				{prop.generate.templateOption &&
-					(generate.generateType.value === "xlsx" ||
-						generate.generateType.value === "xls") && (
-						<JxlsFormSection
-							templateOption={prop.generate.templateOption}
-							showFormulaProcess={
-								generate.generateType.value === "xlsx"
-							}
-						/>
-					)}
+				{prop.generate.templateOption && isExcelGenerate && (
+					<JxlsFormSection
+						templateOption={prop.generate.templateOption}
+					/>
+				)}
 				<FileText prefix="" element={generate.result} />
 				<PlainText prefix="" element={generate.resultPath} />
 				{generate.outputEncoding && (

--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -1,5 +1,6 @@
 import type { GenerateOptions } from "../../model/SelectParameter";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
+import JxlsFormSection from "./section/JxlsFormSection";
 import FileText from "./section/element/FileText";
 import PlainText from "./section/element/PlainText";
 import Select from "./section/element/Select";
@@ -37,6 +38,16 @@ export function GenerateForm(prop: {
 							templateOption={prop.generate.templateOption}
 							showEncoding={true}
 							handleValueChange={() => (_: string) => {}}
+						/>
+					)}
+				{prop.generate.templateOption &&
+					(generate.generateType.value === "xlsx" ||
+						generate.generateType.value === "xls") && (
+						<JxlsFormSection
+							templateOption={prop.generate.templateOption}
+							showFormulaProcess={
+								generate.generateType.value === "xlsx"
+							}
 						/>
 					)}
 				<FileText prefix="" element={generate.result} />

--- a/tauri/src/app/form/section/JxlsFormSection.tsx
+++ b/tauri/src/app/form/section/JxlsFormSection.tsx
@@ -7,10 +7,8 @@ import PlainText from "./element/PlainText";
 
 export default function JxlsFormSection({
 	templateOption,
-	showFormulaProcess,
 }: {
 	templateOption: TemplateOption;
-	showFormulaProcess: boolean;
 }) {
 	const [showOptional, setShowOptional] = useState(false);
 	const toggleOptional = () => setShowOptional(!showOptional);
@@ -30,7 +28,7 @@ export default function JxlsFormSection({
 				element={templateOption.templateParameterAttribute}
 				hidden={!showOptional}
 			/>
-			{showFormulaProcess && templateOption.formulaProcess && (
+			{templateOption.formulaProcess && (
 				<Check
 					prefix={templateOption.prefix}
 					element={templateOption.formulaProcess}

--- a/tauri/src/app/form/section/JxlsFormSection.tsx
+++ b/tauri/src/app/form/section/JxlsFormSection.tsx
@@ -21,7 +21,7 @@ export default function JxlsFormSection({
 					showOptional={showOptional}
 					caption="jxls option"
 				/>
-				<SectionHelpButton command="generate" label="Jxls" />
+				<SectionHelpButton command="jxls" label="Jxls" />
 			</div>
 			<PlainText
 				prefix={templateOption.prefix}

--- a/tauri/src/app/form/section/JxlsFormSection.tsx
+++ b/tauri/src/app/form/section/JxlsFormSection.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { SectionHelpButton } from "../../../components/dialog";
+import { ExpandButton } from "../../../components/element/ButtonIcon";
+import type { TemplateOption } from "../../../model/CommandOption";
+import Check from "./element/Check";
+import PlainText from "./element/PlainText";
+
+export default function JxlsFormSection({
+	templateOption,
+	showFormulaProcess,
+}: {
+	templateOption: TemplateOption;
+	showFormulaProcess: boolean;
+}) {
+	const [showOptional, setShowOptional] = useState(false);
+	const toggleOptional = () => setShowOptional(!showOptional);
+	return (
+		<fieldset className="border border-border-subtle p-3">
+			<legend>jxls</legend>
+			<div className="flex items-center gap-2">
+				<ExpandButton
+					toggleOptional={toggleOptional}
+					showOptional={showOptional}
+					caption="jxls option"
+				/>
+				<SectionHelpButton command="generate" label="Jxls" />
+			</div>
+			<PlainText
+				prefix={templateOption.prefix}
+				element={templateOption.templateParameterAttribute}
+				hidden={!showOptional}
+			/>
+			{showFormulaProcess && templateOption.formulaProcess && (
+				<Check
+					prefix={templateOption.prefix}
+					element={templateOption.formulaProcess}
+					hidden={!showOptional}
+				/>
+			)}
+			{templateOption.evaluateFormulas && (
+				<Check
+					prefix={templateOption.prefix}
+					element={templateOption.evaluateFormulas}
+					hidden={!showOptional}
+				/>
+			)}
+			{templateOption.forceFormulaRecalc && (
+				<Check
+					prefix={templateOption.prefix}
+					element={templateOption.forceFormulaRecalc}
+					hidden={!showOptional}
+				/>
+			)}
+			{templateOption.fastFormulaProcess && (
+				<Check
+					prefix={templateOption.prefix}
+					element={templateOption.fastFormulaProcess}
+					hidden={!showOptional}
+				/>
+			)}
+			{templateOption.deleteBlankCells && (
+				<Check
+					prefix={templateOption.prefix}
+					element={templateOption.deleteBlankCells}
+					hidden={!showOptional}
+				/>
+			)}
+		</fieldset>
+	);
+}

--- a/tauri/src/app/form/section/JxlsFormSection.tsx
+++ b/tauri/src/app/form/section/JxlsFormSection.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { SectionHelpButton } from "../../../components/dialog";
 import { ExpandButton } from "../../../components/element/ButtonIcon";
-import type { TemplateOption } from "../../../model/CommandOption";
+import type { GenerateTemplateOption } from "../../../model/CommandOption";
 import Check from "./element/Check";
 import PlainText from "./element/PlainText";
 
 export default function JxlsFormSection({
 	templateOption,
 }: {
-	templateOption: TemplateOption;
+	templateOption: GenerateTemplateOption;
 }) {
 	const [showOptional, setShowOptional] = useState(false);
 	const toggleOptional = () => setShowOptional(!showOptional);

--- a/tauri/src/app/form/section/JxlsFormSection.tsx
+++ b/tauri/src/app/form/section/JxlsFormSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { SectionHelpButton } from "../../../components/dialog";
 import { ExpandButton } from "../../../components/element/ButtonIcon";
-import type { GenerateTemplateOption } from "../../../model/CommandOption";
+import type { GenerateTemplateOption } from "../../../model/SelectParameter";
 import Check from "./element/Check";
 import PlainText from "./element/PlainText";
 

--- a/tauri/src/model/CommandOption.ts
+++ b/tauri/src/model/CommandOption.ts
@@ -153,6 +153,11 @@ export type TemplateOption = CommandOptions & {
 	templateParameterAttribute: CommandOption;
 	templateVarStart: CommandOption;
 	templateVarStop: CommandOption;
+	formulaProcess?: CommandOption;
+	evaluateFormulas?: CommandOption;
+	forceFormulaRecalc?: CommandOption;
+	fastFormulaProcess?: CommandOption;
+	deleteBlankCells?: CommandOption;
 };
 export type CsvOptions = CommandOptions & {
 	srcType: Csv;

--- a/tauri/src/model/CommandOption.ts
+++ b/tauri/src/model/CommandOption.ts
@@ -154,13 +154,6 @@ export type TemplateOption = CommandOptions & {
 	templateVarStart: CommandOption;
 	templateVarStop: CommandOption;
 };
-export type GenerateTemplateOption = TemplateOption & {
-	formulaProcess?: CommandOption;
-	evaluateFormulas?: CommandOption;
-	forceFormulaRecalc?: CommandOption;
-	fastFormulaProcess?: CommandOption;
-	deleteBlankCells?: CommandOption;
-};
 export type CsvOptions = CommandOptions & {
 	srcType: Csv;
 	delimiter: CommandOption;

--- a/tauri/src/model/CommandOption.ts
+++ b/tauri/src/model/CommandOption.ts
@@ -153,6 +153,8 @@ export type TemplateOption = CommandOptions & {
 	templateParameterAttribute: CommandOption;
 	templateVarStart: CommandOption;
 	templateVarStop: CommandOption;
+};
+export type GenerateTemplateOption = TemplateOption & {
 	formulaProcess?: CommandOption;
 	evaluateFormulas?: CommandOption;
 	forceFormulaRecalc?: CommandOption;

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -2,6 +2,7 @@ import type {
 	CommandOption,
 	CommandOptions,
 	DatasetSource,
+	GenerateTemplateOption,
 	JdbcOption,
 	ResultOption,
 	TemplateOption,
@@ -71,7 +72,7 @@ export type GenerateOptions = CommandOptions & {
 	resultPath: CommandOption;
 	outputEncoding: CommandOption;
 	srcData: DatasetSource;
-	templateOption?: TemplateOption;
+	templateOption?: GenerateTemplateOption;
 };
 export type RunOptions = CommandOptions & {
 	command: "run";

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -2,11 +2,17 @@ import type {
 	CommandOption,
 	CommandOptions,
 	DatasetSource,
-	GenerateTemplateOption,
 	JdbcOption,
 	ResultOption,
 	TemplateOption,
 } from "./CommandOption";
+export type GenerateTemplateOption = TemplateOption & {
+	formulaProcess?: CommandOption;
+	evaluateFormulas?: CommandOption;
+	forceFormulaRecalc?: CommandOption;
+	fastFormulaProcess?: CommandOption;
+	deleteBlankCells?: CommandOption;
+};
 export type Command =
 	| "convert"
 	| "compare"

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -6,13 +6,6 @@ import type {
 	ResultOption,
 	TemplateOption,
 } from "./CommandOption";
-export type GenerateTemplateOption = TemplateOption & {
-	formulaProcess?: CommandOption;
-	evaluateFormulas?: CommandOption;
-	forceFormulaRecalc?: CommandOption;
-	fastFormulaProcess?: CommandOption;
-	deleteBlankCells?: CommandOption;
-};
 export type Command =
 	| "convert"
 	| "compare"
@@ -37,6 +30,13 @@ export type Options =
 	| GenerateOptions
 	| RunOptions
 	| ParameterizeOptions;
+export type GenerateTemplateOption = TemplateOption & {
+	formulaProcess?: CommandOption;
+	evaluateFormulas?: CommandOption;
+	forceFormulaRecalc?: CommandOption;
+	fastFormulaProcess?: CommandOption;
+	deleteBlankCells?: CommandOption;
+};
 export type ImageOption = CommandOptions & {
 	threshold: CommandOption;
 	pixelToleranceLevel: CommandOption;

--- a/tauri/src/tests/app/form/GenerateForm.test.tsx
+++ b/tauri/src/tests/app/form/GenerateForm.test.tsx
@@ -34,13 +34,7 @@ vi.mock("../../../hooks/useJdbc", () => ({
 	useDeleteJdbcProperties: () => vi.fn(),
 }));
 
-function makeGenerateProps(
-	fixture:
-		| typeof generateLoadResponseFixture
-		| typeof generateRefreshSrcTypeTableResponseFixture
-		| typeof generateRefreshGenerateTypeXlsxResponseFixture
-		| typeof generateRefreshGenerateTypeXlsResponseFixture = generateLoadResponseFixture,
-): {
+function makeGenerateProps(fixture: GenerateOptions = generateLoadResponseFixture): {
 	handleTypeSelect: () => Promise<void>;
 	name: string;
 	generate: GenerateOptions;
@@ -48,7 +42,7 @@ function makeGenerateProps(
 	return {
 		handleTypeSelect: vi.fn().mockResolvedValue(undefined),
 		name: "test",
-		generate: fixture as unknown as GenerateOptions,
+		generate: fixture,
 	};
 }
 

--- a/tauri/src/tests/app/form/GenerateForm.test.tsx
+++ b/tauri/src/tests/app/form/GenerateForm.test.tsx
@@ -5,6 +5,8 @@ import type { GenerateOptions } from "../../../model/SelectParameter";
 import { environmentFixture, workspaceResourcesFixture } from "../../setup";
 import {
 	generateLoadResponseFixture,
+	generateRefreshGenerateTypeXlsResponseFixture,
+	generateRefreshGenerateTypeXlsxResponseFixture,
 	generateRefreshSrcTypeTableResponseFixture,
 } from "./fixtures";
 
@@ -35,7 +37,9 @@ vi.mock("../../../hooks/useJdbc", () => ({
 function makeGenerateProps(
 	fixture:
 		| typeof generateLoadResponseFixture
-		| typeof generateRefreshSrcTypeTableResponseFixture = generateLoadResponseFixture,
+		| typeof generateRefreshSrcTypeTableResponseFixture
+		| typeof generateRefreshGenerateTypeXlsxResponseFixture
+		| typeof generateRefreshGenerateTypeXlsResponseFixture = generateLoadResponseFixture,
 ): {
 	handleTypeSelect: () => Promise<void>;
 	name: string;
@@ -156,6 +160,99 @@ describe("GenerateFormの描画テスト", () => {
 					'input[type="checkbox"][name="-src.useJdbcMetaData"]',
 				),
 			).toBeVisible();
+		});
+	});
+
+	describe("xlsxタイプ（generateType=xlsx）", () => {
+		it("generate・jxls・src・traversalのセクションがこの順で表示される", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("generate");
+			expect(legends[1]).toHaveTextContent("jxls");
+			expect(legends[2]).toHaveTextContent("src");
+			expect(legends[3]).toHaveTextContent("traversal");
+		});
+
+		it("jxlsオプション要素は初期状態でhiddenになっている", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-template.formulaProcess"]',
+				),
+			).not.toBeVisible();
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-template.evaluateFormulas"]',
+				),
+			).not.toBeVisible();
+		});
+
+		it("formulaProcessがjxlsセクションに含まれる", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsxResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-template.formulaProcess"]',
+				),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("xlsタイプ（generateType=xls）", () => {
+		it("generate・jxls・src・traversalのセクションがこの順で表示される", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsResponseFixture)}
+				/>,
+			);
+
+			const legends = document.querySelectorAll("fieldset legend");
+			expect(legends[0]).toHaveTextContent("generate");
+			expect(legends[1]).toHaveTextContent("jxls");
+			expect(legends[2]).toHaveTextContent("src");
+			expect(legends[3]).toHaveTextContent("traversal");
+		});
+
+		it("formulaProcessはjxlsセクションに含まれない", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-template.formulaProcess"]',
+				),
+			).not.toBeInTheDocument();
+		});
+
+		it("evaluateFormulasがjxlsセクションに含まれる", () => {
+			render(
+				<GenerateForm
+					{...makeGenerateProps(generateRefreshGenerateTypeXlsResponseFixture)}
+				/>,
+			);
+
+			expect(
+				document.querySelector(
+					'input[type="checkbox"][name="-template.evaluateFormulas"]',
+				),
+			).toBeInTheDocument();
 		});
 	});
 });

--- a/tauri/src/tests/app/form/fixtures.ts
+++ b/tauri/src/tests/app/form/fixtures.ts
@@ -950,48 +950,34 @@ export const runRefreshScriptTypeSqlResponseFixture = {
 	},
 } as RunOptions;
 
-// generate-refresh-generateType-xlsx フィクスチャ（formulaProcess あり）
-export const generateRefreshGenerateTypeXlsxResponseFixture = {
-	prefix: "",
-	generateType: makeElement("generateType", "ENUM", "xlsx", "WORKSPACE", false, [
-		"txt",
-		"xlsx",
-		"xls",
-		"settings",
-		"sql",
-		"xlsxTemplate",
-	]),
-	unit: makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
-		"record",
-		"table",
-		"dataset",
-	]),
-	template: makeElement("template", "FILE", "", "TEMPLATE", true),
-	result: makeElement("result", "DIR", "", "RESULT", false),
-	resultPath: makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
-	srcData: makeCsvSrcData("src", ""),
-	templateOption: makeJxlsTemplateOption(true),
-} as GenerateOptions;
+const GENERATE_TYPE_OPTIONS = ["txt", "xlsx", "xls", "settings", "sql", "xlsxTemplate"];
+const UNIT_OPTIONS = ["record", "table", "dataset"];
 
-// generate-refresh-generateType-xls フィクスチャ（formulaProcess なし）
-export const generateRefreshGenerateTypeXlsResponseFixture = {
-	prefix: "",
-	generateType: makeElement("generateType", "ENUM", "xls", "WORKSPACE", false, [
-		"txt",
-		"xlsx",
-		"xls",
-		"settings",
-		"sql",
-		"xlsxTemplate",
-	]),
-	unit: makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
-		"record",
-		"table",
-		"dataset",
-	]),
-	template: makeElement("template", "FILE", "", "TEMPLATE", true),
-	result: makeElement("result", "DIR", "", "RESULT", false),
-	resultPath: makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
-	srcData: makeCsvSrcData("src", ""),
-	templateOption: makeJxlsTemplateOption(false),
-} as GenerateOptions;
+function makeGenerateJxlsFixture(
+	generateTypeValue: "xlsx" | "xls",
+	includeFormulaProcess: boolean,
+): GenerateOptions {
+	return {
+		prefix: "",
+		generateType: makeElement(
+			"generateType",
+			"ENUM",
+			generateTypeValue,
+			"WORKSPACE",
+			false,
+			GENERATE_TYPE_OPTIONS,
+		),
+		unit: makeElement("unit", "ENUM", "record", "WORKSPACE", false, UNIT_OPTIONS),
+		template: makeElement("template", "FILE", "", "TEMPLATE", true),
+		result: makeElement("result", "DIR", "", "RESULT", false),
+		resultPath: makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
+		srcData: makeCsvSrcData("src", ""),
+		templateOption: makeJxlsTemplateOption(includeFormulaProcess),
+	} as GenerateOptions;
+}
+
+export const generateRefreshGenerateTypeXlsxResponseFixture =
+	makeGenerateJxlsFixture("xlsx", true);
+
+export const generateRefreshGenerateTypeXlsResponseFixture =
+	makeGenerateJxlsFixture("xls", false);

--- a/tauri/src/tests/app/form/fixtures.ts
+++ b/tauri/src/tests/app/form/fixtures.ts
@@ -72,6 +72,51 @@ function makeTemplateOption() {
 	};
 }
 
+function makeJxlsTemplateOption(includeFormulaProcess: boolean) {
+	return {
+		...makeTemplateOption(),
+		...(includeFormulaProcess
+			? {
+					formulaProcess: makeElement(
+						"formulaProcess",
+						"FLG",
+						"true",
+						"WORKSPACE",
+						false,
+					),
+				}
+			: {}),
+		evaluateFormulas: makeElement(
+			"evaluateFormulas",
+			"FLG",
+			"true",
+			"WORKSPACE",
+			false,
+		),
+		forceFormulaRecalc: makeElement(
+			"forceFormulaRecalc",
+			"FLG",
+			"false",
+			"WORKSPACE",
+			false,
+		),
+		fastFormulaProcess: makeElement(
+			"fastFormulaProcess",
+			"FLG",
+			"false",
+			"WORKSPACE",
+			false,
+		),
+		deleteBlankCells: makeElement(
+			"deleteBlankCells",
+			"FLG",
+			"false",
+			"WORKSPACE",
+			false,
+		),
+	};
+}
+
 function makeCsvSrcData(
 	prefix: string,
 	src: string,
@@ -904,3 +949,49 @@ export const runRefreshScriptTypeSqlResponseFixture = {
 		jdbcPass: makeElement("jdbcPass", "TEXT", "", "WORKSPACE", false),
 	},
 } as RunOptions;
+
+// generate-refresh-generateType-xlsx フィクスチャ（formulaProcess あり）
+export const generateRefreshGenerateTypeXlsxResponseFixture = {
+	prefix: "",
+	generateType: makeElement("generateType", "ENUM", "xlsx", "WORKSPACE", false, [
+		"txt",
+		"xlsx",
+		"xls",
+		"settings",
+		"sql",
+		"xlsxTemplate",
+	]),
+	unit: makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
+		"record",
+		"table",
+		"dataset",
+	]),
+	template: makeElement("template", "FILE", "", "TEMPLATE", true),
+	result: makeElement("result", "DIR", "", "RESULT", false),
+	resultPath: makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
+	srcData: makeCsvSrcData("src", ""),
+	templateOption: makeJxlsTemplateOption(true),
+} as GenerateOptions;
+
+// generate-refresh-generateType-xls フィクスチャ（formulaProcess なし）
+export const generateRefreshGenerateTypeXlsResponseFixture = {
+	prefix: "",
+	generateType: makeElement("generateType", "ENUM", "xls", "WORKSPACE", false, [
+		"txt",
+		"xlsx",
+		"xls",
+		"settings",
+		"sql",
+		"xlsxTemplate",
+	]),
+	unit: makeElement("unit", "ENUM", "record", "WORKSPACE", false, [
+		"record",
+		"table",
+		"dataset",
+	]),
+	template: makeElement("template", "FILE", "", "TEMPLATE", true),
+	result: makeElement("result", "DIR", "", "RESULT", false),
+	resultPath: makeElement("resultPath", "TEXT", "result", "WORKSPACE", false),
+	srcData: makeCsvSrcData("src", ""),
+	templateOption: makeJxlsTemplateOption(false),
+} as GenerateOptions;


### PR DESCRIPTION
## Summary
Added support for JXLS-specific template options in the generate form when targeting Excel file formats (xlsx/xls). This includes a new collapsible form section that displays JXLS configuration options.

## Key Changes
- **New Component**: Created `JxlsFormSection.tsx` - a reusable form section component that displays JXLS-specific options with an expandable/collapsible interface
  - Includes template parameter attribute input
  - Supports optional formula processing flags: `formulaProcess`, `evaluateFormulas`, `forceFormulaRecalc`, `fastFormulaProcess`, and `deleteBlankCells`
  - Uses existing `Check` and `PlainText` form elements for consistency

- **Updated GenerateForm**: Modified to conditionally render the JXLS form section when:
  - Template options are available
  - Generate type is set to Excel formats (xlsx or xls)

- **Type Definitions**: Extended `GenerateTemplateOption` type to include JXLS-specific command options while maintaining backward compatibility with existing `TemplateOption` type

## Implementation Details
- The JXLS section uses a collapsible design pattern (via `ExpandButton`) to keep the form compact while providing access to optional settings
- All JXLS options are conditionally rendered based on their presence in the template option object
- Maintains consistency with existing form patterns used for other template types (e.g., txt templates)

https://claude.ai/code/session_012ARoubGNsdAKz9fAND1NqM