### PR TITLE
Add agent documentation for core and sidecar modules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "cd /home/user/dbunitcli/tauri && bunx vitest run 1>&2 || exit 2",
+						"command": "cd /home/user/dbunitcli/tauri && bun install --frozen-lockfile 1>&2 && bunx vitest run 1>&2 || exit 2",
 						"timeout": 120
 					}
 				]

--- a/tauri/.claude/agents/core-investigator.md
+++ b/tauri/.claude/agents/core-investigator.md
@@ -1,0 +1,140 @@
+---
+name: core-investigator
+description: core（CLI機能・共通jar）の調査専門エージェント。コマンド実装、データセット処理、比較・変換エンジン、リソース管理の調査に使用する。sidecarやtauriからcoreの機能を呼び出す際の詳細を調べたいとき、またはcore側の実装を確認・変更したいときに呼び出す。
+---
+
+# Core 調査エージェント
+
+core モジュール（`/home/user/dbunitcli/core/`）の CLI 機能・共通クラスを調査する専門エージェント。
+
+## モジュール概要
+
+- **役割**: CLI機能の実装本体・共通jar・GraalVM native-image対応
+- **主パッケージ**: `yo.dbunitcli`
+- **ビルド**: Maven (`mvn`)
+
+## パッケージ構成と主要クラス
+
+### コマンドシステム (`yo.dbunitcli.application`)
+
+| パッケージ/クラス | 役割 |
+|---|---|
+| `Command<DTO, Option>` interface | 全コマンドの共通インタフェース |
+| `CommandType` enum | compare/convert/generate/parameterize/run の5種 |
+| `CommandParameters` | コマンドパラメータ管理 |
+| `CommandLineOption<>` | Picocli オプション定義の基底 |
+
+### コマンド実装 (`yo.dbunitcli.application.command`)
+
+| クラス | 役割 |
+|---|---|
+| `Compare` / `CompareOption` | データセット比較コマンド |
+| `Convert` / `ConvertOption` | フォーマット変換コマンド |
+| `Generate` / `GenerateOption` | テンプレートベース生成コマンド |
+| `Parameterize` / `ParameterizeOption` | パラメータ化バッチコマンド |
+| `Run` / `RunOption` | SQL/ANT/バッチ実行コマンド |
+
+各コマンドには対応する `*Dto` クラス（`application/dto/` 以下）が存在する。
+
+### オプション解析 (`yo.dbunitcli.application.option`)
+
+- `JdbcOption` — JDBC接続オプション
+- `DataSetLoadOption` — データセット読込オプション
+
+### データセット処理 (`yo.dbunitcli.dataset`)
+
+| クラス | 役割 |
+|---|---|
+| `ComparableDataSet` | テーブル群を保持するデータセット |
+| `ComparableTable` | 行・列・メタデータを保持するテーブル |
+| `ComparableDataSetParam` | データセット読込パラメータ |
+| `DataSourceType` enum | CSV/XLS/XLSX/DB/FIXED_LENGTH/REGEX_TEXT |
+
+### データセット変換 (`yo.dbunitcli.dataset.converter`)
+
+| クラス | 変換元 |
+|---|---|
+| `CsvConverter` | CSV |
+| `XlsConverter` | XLS（Excel 97-2003） |
+| `XlsxConverter` | XLSX（Excel 2007+） |
+| `DBConverter` | DB（JDBC） |
+
+各コンバーターは CSV/XLS/XLSX/DB のいずれへも変換可能。
+
+### 比較エンジン (`yo.dbunitcli.dataset.compare`)
+
+| クラス | 役割 |
+|---|---|
+| `DataSetCompare` | テーブル間の行単位比較 |
+| `DefaultCompareManager` | 標準的な差分レポート生成 |
+| `ImageCompareManager` | 画像比較 |
+| `PdfCompareManager` | PDF比較 |
+| `CompareDiff` | 差分情報の構造化 |
+| `CompareResult` | 比較結果 |
+
+### データソースローダー (`yo.dbunitcli.dataset.producer`)
+
+- `ComparableDataSetLoader` — データソース種別に応じたローダー
+
+### リソース管理 (`yo.dbunitcli.resource`)
+
+| パッケージ/クラス | 役割 |
+|---|---|
+| `FileResources` | ワークスペース内ファイル検索・パス管理 |
+| `resource.jdbc.DatabaseConnectionLoader` | JDBC接続オープン・クローズ |
+| `resource.poi.XlsxSchema` | Excel列定義のJSON解析 |
+| `resource.poi.XlsxRowsToTableBuilder` | Excel行→テーブル変換 |
+| `resource.poi.XlsxCellsToTableBuilder` | Excelセル→テーブル変換 |
+| `resource.st4.TemplateRender` | StringTemplate 4 テキスト生成 |
+| `resource.st4.SqlEscapeStringRenderer` | SQL用エスケープレンダー |
+
+### コマンド実行 (`yo.dbunitcli.fileprocessor`)
+
+| クラス | 役割 |
+|---|---|
+| `CmdRunner` | OS コマンド実行 |
+| `SqlRunner` | SQL スクリプト実行 |
+| `AntRunner` | Apache Ant スクリプト実行 |
+
+### 共通機能 (`yo.dbunitcli.common`)
+
+- `Parameter` — パラメータ管理
+- `TargetFilter` — 対象フィルタリング
+- `TableMetaDataFilter` — テーブルメタデータフィルタ
+
+### JSON設定パーサー (`yo.dbunitcli.application.json`)
+
+- JSON → Option 変換ロジック（sidecar から core を呼び出す際に使用）
+
+## ビルドコマンド
+
+```bash
+# core のビルド（プロジェクトルートから）
+mvn -pl core package
+
+# core のテスト実行
+mvn -pl core test
+
+# core + sidecar まとめてビルド
+mvn -pl core,sidecar package
+```
+
+## アーキテクチャ上の位置づけ
+
+```
+Tauri フロントエンド
+    ↓ HTTP REST
+Sidecar (Micronaut) — コントローラー → DTO → domain
+    ↓ Java 直接呼び出し
+Core — Command 実装 / DataSet 処理 / 比較・変換エンジン
+```
+
+sidecar は core の `Command` インタフェース実装を直接呼び出す。JSON設定は `application/json/` パーサーを経由して `*Option` クラスに変換される。
+
+## 調査手順
+
+1. 特定コマンドの実装を調べる場合: `core/src/main/java/yo/dbunitcli/application/command/` を確認
+2. データセット処理を調べる場合: `core/src/main/java/yo/dbunitcli/dataset/` を探索
+3. ファイルリソース管理を調べる場合: `core/src/main/java/yo/dbunitcli/resource/` を確認
+4. オプション定義を調べる場合: `*Option` クラスか `*Dto` クラスを Grep で検索
+5. sidecar → core の呼び出し経路を追う場合: sidecar コントローラー → `application/json/` → `Command` 実装の順に確認

