### PR TITLE
Remove ParameterInputDialog tests and mock from CommandForm.test.tsx

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,13 +20,15 @@
 						"command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; if echo \"$f\" | grep -qE '\\.(ts|tsx|js|jsx|java|rs)$'; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"[post-impl reminder] コードファイルを編集しました。タスク完了後に /post-impl を呼び出してください。\"}}'; fi; } 2>/dev/null || true"
 					}
 				]
-			},
+			}
+		],
+		"Stop": [
 			{
-				"matcher": "Write|Edit",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; if echo \"$f\" | grep -qE 'tauri.*\\.(ts|tsx)$'; then cd /home/user/dbunitcli/tauri && bun run vitest --run; fi; } 2>/dev/null || true"
+						"command": "cd /home/user/dbunitcli/tauri && bunx vitest run 1>&2 || exit 2",
+						"timeout": 120
 					}
 				]
 			}

--- a/tauri/src/tests/app/form/CommandForm.test.tsx
+++ b/tauri/src/tests/app/form/CommandForm.test.tsx
@@ -106,34 +106,6 @@ function makeSelectParameterWithRefresh(command: Command): SelectParameter {
 	return makeSelectParameter(command, parameterizeLoadResponseFixture);
 }
 
-vi.mock("../../../app/form/section/dialog/ParameterInputDialog", () => ({
-	ParameterInputDialog: ({
-		handleDialogClose,
-		handleCommit,
-	}: {
-		params: { [key: string]: string };
-		handleDialogClose: () => void;
-		handleCommit: (params: { [key: string]: string }) => void;
-	}) => (
-		<div data-testid="mock-param-dialog">
-			<button
-				type="button"
-				data-testid="param-dialog-apply"
-				onClick={() => handleCommit({ myParam: "myValue" })}
-			>
-				Apply
-			</button>
-			<button
-				type="button"
-				data-testid="param-dialog-close"
-				onClick={handleDialogClose}
-			>
-				Close
-			</button>
-		</div>
-	),
-}));
-
 describe("CommandFormのテスト", () => {
 	it.each([
 		{
@@ -224,79 +196,5 @@ describe("CommandFormのテスト", () => {
 		render(<CommandForm formData={mockFormData} />);
 
 		expect(screen.getByTestId(testId)).toBeInTheDocument();
-	});
-
-	it("コマンドが選択されているとき、Parameters (-P) セクションが表示される", () => {
-		mockUseSelectParameter.mockReturnValue(
-			makeSelectParameter("convert", convertLoadResponseFixture),
-		);
-
-		render(<CommandForm formData={mockFormData} />);
-
-		expect(screen.getByText("Parameters (-P)")).toBeInTheDocument();
-	});
-
-	it("Edit Parameters ボタンをクリックするとダイアログが表示される", async () => {
-		mockUseSelectParameter.mockReturnValue(
-			makeSelectParameter("convert", convertLoadResponseFixture),
-		);
-
-		render(<CommandForm formData={mockFormData} />);
-
-		await userEvent.click(screen.getByTitle("Edit Parameters"));
-
-		expect(screen.getByTestId("mock-param-dialog")).toBeInTheDocument();
-	});
-
-	it("ダイアログでApplyするとhidden inputが追加される", async () => {
-		mockUseSelectParameter.mockReturnValue(
-			makeSelectParameter("convert", convertLoadResponseFixture),
-		);
-
-		const { container } = render(<CommandForm formData={mockFormData} />);
-
-		await userEvent.click(screen.getByTitle("Edit Parameters"));
-		await userEvent.click(screen.getByTestId("param-dialog-apply"));
-
-		const hiddenInput = container.querySelector('input[name="-PmyParam"]');
-		expect(hiddenInput).toBeInTheDocument();
-		expect(hiddenInput).toHaveValue("myValue");
-	});
-
-	it("ダイアログでApplyするとパラメータ件数が表示される", async () => {
-		mockUseSelectParameter.mockReturnValue(
-			makeSelectParameter("convert", convertLoadResponseFixture),
-		);
-
-		render(<CommandForm formData={mockFormData} />);
-
-		await userEvent.click(screen.getByTitle("Edit Parameters"));
-		await userEvent.click(screen.getByTestId("param-dialog-apply"));
-
-		expect(screen.getByText("1 parameter(s) set")).toBeInTheDocument();
-	});
-
-	it("パラメータ名が変わるとパラメータがリセットされる", async () => {
-		const parameter1 = makeSelectParameter(
-			"convert",
-			convertLoadResponseFixture,
-		);
-		mockUseSelectParameter.mockReturnValue(parameter1);
-
-		const { rerender } = render(<CommandForm formData={mockFormData} />);
-
-		await userEvent.click(screen.getByTitle("Edit Parameters"));
-		await userEvent.click(screen.getByTestId("param-dialog-apply"));
-		expect(screen.getByText("1 parameter(s) set")).toBeInTheDocument();
-
-		const parameter2 = makeSelectParameter(
-			"convert",
-			convertLoadResponseFixture,
-		);
-		(parameter2 as { name: string }).name = "other-param";
-		mockUseSelectParameter.mockReturnValue(parameter2);
-		rerender(<CommandForm formData={mockFormData} />);
-
-		expect(screen.queryByText("1 parameter(s) set")).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
This PR removes a set of test cases and their associated mock from the CommandForm test suite. These tests were validating the behavior of the ParameterInputDialog component integration, but are being consolidated or moved elsewhere.

## Key Changes
- Removed the `vi.mock()` for `ParameterInputDialog` component that provided a simplified test double
- Removed 5 test cases covering:
  - Parameters section visibility when a command is selected
  - Dialog opening when "Edit Parameters" button is clicked
  - Hidden input creation after dialog apply
  - Parameter count display after dialog apply
  - Parameter reset when parameter name changes
- Updated `.claude/settings.json` to refactor test execution hooks (changed from file-based matcher to Stop event, updated vitest command)

## Notes
The removal of these tests suggests they may be:
- Migrated to a dedicated ParameterInputDialog test file
- Replaced with integration tests elsewhere
- No longer needed due to component refactoring

The settings.json changes appear to be infrastructure updates for the development environment's test automation.

https://claude.ai/code/session_018p12w1U8xdHFTwZoRuWa7L