### PR TITLE
Refactor parameter handling in dataset settings API

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
@@ -25,6 +25,7 @@ import yo.dbunitcli.sidecar.dto.DatasetTablePreviewResponseDto;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Controller("dataset-setting")
 public class DatasetSettingsController extends AbstractResourceFileController<DatasetRequestDto> {
@@ -40,7 +41,7 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
             final DataSetLoadOption option = new DataSetLoadOption("", this.buildDataSetLoadDto(request, "false"));
             final ComparableDataSetParam param = option.getParam().build();
             return ObjectMapper.getDefault().writeValueAsString(
-                    new ComparableDataSetLoader(Parameter.none()).loadDataSet(param).getTableNames());
+                    new ComparableDataSetLoader(this.buildParameter(request)).loadDataSet(param).getTableNames());
         } catch (final Throwable th) {
             LOGGER.warn("Could not get table names", th);
             return "[]";
@@ -52,7 +53,7 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
         try {
             final DataSetLoadOption option = new DataSetLoadOption("", this.buildDataSetLoadDto(request, "true"));
             final ComparableDataSetParam param = option.getParam().build();
-            final ComparableDataSet dataSet = new ComparableDataSetLoader(Parameter.none()).loadDataSet(param);
+            final ComparableDataSet dataSet = new ComparableDataSetLoader(this.buildParameter(request)).loadDataSet(param);
             final ComparableTable table = dataSet.getTable(request.getTableName());
             if (table == null) {
                 return ObjectMapper.getDefault()
@@ -86,6 +87,14 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
     @Override
     protected ResourceFile getResourceFile() {
         return this.workspace.resources().datasetSetting();
+    }
+
+    private Parameter buildParameter(final DatasetTableNamesRequestDto request) {
+        final Map<String, String> params = request.getParameters();
+        if (params == null) {
+            return Parameter.none();
+        }
+        return Parameter.none().addAll(params);
     }
 
     private DataSetLoadDto buildDataSetLoadDto(final DatasetTableNamesRequestDto request, final String loadData) {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
@@ -2,8 +2,12 @@ package yo.dbunitcli.sidecar.dto;
 
 import io.micronaut.serde.annotation.Serdeable;
 
+import java.util.Map;
+
 @Serdeable
 public class DatasetTableNamesRequestDto {
+
+    private Map<String, String> parameters;
 
     private String srcType;
     private String src;
@@ -37,6 +41,14 @@ public class DatasetTableNamesRequestDto {
     private String jdbcUser;
     private String jdbcPass;
     private String jdbcProperties;
+
+    public Map<String, String> getParameters() {
+        return this.parameters;
+    }
+
+    public void setParameters(final Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
 
     public String getSetting() {
         return this.setting;

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -16,12 +16,6 @@ import {
 	type OperationResult,
 } from "../utils/fetchUtils";
 
-function buildParamExtra(paramInputs: Record<string, string>): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
-	);
-}
-
 function buildDatasetRequestBody(
 	info: DatasetSrcInfo,
 	jdbcValues: Record<string, string>,
@@ -65,13 +59,12 @@ async function fetchTableNames(
 	if (!info.srcPath) {
 		return [];
 	}
-	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-names`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, paramExtra),
+			body: buildDatasetRequestBody(info, jdbcValues, { parameters: paramInputs }),
 		},
 	};
 	return fetchData(fetchParams)
@@ -129,13 +122,12 @@ async function fetchTablePreview(
 	if (!info.srcPath || !tableName) {
 		return { headers: [], rows: [] };
 	}
-	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-preview`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, { tableName, ...paramExtra }),
+			body: buildDatasetRequestBody(info, jdbcValues, { tableName, parameters: paramInputs }),
 		},
 	};
 	return fetchData(fetchParams)


### PR DESCRIPTION
## Summary
This PR refactors how parameters are passed to the dataset settings API endpoints, moving from a command-line style parameter format (`-Pkey=value`) to a structured map-based approach. This simplifies the parameter handling logic and makes the API contract more explicit.

## Key Changes
- **Backend (Java)**: 
  - Added `parameters` field to `DatasetTableNamesRequestDto` to accept a `Map<String, String>` of parameters
  - Created `buildParameter()` method in `DatasetSettingsController` to convert the parameter map into `Parameter` objects
  - Updated `tableNames()` and `tablePreview()` endpoints to use the new parameter building method instead of `Parameter.none()`

- **Frontend (TypeScript)**:
  - Removed `buildParamExtra()` helper function that was transforming parameters into `-Pkey` format
  - Updated `fetchTableNames()` and `fetchTablePreview()` to pass parameters as a structured `{ parameters: paramInputs }` object instead of spreading transformed parameters
  - Simplified the request body construction by removing the parameter transformation step

## Implementation Details
- The `buildParameter()` method safely handles null parameters by returning `Parameter.none()` as a fallback
- Parameters are now passed directly as a map, making the API contract clearer and reducing string manipulation on both client and server sides
- The change maintains backward compatibility by treating missing parameters as an empty parameter set

https://claude.ai/code/session_01Tk84f8BMjP71emKv6j6K42