### PR TITLE
Configure GitHub Actions workflows to use Node.js 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,9 @@ on:
       - 'sidecar/pom.xml'
       - '.github/workflows/maven.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -2,6 +2,9 @@ name: Native-Test
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   native-test:
     runs-on: windows-latest

--- a/.github/workflows/native-trace.yml
+++ b/.github/workflows/native-trace.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/native-trace.yml'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/sync-sample.yml
+++ b/.github/workflows/sync-sample.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'sidecar/src/test/resources/workspace/sample/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,6 +1,9 @@
 name: tauri-build
 on:
     workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   tauri-build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
This pull request updates all GitHub Actions workflows to explicitly use Node.js 24 by setting the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable.

## Changes Made
- Added `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the following workflows:
  - `.github/workflows/maven.yml`
  - `.github/workflows/native-test.yml`
  - `.github/workflows/native-trace.yml`
  - `.github/workflows/sync-sample.yml`
  - `.github/workflows/tauri-build.yml`

## Details
The environment variable is set at the workflow level, ensuring that all jobs and steps within each workflow will use Node.js 24 for any JavaScript-based GitHub Actions. This provides consistency across the CI/CD pipeline and ensures compatibility with the latest Node.js runtime.

https://claude.ai/code/session_01C1B47ZteJdGAMExm9opeSV