### PR TITLE
Import system CA certificates into JDK cacerts for TLS inspection

### DIFF
--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -71,6 +71,26 @@ else
   echo "Java $CURRENT_JAVA_MAJOR >= $REQUIRED_JAVA_VERSION, no installation needed"
 fi
 
+# TLS インスペクション環境向け: システム CA を JDK の cacerts にインポート
+# (Maven が Maven Central などへ HTTPS 接続できるようにする)
+JDK_HOME="${JAVA_HOME:-$JDK25_DIR}"
+CACERTS="$JDK_HOME/lib/security/cacerts"
+if [ -f "$CACERTS" ] && [ -d /usr/local/share/ca-certificates ]; then
+  IMPORTED=0
+  for crt in /usr/local/share/ca-certificates/*.crt; do
+    [ -f "$crt" ] || continue
+    alias_name="claude-$(basename "$crt" .crt)"
+    if ! "$JDK_HOME/bin/keytool" -list -keystore "$CACERTS" -storepass changeit -alias "$alias_name" >/dev/null 2>&1; then
+      if "$JDK_HOME/bin/keytool" -importcert -noprompt -trustcacerts \
+          -keystore "$CACERTS" -storepass changeit \
+          -alias "$alias_name" -file "$crt" >/dev/null 2>&1; then
+        IMPORTED=$((IMPORTED + 1))
+      fi
+    fi
+  done
+  echo "Imported $IMPORTED system CA certificate(s) into JDK cacerts"
+fi
+
 # Create ~/.mavenrc to set JAVA_HOME and optionally proxy settings
 {
   [ "$JDK25_READY" = true ] && echo "JAVA_HOME=\"$JDK25_DIR\""

--- a/.claude/start-maven-proxy.sh
+++ b/.claude/start-maven-proxy.sh
@@ -75,19 +75,18 @@ fi
 # (Maven が Maven Central などへ HTTPS 接続できるようにする)
 JDK_HOME="${JAVA_HOME:-$JDK25_DIR}"
 CACERTS="$JDK_HOME/lib/security/cacerts"
-if [ -f "$CACERTS" ] && [ -d /usr/local/share/ca-certificates ]; then
+CACERTS_MARKER="$JDK_HOME/.claude-cacerts-imported"
+if [ ! -f "$CACERTS_MARKER" ] && [ -f "$CACERTS" ] && [ -d /usr/local/share/ca-certificates ]; then
   IMPORTED=0
   for crt in /usr/local/share/ca-certificates/*.crt; do
     [ -f "$crt" ] || continue
-    alias_name="claude-$(basename "$crt" .crt)"
-    if ! "$JDK_HOME/bin/keytool" -list -keystore "$CACERTS" -storepass changeit -alias "$alias_name" >/dev/null 2>&1; then
-      if "$JDK_HOME/bin/keytool" -importcert -noprompt -trustcacerts \
-          -keystore "$CACERTS" -storepass changeit \
-          -alias "$alias_name" -file "$crt" >/dev/null 2>&1; then
-        IMPORTED=$((IMPORTED + 1))
-      fi
+    if "$JDK_HOME/bin/keytool" -importcert -noprompt -trustcacerts \
+        -keystore "$CACERTS" -storepass changeit \
+        -alias "claude-$(basename "$crt" .crt)" -file "$crt" >/dev/null 2>&1; then
+      IMPORTED=$((IMPORTED + 1))
     fi
   done
+  touch "$CACERTS_MARKER"
   echo "Imported $IMPORTED system CA certificate(s) into JDK cacerts"
 fi
 


### PR DESCRIPTION
## Summary
Added support for TLS inspection environments by automatically importing system CA certificates into the JDK's cacerts keystore. This enables Maven to successfully establish HTTPS connections to Maven Central and other repositories when operating behind corporate proxies with certificate inspection.

## Key Changes
- Added a new certificate import routine that runs during Maven proxy startup
- Scans `/usr/local/share/ca-certificates/` for `.crt` files and imports them into the JDK's cacerts keystore using `keytool`
- Implements idempotent behavior using a marker file (`.claude-cacerts-imported`) to avoid re-importing certificates on subsequent runs
- Uses the default cacerts password (`changeit`) and generates unique aliases for each imported certificate
- Silently handles import failures and reports the total number of successfully imported certificates

## Implementation Details
- The import process only runs if the marker file doesn't exist, the cacerts file is present, and system CA certificates directory exists
- Each certificate is imported with an alias in the format `claude-<certificate-name>` for easy identification
- The routine is placed early in the startup script, before Maven proxy configuration, ensuring certificates are available for all subsequent operations
- Errors during individual certificate imports are suppressed to allow partial success (e.g., if some certificates are already imported)

https://claude.ai/code/session_01J2uWyfbf1uRqbnHhemHQDB