### PR TITLE
Expand unit parameter documentation with detailed explanation

### DIFF
--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -36,9 +36,9 @@
   ただし <code>generateType</code> が <code>settings</code> / <code>xlsxTemplate</code> の場合は <code>dataset</code>、<code>sql</code> の場合は <code>table</code> に固定されます。</p>
   <table>
     <tr><th>値</th><th>説明</th></tr>
-    <tr><td>record</td><td>行単位で生成。各行につき 1 ファイルを出力します（デフォルト）</td></tr>
-    <tr><td>table</td><td>テーブル単位で生成。各テーブルにつき 1 ファイルを出力します</td></tr>
-    <tr><td>dataset</td><td>データセット単位で生成。データセット全体から 1 ファイルを出力します</td></tr>
+    <tr><td>record</td><td>行ごとに 1 ファイルを出力</td></tr>
+    <tr><td>table</td><td>テーブルごとに 1 ファイルを出力</td></tr>
+    <tr><td>dataset</td><td>データセット全体から 1 ファイルを出力</td></tr>
   </table>
 
   <h2>その他のオプション</h2>

--- a/tauri/public/help/generate.html
+++ b/tauri/public/help/generate.html
@@ -31,10 +31,19 @@
     <tr><td>xlsxTemplate</td><td>jxls テンプレートのひな型 xlsx を生成</td></tr>
   </table>
 
+  <h2>unit</h2>
+  <p>生成の単位を指定します。デフォルトは <code>record</code> です。<br>
+  ただし <code>generateType</code> が <code>settings</code> / <code>xlsxTemplate</code> の場合は <code>dataset</code>、<code>sql</code> の場合は <code>table</code> に固定されます。</p>
+  <table>
+    <tr><th>値</th><th>説明</th></tr>
+    <tr><td>record</td><td>行単位で生成。各行につき 1 ファイルを出力します（デフォルト）</td></tr>
+    <tr><td>table</td><td>テーブル単位で生成。各テーブルにつき 1 ファイルを出力します</td></tr>
+    <tr><td>dataset</td><td>データセット単位で生成。データセット全体から 1 ファイルを出力します</td></tr>
+  </table>
+
   <h2>その他のオプション</h2>
   <table>
     <tr><th>オプション</th><th>説明</th></tr>
-    <tr><td>unit</td><td>行・テーブル・データセット単位で生成</td></tr>
     <tr><td>template</td><td>テンプレートファイル</td></tr>
     <tr><td>result</td><td>生成結果ファイルを配置するディレクトリ</td></tr>
     <tr><td>resultPath</td><td>result ディレクトリからの相対パス</td></tr>


### PR DESCRIPTION
## Summary
Reorganized and expanded the documentation for the `unit` parameter in the generate help page, moving it from a brief entry in "その他のオプション" (Other Options) to a dedicated section with comprehensive details.

## Key Changes
- Created a new dedicated `unit` section with detailed explanation of the parameter's purpose and default behavior
- Added a table documenting all three unit options: `record`, `table`, and `dataset` with their descriptions
- Documented the conditional behavior where `generateType` values (`settings`, `xlsxTemplate`, `sql`) override the default unit setting
- Removed the brief `unit` entry from the "その他のオプション" table to avoid duplication

## Details
The change improves documentation clarity by:
- Providing a dedicated section that explains the `unit` parameter's role in controlling generation granularity
- Clarifying the relationship between `generateType` and `unit` parameter constraints
- Offering clear descriptions of each unit option's output behavior
- Maintaining better organization by separating core generation parameters from miscellaneous options

https://claude.ai/code/session_013XUURT4F1zbuv6QvKMpZUF