### PR TITLE
Remove input parameters from shell save operation

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/controller/AbstractCommandController.java
@@ -129,7 +129,7 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
     @Post(uri = "shell", produces = MediaType.TEXT_PLAIN)
     public String shell(@Body final CommandRequestDto body) throws IOException {
         try {
-            return Path.of(this.workspace.saveShell(this.getCommandType(), body.getName(), this.resolveParameters(body.getInput()))).getParent().toString();
+            return Path.of(this.workspace.saveShell(this.getCommandType(), body.getName())).getParent().toString();
         } catch (IOException e) {
             throw e;
         } catch (final Throwable th) {
@@ -154,7 +154,11 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
     public String exec(@Body final CommandRequestDto body) {
         try {
             LOGGER.info(System.getProperty(FileResources.PROPERTY_WORKSPACE));
-            final CommandParameters parameters = this.resolveParameters(body.getInput());
+            final CommandParameters parameters = new CommandParameters(this.getCommandType(), body.getInput())
+                    .resolveFilePaths((baseDir, value) ->
+                            SIDECAR_RESOLVE_BASEDIR.contains(baseDir) && !new File(value).isAbsolute()
+                                    ? new File(Workspace.resolveBaseDir(baseDir), value).getAbsolutePath()
+                                    : value);
             try {
                 parameters.exec(body.getName());
             } catch (final Command.CommandFailException th) {
@@ -165,14 +169,6 @@ public abstract class AbstractCommandController implements ControllerExceptionHa
             LOGGER.error("cause:", th);
             throw new ApplicationException(th);
         }
-    }
-
-    private CommandParameters resolveParameters(final Map<String, String> input) {
-        return new CommandParameters(this.getCommandType(), input)
-                .resolveFilePaths((baseDir, value) ->
-                        SIDECAR_RESOLVE_BASEDIR.contains(baseDir) && !new File(value).isAbsolute()
-                                ? new File(Workspace.resolveBaseDir(baseDir), value).getAbsolutePath()
-                                : value);
     }
 
     abstract protected Type getCommandType();

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -176,7 +175,7 @@ public class Workspace {
         return this.options().paths(type);
     }
 
-    public String saveShell(final Type commandType, final String name, final CommandParameters parameters) throws IOException {
+    public String saveShell(final Type commandType, final String name) throws IOException {
         final Path launchDir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
         final Path backendDir = this.installDir().resolve("backend");
         final STGroup group = new STGroupFile("shell/saveShell.stg", '$', '$');
@@ -190,7 +189,7 @@ public class Workspace {
         template.add("resultBaseProperty", FileResources.PROPERTY_RESULT_BASE);
         template.add("resultBase", rawOrRelative(launchDir, FileResources.PROPERTY_RESULT_BASE, () -> FileResources.resultDir().toPath().toAbsolutePath().normalize()));
         template.add("commandType", commandType.name());
-        template.add("args", Arrays.asList(parameters.args()));
+        template.add("name", name);
         final String content = template.render();
         final File scriptFile = new File(launchDir.toFile(), commandType.name() + "_" + name + ".bat");
         // BATファイルはWindowsのOSデフォルト文字コードで保存する必要がある

--- a/sidecar/src/main/resources/shell/saveShell.stg
+++ b/sidecar/src/main/resources/shell/saveShell.stg
@@ -1,4 +1,4 @@
-saveShell(sidecarExe, backendDir, workspaceProperty, workspace, datasetBaseProperty, datasetBase, resultBaseProperty, resultBase, commandType, args) ::= <<
+saveShell(sidecarExe, backendDir, workspaceProperty, workspace, datasetBaseProperty, datasetBase, resultBaseProperty, resultBase, commandType, name) ::= <<
 @echo off
 cd /d %~dp0
 $sidecarExe$ ^
@@ -8,5 +8,6 @@ $sidecarExe$ ^
   -D$resultBaseProperty$=$resultBase$ ^
   -cli ^
   -cmd=$commandType$ ^
-  $args; separator=" ^\n  "$
+  -template=option/$commandType$/$name$.txt ^
+  -srcType=none
 >>

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -84,11 +84,7 @@ export default function Footer(prop: {
 				controller.signal,
 			);
 		} else if (running.command === "saveShell") {
-			saveShellRef.current(
-				{ ...formValues, ...paramExtra },
-				handleResult,
-				controller.signal,
-			);
+			saveShellRef.current(handleResult, controller.signal);
 		}
 
 		return () => {

--- a/tauri/src/hooks/useSelectParameter.ts
+++ b/tauri/src/hooks/useSelectParameter.ts
@@ -132,11 +132,8 @@ export const useExecParameter = () => {
 
 export const useSaveShell = () => {
 	const execute = useParameterAction();
-	return async (
-		input: { [k: string]: FormDataEntryValue },
-		handleResult: (result: Running) => void,
-		signal?: AbortSignal,
-	) => execute("shell", { input }, handleResult, signal);
+	return async (handleResult: (result: Running) => void, signal?: AbortSignal) =>
+		execute("shell", {}, handleResult, signal);
 };
 
 export const useParameterizeFrom = () => {


### PR DESCRIPTION
## Summary
This PR refactors the shell save operation to remove the need for passing input parameters from the client. The shell script generation now uses a template-based approach instead of dynamically injecting command arguments.

## Key Changes

- **Backend (Java)**
  - Removed `resolveParameters()` method from `AbstractCommandController` as it's no longer needed for the shell operation
  - Updated `shell()` endpoint to no longer pass input parameters to `workspace.saveShell()`
  - Modified `Workspace.saveShell()` signature to remove the `CommandParameters` parameter
  - Changed shell template generation to use the command name directly instead of dynamically resolved arguments
  - Updated `exec()` method to inline parameter resolution logic

- **Frontend (TypeScript/React)**
  - Simplified `useSaveShell()` hook to remove the `input` parameter - now only accepts callback and signal
  - Updated `Footer.tsx` to call `saveShellRef.current()` without form values and parameter extras

- **Shell Template**
  - Modified `saveShell.stg` template to accept `name` parameter instead of `args`
  - Changed generated script to use `-template=option/$commandType$/$name$.txt` and `-srcType=none` instead of dynamic argument injection

## Implementation Details

The refactoring simplifies the shell save workflow by moving away from dynamic parameter injection at save time. Instead, the generated shell script now references a template file by name, which will be resolved at execution time. This reduces complexity in the client-server communication and makes the shell generation more predictable.

https://claude.ai/code/session_01Gu3EGFL3ZMg5ebgnW9aA6B