### PR TITLE
Add connection timeouts for database drivers

### DIFF
--- a/core/src/main/java/yo/dbunitcli/resource/jdbc/DatabaseConnectionLoader.java
+++ b/core/src/main/java/yo/dbunitcli/resource/jdbc/DatabaseConnectionLoader.java
@@ -17,6 +17,8 @@ import java.util.Properties;
 
 public record DatabaseConnectionLoader(Properties jdbcProp) {
 
+    private static final int CONNECT_TIMEOUT_SECONDS = 30;
+
     public IDatabaseConnection loadConnection() {
         final String url = this.jdbcProp.get("url").toString();
         final String user = this.jdbcProp.get("user").toString();
@@ -25,7 +27,9 @@ public record DatabaseConnectionLoader(Properties jdbcProp) {
         try {
             if (url.contains("jdbc:oracle:thin")) {
                 Class.forName("oracle.jdbc.driver.OracleDriver");
-                final Connection conn = DriverManager.getConnection(url, user, pass);
+                final Properties props = baseProperties(user, pass);
+                props.setProperty("oracle.net.CONNECT_TIMEOUT", String.valueOf(CONNECT_TIMEOUT_SECONDS * 1000));
+                final Connection conn = DriverManager.getConnection(url, props);
                 result = new DatabaseConnection(conn, user);
                 final DatabaseConfig config = result.getConfig();
                 config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
@@ -35,7 +39,9 @@ public record DatabaseConnectionLoader(Properties jdbcProp) {
                 config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, new ForwardOnlyResultSetTableFactory());
             } else if (url.contains("jdbc:sqlserver")) {
                 Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
-                final Connection conn = DriverManager.getConnection(url, user, pass);
+                final Properties props = baseProperties(user, pass);
+                props.setProperty("loginTimeout", String.valueOf(CONNECT_TIMEOUT_SECONDS));
+                final Connection conn = DriverManager.getConnection(url, props);
                 result = new DatabaseConnection(conn, conn.getCatalog());
                 final DatabaseConfig config = result.getConfig();
                 config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
@@ -44,7 +50,11 @@ public record DatabaseConnectionLoader(Properties jdbcProp) {
                 config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, new ForwardOnlyResultSetTableFactory());
             } else if (url.contains("jdbc:postgresql")) {
                 Class.forName("org.postgresql.Driver");
-                final Connection conn = DriverManager.getConnection(url, user, pass);
+                final Properties props = baseProperties(user, pass);
+                props.setProperty("connectTimeout", String.valueOf(CONNECT_TIMEOUT_SECONDS));
+                // socketTimeout covers data transfer after connect, so allow more time than connectTimeout
+                props.setProperty("socketTimeout", String.valueOf(CONNECT_TIMEOUT_SECONDS * 2));
+                final Connection conn = DriverManager.getConnection(url, props);
                 result = new DatabaseConnection(conn);
                 final DatabaseConfig config = result.getConfig();
                 config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
@@ -54,6 +64,7 @@ public record DatabaseConnectionLoader(Properties jdbcProp) {
                 config.setProperty(DatabaseConfig.PROPERTY_RESULTSET_TABLE_FACTORY, new ForwardOnlyResultSetTableFactory());
             } else if (url.contains("jdbc:h2")) {
                 Class.forName("org.h2.Driver");
+                // H2 is embedded/local; no network timeout needed
                 final Connection conn = DriverManager.getConnection(url, user, pass);
                 result = new DatabaseConnection(conn);
                 final DatabaseConfig config = result.getConfig();
@@ -69,5 +80,12 @@ public record DatabaseConnectionLoader(Properties jdbcProp) {
         } catch (final ClassNotFoundException | SQLException | DatabaseUnitException ex) {
             throw new AssertionError(ex);
         }
+    }
+
+    private static Properties baseProperties(final String user, final String pass) {
+        final Properties props = new Properties();
+        props.setProperty("user", user);
+        props.setProperty("password", pass);
+        return props;
     }
 }

--- a/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
+++ b/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
@@ -182,7 +182,10 @@ function ColumnSelectDialog({
 		return (
 			<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[60]">
 				<div className="bg-surface rounded-lg shadow-lg p-6 w-80 max-w-full">
-					<p className="text-sm text-content-muted">Loading...</p>
+					<p className="text-sm text-content-muted mb-4">Loading...</p>
+					<div className="flex gap-2 justify-end">
+						<WhiteButton title="Cancel" handleClick={onClose} />
+					</div>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
## Summary
This PR adds configurable connection timeouts for JDBC database connections and improves the loading dialog UX in the SQL table insert dialog.

## Key Changes

### Database Connection Timeouts
- Added a `CONNECT_TIMEOUT_SECONDS` constant (30 seconds) to standardize timeout behavior across database drivers
- Introduced a new `baseProperties()` helper method to create a Properties object with user and password credentials
- **Oracle**: Set `oracle.net.CONNECT_TIMEOUT` to 30 seconds (in milliseconds)
- **SQL Server**: Set `loginTimeout` to 30 seconds
- **PostgreSQL**: Set `connectTimeout` to 30 seconds and `socketTimeout` to 60 seconds (allowing more time for data transfer after connection)
- **H2**: Added a comment noting that H2 is embedded/local and doesn't require network timeouts

### UI Improvements
- Enhanced the loading dialog in `SqlTableInsertDialog` by:
  - Adding bottom margin to the loading text for better spacing
  - Adding a Cancel button to allow users to close the dialog while loading

## Implementation Details
- All database drivers now use the `DriverManager.getConnection(url, Properties)` overload instead of the `(url, user, password)` variant, enabling driver-specific timeout configuration
- PostgreSQL's socket timeout is set to 2x the connection timeout to account for data transfer delays after the initial connection
- The refactoring maintains backward compatibility while improving reliability for network-based database connections

https://claude.ai/code/session_0192nauzDg77ydqbNgTuQtCg