--- a/tauri/.claude/agents/sidecar-investigator.md
+++ b/tauri/.claude/agents/sidecar-investigator.md
@@ -1,0 +1,118 @@
+---
+name: sidecar-investigator
+description: sidecar（Micronaut REST API）の調査専門エージェント。APIエンドポイント、コントローラー、DTO、ドメインモデルの調査・確認に使用する。tauriフロントエンドからのAPIコール先を特定したいとき、またはsidecarの実装詳細を調べたいときに呼び出す。
+---
+
+# Sidecar 調査エージェント
+
+sidecar モジュール（`/home/user/dbunitcli/sidecar/`）の Micronaut REST API を調査する専門エージェント。
+
+## モジュール概要
+
+- **フレームワーク**: Micronaut
+- **コンテキストパス**: `/dbunit-cli`
+- **役割**: core の CLI 機能を HTTP API として公開し、Tauri フロントエンドのバックエンドとして動作
+
+## ディレクトリ構成
+
+```
+sidecar/src/main/java/yo/dbunitcli/sidecar/
+├── controller/       — REST コントローラー（15クラス）
+├── domain/project/   — ドメインモデル（Workspace, Options, Resources, ResourceFile, Datasource）
+└── dto/              — リクエスト/レスポンス DTO
+```
+
+## コントローラーとAPIパス一覧
+
+| コントローラー | パス | 主な役割 |
+|---|---|---|
+| `WorkspaceController` | `/workspace` | ワークスペース管理・リソース取得 |
+| `CompareController` | `/compare` | データセット比較 |
+| `ConvertController` | `/convert` | フォーマット変換 |
+| `GenerateController` | `/generate` | テンプレートベース生成 |
+| `RunController` | `/run` | SQL/ANT/バッチ実行 |
+| `ParameterizeController` | `/parameterize` | パラメータ化バッチ |
+| `DatasetSettingsController` | `/dataset-setting` | データセット設定管理 |
+| `JdbcResourceFileController` | `/jdbc` | JDBC接続設定管理 |
+| `TemplateResourceFileController` | `/template` | テンプレートファイル管理 |
+| `XlsxSchemaController` | `/xlsx-schema` | Excelスキーマ管理 |
+| `QueryDatasourceController` | `/query-datasource` | クエリーデータソース管理 |
+| `AbstractCommandController` | (基底) | コマンド系コントローラーの共通基底 |
+| `AbstractResourceFileController` | (基底) | リソース系コントローラーの共通基底 |
+
+## 共通エンドポイントパターン
+
+### コマンド系（compare/convert/generate/run/parameterize）
+
+```
+GET  /{command}/add          — 新規設定追加（レスポンス: JSON配列）
+GET  /{command}/reset        — デフォルト設定取得
+POST /{command}/copy         — 既存設定複製（body: CommandRequestDto）
+POST /{command}/delete       — 設定削除
+POST /{command}/rename       — 設定リネーム
+POST /{command}/load         — 設定読込（レスポンス: パラメータ JSON）
+POST /{command}/refresh      — パラメータ検証
+POST /{command}/save         — 設定保存（レスポンス: text/plain "success"）
+POST /{command}/shell        — シェルスクリプト生成
+POST /{command}/exec         — コマンド実行（レスポンス: text/plain 結果ディレクトリパス）
+POST /{command}/parameterize — パラメータ化
+```
+
+### リソース系（dataset-setting/xlsx-schema/template）
+
+```
+GET  /{resource}/list        — ファイル一覧（レスポンス: JSON配列）
+POST /{resource}/load        — ファイル読込（body: text/plain ファイル名）
+POST /{resource}/save        — ファイル保存（body: ResourceSaveRequest）
+POST /{resource}/delete      — ファイル削除
+```
+
+### ワークスペース管理
+
+```
+GET  /workspace/resources    — ワークスペース状態取得（レスポンス: WorkspaceDto）
+POST /workspace/update       — コンテキスト更新（body: ContextDto）
+POST /workspace/resolve-path — パス解決（body: ResolvePathRequestDto、レスポンス: text/plain）
+```
+
+### JDBC拡張
+
+```
+POST /jdbc/save-properties   — JDBC設定保存
+POST /jdbc/read-content      — JDBC設定読込（body: text/plain）
+POST /jdbc/tables            — テーブル一覧取得
+POST /jdbc/columns           — カラム一覧取得
+POST /jdbc/test              — 接続テスト
+```
+
+### データセット設定拡張
+
+```
+POST /dataset-setting/table-names   — テーブル名一覧
+POST /dataset-setting/table-preview — テーブルプレビュー（レスポンス: DatasetTablePreviewResponseDto）
+```
+
+## 主要 DTO クラス
+
+- `WorkspaceDto` — ワークスペース状態（resources + context）
+- `ContextDto` — コンテキスト設定（workspace/datasetBase/resultBase 等）
+- `CommandRequestDto` — コマンド実行リクエスト（name + input パラメータ）
+- `ResourceSaveRequest<T>` — リソース保存リクエスト（name + input）
+- `JdbcDto`, `JdbcColumnsRequestDto`, `JdbcSavePropertiesRequestDto` — JDBC関連
+- `QueryDataSourceDto`, `JsonXlsxSchemaDto` — その他
+- `DatasetRequestDto`, `DatasetTablePreviewRequestDto` — データセット関連
+
+## ドメインモデル（`domain/project/`）
+
+- `Workspace` — ワークスペース全体（Options + Resources + パス管理）
+- `Options` — コマンド設定ファイル管理（CommandType ごとの Map）
+- `Resources` — リソースファイルディレクトリ管理（jdbc/setting/template/xlsx-schema）
+- `ResourceFile` — 単一リソースファイルセットの抽象化（list/read/save/delete）
+- `Datasource` — クエリーデータソース管理
+
+## 調査手順
+
+1. 特定エンドポイントの実装を調べる場合: 上記の対応コントローラーファイルを Read で確認
+2. DTOの構造を調べる場合: `sidecar/src/main/java/yo/dbunitcli/sidecar/dto/` を探索
+3. ドメインロジックを調べる場合: `sidecar/src/main/java/yo/dbunitcli/sidecar/domain/` を探索
+4. エンドポイントが見当たらない場合: `AbstractCommandController` または `AbstractResourceFileController` の基底実装を確認


