### PR TITLE
Fix dataset form state management and key generation

### DIFF
--- a/tauri/src/app/form/section/DatasetLoadForm.tsx
+++ b/tauri/src/app/form/section/DatasetLoadForm.tsx
@@ -38,10 +38,11 @@ function DatasetLoadFormContent({
 			}
 		};
 	const handleValueChange = (element: CommandOption) => (newValue: string) => {
-		if (element.name in datasetSrcInfo) {
+		const key = element.name === "src" ? "srcPath" : element.name;
+		if (key in datasetSrcInfo) {
 			setDatasetSrcInfo({
 				...datasetSrcInfo,
-				[element.name]: newValue,
+				[key]: newValue,
 			} as DatasetSrcInfo);
 		}
 	};
@@ -107,7 +108,7 @@ export function DatasetLoadForm(prop: {
 	const initialDatasetSrcInfo = buildDatasetSrcInfo(prop.srcData);
 	return (
 		<DatasetSrcInfoProvider
-			key={prop.name + prop.srcData.prefix}
+			key={`${prop.name}:${prop.srcData.prefix}:${prop.srcData.srcType?.value ?? ""}`}
 			initialValue={initialDatasetSrcInfo}
 		>
 			<DatasetLoadFormContent


### PR DESCRIPTION
## Summary
This PR fixes two issues in the DatasetLoadForm component related to state management and React key generation for proper component re-rendering.

## Key Changes
- **State key mapping**: Updated `handleValueChange` to map the "src" element name to "srcPath" when updating `datasetSrcInfo` state, ensuring the correct state property is modified
- **Provider key generation**: Enhanced the `DatasetSrcInfoProvider` key to include `srcType` value in addition to `name` and `prefix`, preventing stale state when the source type changes

## Implementation Details
The first change ensures that form input changes are correctly persisted to the appropriate state properties. The second change improves the React key by making it more comprehensive, which helps the provider properly reset its state when any of the relevant data properties change, preventing bugs related to stale cached values across different dataset configurations.

https://claude.ai/code/session_016qEEAjf8ao8YXTwcVHdgNn