### PR TITLE
Preserve -P options when resolving file paths in CommandParameters

### DIFF
--- a/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
+++ b/core/src/main/java/yo/dbunitcli/application/CommandParameters.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -53,7 +54,11 @@ public record CommandParameters(CommandType type, String[] args) {
             }
             newArgs.add(key + "=" + resolved);
         }
-        return changed ? new CommandParameters(this.type, newArgs.toArray(new String[0])) : this;
+        if (!changed) {
+            return this;
+        }
+        Arrays.stream(this.args).filter(it -> it.startsWith("-P")).forEach(newArgs::add);
+        return new CommandParameters(this.type, newArgs.toArray(new String[0]));
     }
 
     public CommandParameters shrink() {

--- a/core/src/test/java/yo/dbunitcli/application/CommandParametersTest.java
+++ b/core/src/test/java/yo/dbunitcli/application/CommandParametersTest.java
@@ -1,0 +1,70 @@
+package yo.dbunitcli.application;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import yo.dbunitcli.application.command.Type;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class CommandParametersTest {
+
+    @Test
+    void resolveFilePaths_パス変更時にPオプションが保持される() {
+        final Map<String, String> input = new LinkedHashMap<>();
+        input.put("-srcType", "csv");
+        input.put("-src", "some/path");
+        input.put("-setting", "relative/setting.json");
+        input.put("-resultType", "csv");
+        input.put("-result", "some/result");
+        input.put("-Pmykey", "myvalue");
+
+        final CommandParameters params = new CommandParameters(Type.convert, input)
+                .resolveFilePaths((baseDir, value) ->
+                        baseDir == Option.BaseDir.SETTING
+                                ? "/abs/" + value
+                                : value);
+
+        final boolean containsPArg = Arrays.stream(params.args())
+                .anyMatch(it -> it.equals("-Pmykey=myvalue"));
+        Assertions.assertTrue(containsPArg, "-Pmykey=myvalue がresolveFilePaths後も保持されること");
+    }
+
+    @Test
+    void resolveFilePaths_パス変更なし時は同一インスタンスを返す() {
+        final Map<String, String> input = new LinkedHashMap<>();
+        input.put("-srcType", "csv");
+        input.put("-src", "some/path");
+        input.put("-Pmykey", "myvalue");
+
+        final CommandParameters original = new CommandParameters(Type.convert, input);
+        final CommandParameters result = original.resolveFilePaths((baseDir, value) -> value);
+
+        Assertions.assertSame(original, result, "パス変更がない場合は同一インスタンスを返すこと");
+    }
+
+    @Test
+    void resolveFilePaths_複数のPオプションがすべて保持される() {
+        final Map<String, String> input = new LinkedHashMap<>();
+        input.put("-srcType", "csv");
+        input.put("-src", "some/path");
+        input.put("-setting", "relative/setting.json");
+        input.put("-resultType", "csv");
+        input.put("-result", "some/result");
+        input.put("-Pkey1", "value1");
+        input.put("-Pkey2", "value2");
+
+        final CommandParameters params = new CommandParameters(Type.convert, input)
+                .resolveFilePaths((baseDir, value) ->
+                        baseDir == Option.BaseDir.SETTING
+                                ? "/abs/" + value
+                                : value);
+
+        final String[] args = params.args();
+        Assertions.assertTrue(Arrays.stream(args).anyMatch(it -> it.equals("-Pkey1=value1")),
+                "-Pkey1=value1 が保持されること");
+        Assertions.assertTrue(Arrays.stream(args).anyMatch(it -> it.equals("-Pkey2=value2")),
+                "-Pkey2=value2 が保持されること");
+    }
+}


### PR DESCRIPTION
## Summary
Fixed a bug in `CommandParameters.resolveFilePaths()` where command-line property options (prefixed with `-P`) were being lost when file paths were resolved.

## Changes
- **CommandParameters.java**: Modified `resolveFilePaths()` method to preserve all `-P` prefixed arguments when creating a new instance after path resolution
  - Previously, only the resolved file path arguments were carried over to the new instance
  - Now explicitly filters and adds all `-P` options to the new arguments array
  - Maintains the optimization of returning the same instance when no path changes occur

- **CommandParametersTest.java**: Added comprehensive test coverage for the fix
  - Test that single `-P` options are preserved after path resolution
  - Test that the same instance is returned when no path changes occur
  - Test that multiple `-P` options are all preserved correctly

## Implementation Details
The fix ensures that property arguments (e.g., `-Pmykey=myvalue`) are not discarded during the `resolveFilePaths()` operation. These arguments are now explicitly added to the new arguments array after path resolution, maintaining backward compatibility while fixing the regression.

https://claude.ai/code/session_0159FQaXUES3gR83cn5zZpBz