### PR TITLE
Add template command preview dialog to ParameterizeForm

### DIFF
--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react";
+import { useParameterList } from "../../context/WorkspaceResourcesProvider";
 import type { ParameterizeOptions } from "../../model/SelectParameter";
 import { DatasetLoadForm } from "./section/DatasetLoadForm";
 import Check from "./section/element/Check";
-import FileText from "./section/element/FileText";
 import PlainText from "./section/element/PlainText";
 import Select from "./section/element/Select";
+import Text, { TextDropDownMenu } from "./section/element/Text";
 import TemplateFormSection from "./section/TemplateFormSection";
+import {
+	TemplateCommandButton,
+	resolveCommandAndName,
+} from "./section/dialog/TemplateCommandDialog";
 
 export function ParameterizeForm(prop: {
 	handleTypeSelect: () => Promise<void>;
@@ -14,6 +20,12 @@ export function ParameterizeForm(prop: {
 	const parameterize = prop.parameterize;
 	const paramData = parameterize.paramData;
 	const templateOption = parameterize.templateOption;
+	const [cmdValue, setCmdValue] = useState(parameterize.cmd.value);
+	const parameterList = useParameterList();
+
+	const resolved = resolveCommandAndName(cmdValue);
+	const templateDataList = resolved ? parameterList[resolved.command] : [];
+
 	return (
 		<>
 			<fieldset className="border border-gray-200 p-3">
@@ -25,9 +37,36 @@ export function ParameterizeForm(prop: {
 				/>
 				<Check prefix="" element={parameterize.parameterize} />
 				<Check prefix="" element={parameterize.ignoreFail} />
-				<PlainText prefix="" element={parameterize.cmd} />
+				<PlainText
+					prefix=""
+					element={parameterize.cmd}
+					handleValueChange={setCmdValue}
+				/>
 				<PlainText prefix="" element={parameterize.cmdParam} />
-				<FileText prefix="" element={parameterize.template} />
+				<Text
+					prefix=""
+					element={parameterize.template}
+					showDefaulePath={true}
+					resourceFiles={templateDataList}
+				>
+					{({ path, setPath, isValueInDatalist }) => (
+						<TextDropDownMenu
+							path={path}
+							setPath={setPath}
+							prefix=""
+							element={parameterize.template}
+							isValueInDatalist={isValueInDatalist}
+							editButtons={[
+								<TemplateCommandButton
+									key="open-cmd"
+									command={resolved?.command ?? null}
+									name={resolved?.name ?? ""}
+									cmdValue={cmdValue}
+								/>,
+							]}
+						/>
+					)}
+				</Text>
 				{templateOption && (
 					<TemplateFormSection
 						templateOption={templateOption}

--- a/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
+++ b/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from "react";
+import { WhiteButton } from "../../../../components/element/Button";
+import { PreviewButton } from "../../../../components/element/ButtonIcon";
+import { useEnvironment } from "../../../../context/EnvironmentProvider";
+import type { Command, Options } from "../../../../model/SelectParameter";
+import { COMMANDS } from "../../../../model/SelectParameter";
+import { fetchData, getErrorMessage } from "../../../../utils/fetchUtils";
+import { CompareForm } from "../../CompareForm";
+import { ConvertForm } from "../../ConvertForm";
+import { GenerateForm } from "../../GenerateForm";
+import { RunForm } from "../../RunForm";
+
+type LoadState =
+	| { status: "loading" }
+	| { status: "error"; message: string }
+	| { status: "loaded"; options: Options };
+
+async function loadCommandOptions(
+	apiUrl: string,
+	command: Command,
+	name: string,
+): Promise<Options> {
+	const fetchParams = {
+		endpoint: `${apiUrl + command}/load`,
+		options: {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name }),
+		},
+	};
+	const response = await fetchData(fetchParams);
+	const options = (await response.json()) as Options;
+	(options as Record<string, unknown>).command = command;
+	return options;
+}
+
+export function resolveCommandAndName(
+	cmdValue: string,
+): { command: Command; name: string } | null {
+	const normalized = cmdValue.replace(/\\/g, "/").replace(/\/$/, "");
+	const parts = normalized.split("/").filter(Boolean);
+	if (parts.length < 2) return null;
+	const fileName = parts[parts.length - 1];
+	const folderName = parts[parts.length - 2];
+	const lower = folderName.toLowerCase() as Command;
+	if (!COMMANDS.includes(lower)) return null;
+	const name = fileName.replace(/\.[^.]+$/, "");
+	return { command: lower, name };
+}
+
+function renderCommandForm(options: Options, name: string) {
+	const noop = async () => {};
+	switch (options.command) {
+		case "convert":
+			return (
+				<ConvertForm handleTypeSelect={noop} name={name} convert={options} />
+			);
+		case "compare":
+			return (
+				<CompareForm handleTypeSelect={noop} name={name} compare={options} />
+			);
+		case "generate":
+			return (
+				<GenerateForm handleTypeSelect={noop} name={name} generate={options} />
+			);
+		case "run":
+			return <RunForm handleTypeSelect={noop} name={name} run={options} />;
+		default:
+			return (
+				<p className="text-content-muted">
+					This command type cannot be displayed.
+				</p>
+			);
+	}
+}
+
+function TemplateCommandDialog({
+	command,
+	name,
+	cmdValue,
+	handleDialogClose,
+}: {
+	command: Command | null;
+	name: string;
+	cmdValue: string;
+	handleDialogClose: () => void;
+}) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const environment = useEnvironment();
+	const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+
+	useEffect(() => {
+		dialogRef.current?.showModal();
+	}, []);
+
+	useEffect(() => {
+		if (!command) return;
+		let isMounted = true;
+		async function load() {
+			const options = await loadCommandOptions(
+				environment.apiUrl,
+				command as Command,
+				name,
+			);
+			if (isMounted) setLoadState({ status: "loaded", options });
+		}
+		load().catch((ex) => {
+			if (isMounted)
+				setLoadState({ status: "error", message: getErrorMessage(ex) });
+		});
+		return () => {
+			isMounted = false;
+		};
+	}, [command, name, environment.apiUrl]);
+
+	return (
+		<dialog
+			ref={dialogRef}
+			onClose={handleDialogClose}
+			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
+		>
+			<div className="overflow-y-auto max-h-[80vh] min-w-[600px] p-4">
+				{command ? (
+					<>
+						<h2 className="text-lg font-bold mb-4">
+							{command} - {name}
+						</h2>
+						{loadState.status === "loading" && (
+							<div className="text-content-muted">Loading...</div>
+						)}
+						{loadState.status === "error" && (
+							<div className="text-error">Error: {loadState.message}</div>
+						)}
+						{loadState.status === "loaded" &&
+							renderCommandForm(loadState.options, name)}
+					</>
+				) : (
+					<>
+						<h2 className="text-lg font-bold mb-2">Command resolution error</h2>
+						<p className="text-error">
+							Cannot resolve command from cmd value: &quot;{cmdValue}&quot;
+						</p>
+						<p className="text-content-muted text-sm mt-1">
+							The parent folder name must be one of: convert, compare, generate,
+							run, parameterize.
+						</p>
+					</>
+				)}
+			</div>
+			<div className="flex justify-end p-4">
+				<WhiteButton title="Close" handleClick={handleDialogClose} />
+			</div>
+		</dialog>
+	);
+}
+
+export function TemplateCommandButton({
+	command,
+	name,
+	cmdValue,
+}: {
+	command: Command | null;
+	name: string;
+	cmdValue: string;
+}) {
+	const [showDialog, setShowDialog] = useState(false);
+	return (
+		<>
+			<PreviewButton handleClick={() => setShowDialog(true)} />
+			{showDialog && (
+				<TemplateCommandDialog
+					command={command}
+					name={name}
+					cmdValue={cmdValue}
+					handleDialogClose={() => setShowDialog(false)}
+				/>
+			)}
+		</>
+	);
+}

--- a/tauri/src/model/SelectParameter.ts
+++ b/tauri/src/model/SelectParameter.ts
@@ -12,6 +12,13 @@ export type Command =
 	| "generate"
 	| "run"
 	| "parameterize";
+export const COMMANDS: Command[] = [
+	"convert",
+	"compare",
+	"generate",
+	"run",
+	"parameterize",
+];
 export class SelectParameter {
 	readonly name: string;
 	readonly command: Command;

--- a/tauri/src/tests/app/form/ParameterizeForm.test.tsx
+++ b/tauri/src/tests/app/form/ParameterizeForm.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@tauri-apps/api/path", () => ({
 vi.mock("../../../context/WorkspaceResourcesProvider", () => ({
 	useWorkspaceContext: () => workspaceResourcesFixture.context,
 	useResourcesSettings: () => workspaceResourcesFixture.resources,
+	useParameterList: () => workspaceResourcesFixture.parameterList,
 }));
 vi.mock("../../../context/EnvironmentProvider", () => ({
 	useEnvironment: () => environmentFixture,


### PR DESCRIPTION
## Summary
This PR adds a preview dialog feature to the ParameterizeForm that allows users to view and inspect template commands before execution. When a user enters a command path, they can now click a preview button to see the resolved command details in a modal dialog.

## Key Changes
- **New TemplateCommandDialog component**: Created a reusable dialog component that loads and displays command options based on the selected command type (convert, compare, generate, run)
  - Includes `resolveCommandAndName()` utility function to parse command paths and extract the command type and template name
  - Handles loading states (loading, error, loaded) with appropriate UI feedback
  - Renders the appropriate form (ConvertForm, CompareForm, GenerateForm, RunForm) based on command type

- **Updated ParameterizeForm**: 
  - Replaced FileText input for template field with an interactive Text component that includes a dropdown menu
  - Added TemplateCommandButton to the template field's edit buttons for quick preview access
  - Integrated command resolution logic to dynamically populate template data list based on the entered command path
  - Added state management for the cmd value to enable real-time command resolution

- **Model updates**: 
  - Added `COMMANDS` constant array to SelectParameter.ts for easier command type validation

- **Test updates**: Updated ParameterizeForm tests to mock the new WorkspaceResourcesProvider dependency

## Implementation Details
- The dialog uses a native HTML `<dialog>` element with modal behavior
- Command resolution handles path normalization (backslashes to forward slashes, trailing slashes)
- The component includes proper cleanup with mounted state tracking to prevent state updates after unmount
- Template data list is dynamically filtered based on the resolved command type from the parameter list context

https://claude.ai/code/session_01AvTPwMp7U3GPwYsL7FWspK