### PR TITLE
Standardize line endings for sidecar test resources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # テストリソースファイルは改行をLF固定にする（プラットフォーム依存を避けるため）
 core/src/test/resources/**/*.txt text eol=lf
+sidecar/src/test/resources/**/* text eol=lf


### PR DESCRIPTION
## Summary
Extended the `.gitattributes` configuration to enforce LF line endings for all test resource files in the sidecar module, consistent with the existing policy for core test resources.

## Changes
- Added `.gitattributes` rule for `sidecar/src/test/resources/**/*` to enforce `text eol=lf`
- This ensures platform-independent line ending handling for sidecar test resources, matching the existing configuration for core test resources

## Details
This change applies the same line ending normalization strategy used for core test resources to the sidecar module's test resources. This prevents platform-specific line ending variations (CRLF on Windows vs LF on Unix-like systems) from causing test failures or unnecessary diffs in version control.

https://claude.ai/code/session_017SYQuB8asVChpwejktZkYb