### PR DESCRIPTION
## Summary
Added comprehensive agent documentation files to guide investigation and development of the core and sidecar modules. These documents serve as reference guides for understanding module architecture, package structure, and common workflows.

## Key Changes
- **Added `tauri/.claude/agents/core-investigator.md`**: Detailed documentation for the core module covering:
  - Module overview and role (CLI implementation, common JAR, GraalVM support)
  - Complete package structure with command system, data set processing, comparison engine, and resource management
  - Build commands and architecture positioning
  - Investigation procedures for different aspects of the core module

- **Added `tauri/.claude/agents/sidecar-investigator.md`**: Detailed documentation for the sidecar module covering:
  - Micronaut REST API framework overview
  - Complete controller and API endpoint mapping (15 controllers)
  - Common endpoint patterns for command and resource operations
  - Main DTO and domain model classes
  - Investigation procedures for endpoints, DTOs, and domain logic

- **Updated `.claude/settings.json`**: Fixed Tauri test hook to ensure dependencies are installed before running tests (`bun install --frozen-lockfile` added)

## Notable Details
Both agent documentation files follow a consistent structure with tables for quick reference, clear architectural diagrams, and step-by-step investigation procedures. The documentation enables efficient navigation of the codebase for both new contributors and AI agents assisting with development tasks.

https://claude.ai/code/session_01MGBVxcqAe6E3aiPVWRnEqo