### PR TITLE
Refactor DatasetLoadForm to extract content into separate component

### DIFF
--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -16,14 +16,81 @@ import SettingFormSection from "./SettingFormSection";
 import SrcFormSection from "./SrcFormSection";
 import SrcTypeFormSection from "./SrcTypeFormSection";
 
+function DatasetLoadFormContent({
+	srcData,
+	handleTypeSelect,
+	defaultType,
+}: {
+	srcData: DatasetSource;
+	handleTypeSelect: () => Promise<void>;
+	defaultType?: SrcType;
+}) {
+	const datasetSrcInfo = useDatasetSrcInfo();
+	const setDatasetSrcInfo = useSetDatasetSrcInfo();
+
+	const handleToggleChecked =
+		(element: CommandOption) => (checked: boolean) => {
+			if (element.name in datasetSrcInfo) {
+				setDatasetSrcInfo({
+					...datasetSrcInfo,
+					[element.name]: checked,
+				} as DatasetSrcInfo);
+			}
+		};
+	const handleValueChange = (element: CommandOption) => (newValue: string) => {
+		if (element.name in datasetSrcInfo) {
+			setDatasetSrcInfo({
+				...datasetSrcInfo,
+				[element.name]: newValue,
+			} as DatasetSrcInfo);
+		}
+	};
+	const jdbcOption = srcData.jdbcProperties ? srcData : undefined;
+	const templateOption = srcData.templateGroup ? srcData : undefined;
+	return (
+		<fieldset className="border border-border-subtle p-3">
+			<legend>{srcData.prefix}</legend>
+			{srcData.srcType && (
+				<Select
+					handleTypeSelect={handleTypeSelect}
+					prefix={srcData.prefix}
+					element={srcData.srcType}
+					hidden={false}
+				/>
+			)}
+			<SrcFormSection
+				srcElements={srcData}
+				srcType={defaultType ?? srcData.srcType?.value}
+				jdbcOption={jdbcOption}
+				templateOption={templateOption}
+				handleValueChange={handleValueChange}
+				handleToggleChecked={handleToggleChecked}
+			/>
+			<DataLoadFormSection
+				options={srcData}
+				handleValueChange={handleValueChange}
+				handleToggleChecked={handleToggleChecked}
+			/>
+			<SrcTypeFormSection
+				options={srcData}
+				handleValueChange={handleValueChange}
+				handleToggleChecked={handleToggleChecked}
+			/>
+			<SettingFormSection
+				settingElements={srcData}
+				handleValueChange={handleValueChange}
+				handleToggleChecked={handleToggleChecked}
+			/>
+		</fieldset>
+	);
+}
+
 export function DatasetLoadForm(prop: {
 	handleTypeSelect: () => Promise<void>;
 	name: string;
 	srcData: DatasetSource;
 	defalutType?: SrcType;
 }) {
-	const datasetSrcInfo = useDatasetSrcInfo();
-	const setDatasetSrcInfo = useSetDatasetSrcInfo();
 	if (prop.srcData.srcType?.value === "none") {
 		return (
 			<fieldset className="border border-border-subtle p-3">
@@ -37,64 +104,17 @@ export function DatasetLoadForm(prop: {
 			</fieldset>
 		);
 	}
-	const handleToggleChecked =
-		(element: CommandOption) => (checked: boolean) => {
-			setDatasetSrcInfo({
-				...datasetSrcInfo,
-				[element.name]: checked,
-			} as DatasetSrcInfo);
-		};
-	const handleValueChange = (element: CommandOption) => (newValue: string) => {
-		if (element.name in datasetSrcInfo) {
-			setDatasetSrcInfo({
-				...datasetSrcInfo,
-				[element.name]: newValue,
-			} as DatasetSrcInfo);
-		}
-	};
-	const srcElements = prop.srcData;
-	const jdbcOption = prop.srcData.jdbcProperties ? prop.srcData : undefined;
-	const templateOption = prop.srcData.templateGroup ? prop.srcData : undefined;
 	const initialDatasetSrcInfo = buildDatasetSrcInfo(prop.srcData);
 	return (
 		<DatasetSrcInfoProvider
 			key={prop.name + prop.srcData.prefix}
 			initialValue={initialDatasetSrcInfo}
 		>
-			<fieldset className="border border-border-subtle p-3">
-				<legend>{prop.srcData.prefix}</legend>
-				{prop.srcData.srcType && (
-					<Select
-						handleTypeSelect={prop.handleTypeSelect}
-						prefix={prop.srcData.prefix}
-						element={prop.srcData.srcType}
-						hidden={false}
-					/>
-				)}
-				<SrcFormSection
-					srcElements={srcElements}
-					srcType={prop.defalutType || prop.srcData.srcType?.value}
-					jdbcOption={jdbcOption}
-					templateOption={templateOption}
-					handleValueChange={handleValueChange}
-					handleToggleChecked={handleToggleChecked}
-				/>
-				<DataLoadFormSection
-					options={srcElements}
-					handleValueChange={handleValueChange}
-					handleToggleChecked={handleToggleChecked}
-				/>
-				<SrcTypeFormSection
-					options={srcElements}
-					handleValueChange={handleValueChange}
-					handleToggleChecked={handleToggleChecked}
-				/>
-				<SettingFormSection
-					settingElements={srcElements}
-					handleValueChange={handleValueChange}
-					handleToggleChecked={handleToggleChecked}
-				/>
-			</fieldset>
+			<DatasetLoadFormContent
+				srcData={prop.srcData}
+				handleTypeSelect={prop.handleTypeSelect}
+				defaultType={prop.defalutType}
+			/>
 		</DatasetSrcInfoProvider>
 	);
 }

--- a/tauri/src/app/form/section/SettingFormSection.tsx
+++ b/tauri/src/app/form/section/SettingFormSection.tsx
@@ -18,6 +18,7 @@ export default function SettingFormSection({
 				prefix={prefix}
 				element={settingElements.setting}
 				hidden={false}
+				handleValueChange={handleValueChange(settingElements.setting)}
 			/>
 			<PlainText
 				prefix={prefix}

--- a/tauri/src/app/form/section/element/DatasetSettingText.tsx
+++ b/tauri/src/app/form/section/element/DatasetSettingText.tsx
@@ -13,6 +13,7 @@ export default function DatasetSettingText({
 	element,
 	hidden,
 	hideDatasetSettingEdit,
+	handleValueChange,
 }: TextProp) {
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const settings = useResourcesSettings();
@@ -25,10 +26,11 @@ export default function DatasetSettingText({
 			hidden={hidden}
 			resourceFiles={resourceFiles}
 			showDefaulePath={true}
+			handleValueChange={handleValueChange}
 			afterContent={({ path }) =>
 				datasetSrcInfo.srcType && !hideDatasetSettingEdit ? (
 					<div className="mt-2 flex items-center gap-3">
-						<DatasetTableNamesPreviewButton title="Preview Before Settings" />
+						<DatasetTableNamesPreviewButton title="Preview Before Settings" setting="" />
 						{path && (
 							<DatasetTableNamesPreviewButton
 								title="Preview Aply Settings"


### PR DESCRIPTION
## Summary
This PR refactors the `DatasetLoadForm` component by extracting the form content rendering logic into a new `DatasetLoadFormContent` component. This improves code organization and maintainability while also fixing some prop passing issues.

## Key Changes
- **Extracted `DatasetLoadFormContent` component**: Moved the main form rendering logic (fieldset, form sections) from `DatasetLoadForm` into a new dedicated component that accepts `srcData`, `handleTypeSelect`, and `defaultType` as props
- **Improved state management**: The new component properly accesses `useDatasetSrcInfo()` and `useSetDatasetSrcInfo()` hooks within its own scope, with proper null checks in `handleToggleChecked` and `handleValueChange`
- **Fixed prop passing in `DatasetSettingText`**: Added missing `handleValueChange` prop to the `TextInput` component and updated `DatasetTableNamesPreviewButton` to include a `setting` prop
- **Fixed prop passing in `SettingFormSection`**: Added missing `handleValueChange` prop when rendering `DatasetSettingText`

## Implementation Details
- The `DatasetLoadForm` component now acts as a wrapper that handles the `DatasetSrcInfoProvider` context setup and delegates rendering to `DatasetLoadFormContent`
- The refactored code maintains the same functionality while improving separation of concerns
- Added defensive checks in the new component to ensure properties exist in `datasetSrcInfo` before updating them

https://claude.ai/code/session_01YJo11WN6sqU4vE8oQwznsB