### PR TITLE
Add settingEncoding field to dataset source configuration

### DIFF
--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -42,6 +42,7 @@ function buildDatasetRequestBody(
 		regHeaderSplit: info.regHeaderSplit,
 		regDataSplit: info.regDataSplit,
 		encoding: info.encoding,
+		settingEncoding: info.settingEncoding,
 		delimiter: info.delimiter,
 		ignoreQuoted: info.ignoreQuoted,
 		headerName: info.headerName,

--- a/tauri/src/model/CommandOption.ts
+++ b/tauri/src/model/CommandOption.ts
@@ -119,6 +119,7 @@ export type SrcInfo = {
 export type DatasetSrcInfo = SrcInfo & {
 	srcType?: SrcType;
 	setting?: string;
+	settingEncoding: string;
 	xlsxSchema: string;
 	fixedLength: string;
 	regHeaderSplit: string;
@@ -250,6 +251,7 @@ export function buildDatasetSrcInfo(datasrc: DatasetSource): DatasetSrcInfo {
 		regTableExclude: datasrc.regTableExclude.value,
 		srcType: datasrc.srcType?.value,
 		setting: datasrc.setting.value,
+		settingEncoding: datasrc.settingEncoding.value,
 		headerName: datasrc.headerName ? datasrc.headerName.value : "",
 		startRow: datasrc.startRow ? datasrc.startRow.value : "",
 		addFileInfo: datasrc.addFileInfo?.value === "true",


### PR DESCRIPTION
## Summary
This PR adds support for a `settingEncoding` field in the dataset source configuration, allowing users to specify encoding for dataset settings separately from the main data encoding.

## Key Changes
- Added `settingEncoding: string` property to the `DatasetSrcInfo` type definition
- Updated `buildDatasetSrcInfo()` function to extract and include `settingEncoding` from the datasource object
- Updated `buildDatasetRequestBody()` function to include `settingEncoding` in the request payload alongside the existing `encoding` field

## Implementation Details
The `settingEncoding` field is now treated as a first-class property in the dataset configuration pipeline, allowing it to be:
- Defined in the source data model
- Extracted during the build process
- Transmitted to the backend in API requests

This change maintains backward compatibility while providing more granular control over encoding settings for different aspects of dataset configuration.

https://claude.ai/code/session_01WQ7JxgUVbioLyjg9SBBtFk