### PR TITLE
ParameterInputDialogの値をComparableDataSetLoaderに渡す

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/DatasetSettingsController.java
@@ -27,6 +27,7 @@ import yo.dbunitcli.sidecar.dto.DatasetTablePreviewResponseDto;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Controller("dataset-setting")
 public class DatasetSettingsController extends AbstractResourceFileController<DatasetRequestDto> {
@@ -40,8 +41,8 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
     public String tableNames(@Body final DatasetTableNamesRequestDto request) {
         try {
             return ObjectMapper.getDefault().writeValueAsString(
-                    new ComparableDataSetLoader(Parameter.none()).loadDataSet(this.toParam(request, "false").build())
-                                                                 .getTableNames());
+                    new ComparableDataSetLoader(this.buildParameter(request)).loadDataSet(this.toParam(request, "false").build())
+                                                                             .getTableNames());
         } catch (final Throwable th) {
             LOGGER.warn("Could not get table names", th);
             return "[]";
@@ -52,7 +53,7 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
     public String tablePreview(@Body final DatasetTablePreviewRequestDto request) {
         try {
             List<ComparableTable.Builder> metaDataBuilder = new ArrayList<>();
-            new ComparableDataSetLoader(Parameter.none()).getComparableDataSetProducer(
+            new ComparableDataSetLoader(this.buildParameter(request)).getComparableDataSetProducer(
                     this.toParam(request, "true").setConverter(new TargetTableHandler(request, metaDataBuilder))
                         .build()).produce();
             if (metaDataBuilder.isEmpty()) {
@@ -78,6 +79,14 @@ public class DatasetSettingsController extends AbstractResourceFileController<Da
     @Override
     protected ResourceFile getResourceFile() {
         return this.workspace.resources().datasetSetting();
+    }
+
+    private Parameter buildParameter(final DatasetTableNamesRequestDto request) {
+        final Map<String, String> params = request.getParameters();
+        if (params == null) {
+            return Parameter.none();
+        }
+        return Parameter.none().addAll(params);
     }
 
     private ComparableDataSetParam.Builder toParam(final DatasetTableNamesRequestDto request, final String loadData) {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/dto/DatasetTableNamesRequestDto.java
@@ -2,8 +2,12 @@ package yo.dbunitcli.sidecar.dto;
 
 import io.micronaut.serde.annotation.Serdeable;
 
+import java.util.Map;
+
 @Serdeable
 public class DatasetTableNamesRequestDto {
+
+    private Map<String, String> parameters;
 
     private String srcType;
     private String src;
@@ -37,6 +41,14 @@ public class DatasetTableNamesRequestDto {
     private String jdbcUser;
     private String jdbcPass;
     private String jdbcProperties;
+
+    public Map<String, String> getParameters() {
+        return this.parameters;
+    }
+
+    public void setParameters(final Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
 
     public String getSetting() {
         return this.setting;

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -16,12 +16,6 @@ import {
 	type OperationResult,
 } from "../utils/fetchUtils";
 
-function buildParamExtra(paramInputs: Record<string, string>): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(paramInputs).map(([k, v]) => [`-P${k}`, v]),
-	);
-}
-
 function buildDatasetRequestBody(
 	info: DatasetSrcInfo,
 	jdbcValues: Record<string, string>,
@@ -65,13 +59,12 @@ async function fetchTableNames(
 	if (!info.srcPath) {
 		return [];
 	}
-	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-names`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, paramExtra),
+			body: buildDatasetRequestBody(info, jdbcValues, { parameters: paramInputs }),
 		},
 	};
 	return fetchData(fetchParams)
@@ -129,13 +122,12 @@ async function fetchTablePreview(
 	if (!info.srcPath || !tableName) {
 		return { headers: [], rows: [] };
 	}
-	const paramExtra = buildParamExtra(paramInputs);
 	const fetchParams = {
 		endpoint: `${apiUrl}dataset-setting/table-preview`,
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, { tableName, ...paramExtra }),
+			body: buildDatasetRequestBody(info, jdbcValues, { tableName, parameters: paramInputs }),
 		},
 	};
 	return fetchData(fetchParams)


### PR DESCRIPTION
dataset-setting/table-namesおよびtable-previewエンドポイントで、 フロントエンドのParameterInputDialogで指定したパラメータ群が
ComparableDataSetLoaderのコンストラクタ引数に使用されるよう対応。

- フロントエンド: buildParamExtraを廃止しparametersフィールドとしてネスト送信
- DTO: DatasetTableNamesRequestDtoにMap<String,String> parametersを追加
- コントローラー: buildParameterメソッドでParameterを構築してローダーに渡す

https://claude.ai/code/session_01Tk84f8BMjP71emKv6j6K42