### PR TITLE
Move parameter input management to context provider

### DIFF
--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -2,6 +2,7 @@ import { core } from "@tauri-apps/api";
 import { useEffect, useRef, useState } from "react";
 import { BlueButton, WhiteButton } from "../../components/element/Button";
 import { BlueEditButton } from "../../components/element/ButtonIcon";
+import { useParamInputs, useSetParamInputs } from "../../context/ParameterInputProvider";
 import { useSelectParameter } from "../../context/SelectParameterProvider";
 import {
 	type Running,
@@ -18,7 +19,8 @@ export default function Footer(prop: {
 		validationError: boolean;
 	};
 }) {
-	const [paramInputs, setParamInputs] = useState<{ [key: string]: string }>({});
+	const paramInputs = useParamInputs();
+	const setParamInputs = useSetParamInputs();
 	const [showParamDialog, setShowParamDialog] = useState(false);
 	const [running, setRunning] = useState({
 		command: "",

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -140,42 +140,8 @@ export default function Footer(prop: {
 					className="fixed bottom-0 right-1
                                 w-full z-50
 								bg-surface-muted
-                                flex items-center justify-end p-4 gap-2"
+                                flex items-center p-4 gap-2"
 				>
-					<BlueButton
-						title="Exec"
-						handleClick={() => {
-							const input = prop.formData(true);
-							if (!input.validationError) {
-								setRunning({
-									command: "exec",
-									resultMessage: "",
-									resultDir: "",
-								});
-							}
-						}}
-					/>
-					<BlueButton
-						title="Save"
-						handleClick={() => {
-							setRunning({
-								command: "save",
-								resultMessage: "",
-								resultDir: "",
-							});
-						}}
-					/>
-					<BlueButton
-						title="Save Shell"
-						handleClick={() => {
-							setRunning({
-								command: "saveShell",
-								resultMessage: "",
-								resultDir: "",
-							});
-						}}
-					/>
-					<span className="text-sm text-content-muted">*Required</span>
 					<BlueEditButton
 						title="Parameters (-P)"
 						handleClick={() => setShowParamDialog(true)}
@@ -185,6 +151,42 @@ export default function Footer(prop: {
 							{paramCount} parameter(s) set
 						</span>
 					)}
+					<div className="ml-auto flex items-center gap-2">
+						<BlueButton
+							title="Exec"
+							handleClick={() => {
+								const input = prop.formData(true);
+								if (!input.validationError) {
+									setRunning({
+										command: "exec",
+										resultMessage: "",
+										resultDir: "",
+									});
+								}
+							}}
+						/>
+						<BlueButton
+							title="Save"
+							handleClick={() => {
+								setRunning({
+									command: "save",
+									resultMessage: "",
+									resultDir: "",
+								});
+							}}
+						/>
+						<BlueButton
+							title="Save Shell"
+							handleClick={() => {
+								setRunning({
+									command: "saveShell",
+									resultMessage: "",
+									resultDir: "",
+								});
+							}}
+						/>
+						<span className="text-sm text-content-muted">*Required</span>
+					</div>
 				</div>
 			)}
 			{Object.entries(paramInputs).map(([name, value]) => (

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -1,6 +1,7 @@
 import { core } from "@tauri-apps/api";
 import { useEffect, useRef, useState } from "react";
 import { BlueButton, WhiteButton } from "../../components/element/Button";
+import { BlueEditButton } from "../../components/element/ButtonIcon";
 import { useSelectParameter } from "../../context/SelectParameterProvider";
 import {
 	type Running,
@@ -8,6 +9,7 @@ import {
 	useSaveParameter,
 	useSaveShell,
 } from "../../hooks/useSelectParameter";
+import { ParameterInputDialog } from "../form/section/dialog/ParameterInputDialog";
 import ResultDialog from "./ResultDialog";
 
 export default function Footer(prop: {
@@ -16,6 +18,8 @@ export default function Footer(prop: {
 		validationError: boolean;
 	};
 }) {
+	const [paramInputs, setParamInputs] = useState<{ [key: string]: string }>({});
+	const [showParamDialog, setShowParamDialog] = useState(false);
 	const [running, setRunning] = useState({
 		command: "",
 		resultMessage: "",
@@ -35,6 +39,10 @@ export default function Footer(prop: {
 	execParameterRef.current = execParameter;
 	saveParameterRef.current = saveParameter;
 	saveShellRef.current = saveShell;
+
+	useEffect(() => {
+		setParamInputs({});
+	}, [parameter.name]);
 
 	useEffect(() => {
 		if (running.command === "" || executingRef.current) {
@@ -102,6 +110,8 @@ export default function Footer(prop: {
 		);
 	}
 
+	const paramCount = Object.keys(paramInputs).length;
+
 	return (
 		<>
 			<ResultDialog hidden={running.resultMessage === ""}>
@@ -166,7 +176,34 @@ export default function Footer(prop: {
 						}}
 					/>
 					<span className="text-sm text-content-muted">*Required</span>
+					<BlueEditButton
+						title="Parameters (-P)"
+						handleClick={() => setShowParamDialog(true)}
+					/>
+					{paramCount > 0 && (
+						<span className="text-sm text-content-muted">
+							{paramCount} parameter(s) set
+						</span>
+					)}
 				</div>
+			)}
+			{Object.entries(paramInputs).map(([name, value]) => (
+				<input
+					key={name}
+					type="hidden"
+					name={`-P${name}`}
+					value={value}
+				/>
+			))}
+			{showParamDialog && (
+				<ParameterInputDialog
+					params={paramInputs}
+					handleDialogClose={() => setShowParamDialog(false)}
+					handleCommit={(newParams) => {
+						setParamInputs(newParams);
+						setShowParamDialog(false);
+					}}
+				/>
 			)}
 		</>
 	);

--- a/tauri/src/app/form/CommandForm.tsx
+++ b/tauri/src/app/form/CommandForm.tsx
@@ -1,6 +1,4 @@
 import "../../App.css";
-import { useEffect, useState } from "react";
-import { BlueEditButton } from "../../components/element/ButtonIcon";
 import { useSelectParameter } from "../../context/SelectParameterProvider";
 import { useRefreshSelectParameter } from "../../hooks/useSelectParameter";
 import { CompareForm } from "./CompareForm";
@@ -8,7 +6,6 @@ import { ConvertForm } from "./ConvertForm";
 import { GenerateForm } from "./GenerateForm";
 import { ParameterizeForm } from "./ParameterizeForm";
 import { RunForm } from "./RunForm";
-import { ParameterInputDialog } from "./section/dialog/ParameterInputDialog";
 
 export default function CommandForm(prop: {
 	formData: (validate: boolean) => {
@@ -19,14 +16,6 @@ export default function CommandForm(prop: {
 	const select = useSelectParameter();
 	const refreshSelect = useRefreshSelectParameter(select.options?.command);
 	const handleTypeSelect = () => refreshSelect(prop.formData(false).values);
-	const [paramInputs, setParamInputs] = useState<{ [key: string]: string }>(
-		{},
-	);
-	const [showParamDialog, setShowParamDialog] = useState(false);
-
-	useEffect(() => {
-		setParamInputs({});
-	}, [select.name]);
 
 	const renderCommandForm = () => {
 		switch (select.options?.command) {
@@ -80,43 +69,5 @@ export default function CommandForm(prop: {
 		return null;
 	}
 
-	const paramCount = Object.keys(paramInputs).length;
-
-	return (
-		<>
-			{commandForm}
-			<fieldset className="border border-gray-200 p-3">
-				<legend>Parameters (-P)</legend>
-				<div className="flex items-center gap-2">
-					<BlueEditButton
-						title="Edit Parameters"
-						handleClick={() => setShowParamDialog(true)}
-					/>
-					{paramCount > 0 && (
-						<span className="text-sm text-content-muted">
-							{paramCount} parameter(s) set
-						</span>
-					)}
-				</div>
-				{Object.entries(paramInputs).map(([name, value]) => (
-					<input
-						key={name}
-						type="hidden"
-						name={`-P${name}`}
-						value={value}
-					/>
-				))}
-				{showParamDialog && (
-					<ParameterInputDialog
-						params={paramInputs}
-						handleDialogClose={() => setShowParamDialog(false)}
-						handleCommit={(newParams) => {
-							setParamInputs(newParams);
-							setShowParamDialog(false);
-						}}
-					/>
-				)}
-			</fieldset>
-		</>
-	);
+	return commandForm;
 }

--- a/tauri/src/app/main/Form.tsx
+++ b/tauri/src/app/main/Form.tsx
@@ -23,17 +23,17 @@ export default function Form() {
 	return (
 		<div className="p-2 rounded-lg mt-10">
 			<ParameterInputProvider>
-			<form
-				id={formid}
-				className="grid gap-6 mb-6 pb-20 grid-cols-1"
-				noValidate
-				onSubmit={(e) => {
-					e.preventDefault();
-				}}
-			>
-				<CommandForm formData={formData} />
-				<Footer formData={formData} />
-			</form>
+				<form
+					id={formid}
+					className="grid gap-6 mb-6 pb-20 grid-cols-1"
+					noValidate
+					onSubmit={(e) => {
+						e.preventDefault();
+					}}
+				>
+					<CommandForm formData={formData} />
+					<Footer formData={formData} />
+				</form>
 			</ParameterInputProvider>
 		</div>
 	);

--- a/tauri/src/app/main/Form.tsx
+++ b/tauri/src/app/main/Form.tsx
@@ -1,5 +1,6 @@
 import Footer from "../footer/Footer";
 import CommandForm from "../form/CommandForm";
+import ParameterInputProvider from "../../context/ParameterInputProvider";
 
 const formid = "commandForm";
 export default function Form() {
@@ -21,6 +22,7 @@ export default function Form() {
 	};
 	return (
 		<div className="p-2 rounded-lg mt-10">
+			<ParameterInputProvider>
 			<form
 				id={formid}
 				className="grid gap-6 mb-6 pb-20 grid-cols-1"
@@ -32,6 +34,7 @@ export default function Form() {
 				<CommandForm formData={formData} />
 				<Footer formData={formData} />
 			</form>
+			</ParameterInputProvider>
 		</div>
 	);
 }

--- a/tauri/src/context/ParameterInputProvider.tsx
+++ b/tauri/src/context/ParameterInputProvider.tsx
@@ -1,0 +1,23 @@
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+import { createContext, use, useState } from "react";
+
+type ParamInputs = { [key: string]: string };
+
+const paramInputsContext = createContext<ParamInputs>({});
+const setParamInputsContext = createContext<Dispatch<SetStateAction<ParamInputs>>>(
+	() => undefined,
+);
+
+export default function ParameterInputProvider({ children }: { children: ReactNode }) {
+	const [paramInputs, setParamInputs] = useState<ParamInputs>({});
+	return (
+		<paramInputsContext.Provider value={paramInputs}>
+			<setParamInputsContext.Provider value={setParamInputs}>
+				{children}
+			</setParamInputsContext.Provider>
+		</paramInputsContext.Provider>
+	);
+}
+
+export const useParamInputs = () => use(paramInputsContext);
+export const useSetParamInputs = () => use(setParamInputsContext);

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useParamInputs } from "../context/ParameterInputProvider";
 import { useEnvironment } from "../context/EnvironmentProvider";
 import { useJdbcConnectionState } from "../context/JdbcConnectionProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
@@ -52,16 +53,20 @@ async function fetchTableNames(
 	apiUrl: string,
 	info: DatasetSrcInfo,
 	jdbcValues: Record<string, string>,
+	paramInputs: Record<string, string>,
 ): Promise<string[]> {
 	if (!info.srcPath) {
 		return [];
 	}
+	const paramExtra = Object.fromEntries(
+		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
+	);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-names`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues),
+			body: buildDatasetRequestBody(info, jdbcValues, paramExtra),
 		},
 	};
 	return fetchData(fetchParams)
@@ -76,6 +81,7 @@ export const useDatasetTableNames = (
 	const [loading, setLoading] = useState(false);
 	const { apiUrl } = useEnvironment();
 	const { jdbcValues, connectionOk } = useJdbcConnectionState();
+	const paramInputs = useParamInputs();
 
 	const srcPath = srcInfo.srcPath;
 	const srcType = srcInfo.srcType;
@@ -89,7 +95,7 @@ export const useDatasetTableNames = (
 		}
 		let isMounted = true;
 		setLoading(true);
-		fetchTableNames(apiUrl, srcInfo, jdbcValues).then((names) => {
+		fetchTableNames(apiUrl, srcInfo, jdbcValues, paramInputs).then((names) => {
 			if (isMounted) {
 				setTableNames(names);
 				setLoading(false);
@@ -98,7 +104,7 @@ export const useDatasetTableNames = (
 		return () => {
 			isMounted = false;
 		};
-	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues]);
+	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, paramInputs]);
 
 	return { tableNames, loading };
 };
@@ -113,16 +119,20 @@ async function fetchTablePreview(
 	info: DatasetSrcInfo,
 	tableName: string,
 	jdbcValues: Record<string, string>,
+	paramInputs: Record<string, string>,
 ): Promise<TablePreview> {
 	if (!info.srcPath || !tableName) {
 		return { headers: [], rows: [] };
 	}
+	const paramExtra = Object.fromEntries(
+		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
+	);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-preview`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, { tableName }),
+			body: buildDatasetRequestBody(info, jdbcValues, { tableName, ...paramExtra }),
 		},
 	};
 	return fetchData(fetchParams)
@@ -138,6 +148,7 @@ export const useDatasetTablePreview = (
 	const [loading, setLoading] = useState(false);
 	const { apiUrl } = useEnvironment();
 	const { jdbcValues, connectionOk } = useJdbcConnectionState();
+	const paramInputs = useParamInputs();
 
 	const srcPath = srcInfo.srcPath;
 	const srcType = srcInfo.srcType;
@@ -157,7 +168,7 @@ export const useDatasetTablePreview = (
 		}
 		let isMounted = true;
 		setLoading(true);
-		fetchTablePreview(apiUrl, srcInfo, tableName, jdbcValues).then((result) => {
+		fetchTablePreview(apiUrl, srcInfo, tableName, jdbcValues, paramInputs).then((result) => {
 			if (isMounted) {
 				setPreview(result);
 				setLoading(false);
@@ -166,7 +177,7 @@ export const useDatasetTablePreview = (
 		return () => {
 			isMounted = false;
 		};
-	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, tableName]);
+	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, tableName, paramInputs]);
 
 	return { preview, loading };
 };

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -16,6 +16,12 @@ import {
 	type OperationResult,
 } from "../utils/fetchUtils";
 
+function buildParamExtra(paramInputs: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
+	);
+}
+
 function buildDatasetRequestBody(
 	info: DatasetSrcInfo,
 	jdbcValues: Record<string, string>,
@@ -58,9 +64,7 @@ async function fetchTableNames(
 	if (!info.srcPath) {
 		return [];
 	}
-	const paramExtra = Object.fromEntries(
-		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
-	);
+	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-names`,
 		options: {
@@ -124,9 +128,7 @@ async function fetchTablePreview(
 	if (!info.srcPath || !tableName) {
 		return { headers: [], rows: [] };
 	}
-	const paramExtra = Object.fromEntries(
-		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
-	);
+	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-preview`,
 		options: {


### PR DESCRIPTION
## Summary
Refactored parameter input state management by extracting it from the `CommandForm` component into a new `ParameterInputProvider` context. This enables parameter inputs to be managed globally and accessed from the `Footer` component, allowing the parameter dialog UI to be relocated to the footer.

## Key Changes
- **Created `ParameterInputProvider` context** (`src/context/ParameterInputProvider.tsx`): New context provider that manages parameter input state globally with `useParamInputs()` and `useSetParamInputs()` hooks
- **Moved parameter dialog to Footer**: Relocated the parameter input dialog UI from `CommandForm` to `Footer`, making it more accessible in the action bar
- **Updated `CommandForm`**: Removed all parameter input state management and dialog logic; now simply renders the command form
- **Enhanced `Footer`**: Added parameter dialog button, parameter count display, and hidden input fields for parameter submission
- **Updated `Form` wrapper**: Wrapped the form with `ParameterInputProvider` to provide context to both `CommandForm` and `Footer`
- **Integrated with dataset hooks**: Updated `useDatasetSettings` hook to consume `paramInputs` from context and include parameters in API requests for table name and preview fetching

## Implementation Details
- Parameter inputs are now reset when the selected parameter/command changes via a `useEffect` in `Footer`
- Parameter count is displayed in the footer when parameters are set
- Hidden input fields with `-P` prefix are generated dynamically for form submission
- The parameter dialog is conditionally rendered in the footer and properly integrated with the form submission flow
- Dataset operations now automatically include parameter inputs in their API calls

https://claude.ai/code/session_01FBCwPsgZyQo74hQLJ9rq9n