### PR TITLE
Refactor: Replace hardcoded colors with design system tokens

### DIFF
--- a/tauri/src/app/footer/ResultDialog.tsx
+++ b/tauri/src/app/footer/ResultDialog.tsx
@@ -11,7 +11,7 @@ export default function ResultDialog(props: {
 			className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 "
 		>
 			<div className="relative p-4 w-full max-w-md max-h-full">
-				<div className="relative bg-white rounded-lg shadow-sm dark:bg-gray-700">
+				<div className="relative bg-surface rounded-lg shadow-sm">
 					{props.children}
 				</div>
 			</div>

--- a/tauri/src/app/form/CompareForm.tsx
+++ b/tauri/src/app/form/CompareForm.tsx
@@ -28,7 +28,7 @@ export function CompareForm(prop: {
 
 	return (
 		<>
-			<fieldset className="border border-gray-200 p-3">
+			<fieldset className="border border-border-subtle p-3">
 				<legend>compare</legend>
 				<Select
 					handleTypeSelect={prop.handleTypeSelect}
@@ -52,7 +52,7 @@ export function CompareForm(prop: {
 				<PlainText prefix="" element={settingEncodingElement} />
 			</fieldset>
 			{prop.compare.imageOption && (
-				<fieldset className="border border-gray-200 p-3">
+				<fieldset className="border border-border-subtle p-3">
 					<legend>image</legend>
 					<SectionHelpButton command="image" label="Image Option" />
 					<ImageOptionFormSection imageOption={imageOption} />
@@ -68,7 +68,7 @@ export function CompareForm(prop: {
 				name={prop.name}
 				srcData={oldData}
 			/>
-			<fieldset className="border border-gray-200 p-3">
+			<fieldset className="border border-border-subtle p-3">
 				<legend>{convertResult.prefix}</legend>
 				<ResultFormSection
 					resultOption={convertResult}

--- a/tauri/src/app/form/ConvertForm.tsx
+++ b/tauri/src/app/form/ConvertForm.tsx
@@ -16,7 +16,7 @@ export function ConvertForm(prop: {
 				name={prop.name}
 				srcData={srcData}
 			/>
-			<fieldset className="border border-gray-200 p-3">
+			<fieldset className="border border-border-subtle p-3">
 				<legend>{convertResult.prefix}</legend>
 				<ResultFormSection
 					resultOption={convertResult}

--- a/tauri/src/app/form/GenerateForm.tsx
+++ b/tauri/src/app/form/GenerateForm.tsx
@@ -18,7 +18,7 @@ export function GenerateForm(prop: {
 		generateTypeValue === "xlsx" || generateTypeValue === "xls";
 	return (
 		<>
-			<fieldset className="border border-gray-200 p-3">
+			<fieldset className="border border-border-subtle p-3">
 				<legend>generate</legend>
 				<Select
 					handleTypeSelect={prop.handleTypeSelect}

--- a/tauri/src/app/form/ParameterizeForm.tsx
+++ b/tauri/src/app/form/ParameterizeForm.tsx
@@ -28,7 +28,7 @@ export function ParameterizeForm(prop: {
 
 	return (
 		<>
-			<fieldset className="border border-gray-200 p-3">
+			<fieldset className="border border-border-subtle p-3">
 				<legend>execute</legend>
 				<Select
 					handleTypeSelect={prop.handleTypeSelect}

--- a/tauri/src/app/form/RunForm.tsx
+++ b/tauri/src/app/form/RunForm.tsx
@@ -12,7 +12,7 @@ export function RunForm(prop: {
 }) {
 	const run = prop.run;
 	return (
-		<fieldset className="border border-gray-200 p-3">
+		<fieldset className="border border-border-subtle p-3">
 			<legend>run</legend>
 			<Select
 				handleTypeSelect={prop.handleTypeSelect}

--- a/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
+++ b/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
@@ -85,7 +85,7 @@ function ParameterizeTemplateDialog({
 		<dialog
 			ref={dialogRef}
 			onClose={handleDialogClose}
-			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-white border border-gray-200"
+			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-surface border border-border-subtle"
 		>
 			<div className="overflow-y-auto max-h-[80vh] min-w-[600px] p-4">
 				<DialogTitle>Template - {name}</DialogTitle>

--- a/tauri/src/app/sidebar/NameEditMenu.tsx
+++ b/tauri/src/app/sidebar/NameEditMenu.tsx
@@ -53,7 +53,7 @@ export default function NameEditMenu({
 			{editName.name && (
 				<div
 					ref={wrapperRef}
-					className="absolute z-10 p-4 pb-0 text-gray-900 bg-white border border-gray-100 rounded-lg shadow-md"
+					className="absolute z-10 p-4 pb-0 text-content bg-surface border border-border-subtle rounded-lg shadow-md"
 					style={
 						editName.afterEdge
 							? { left: editName.x, top: editName.y - 150 }

--- a/tauri/src/app/sidebar/SidebarHelpLink.tsx
+++ b/tauri/src/app/sidebar/SidebarHelpLink.tsx
@@ -38,13 +38,13 @@ export default function SidebarHelpLink() {
 				<HelpIcon />
 			</ButtonIcon>
 			{showMenu && (
-				<div className="absolute bottom-full left-0 mb-1 z-50 p-2 bg-white border border-gray-100 rounded-lg shadow-md w-64">
+				<div className="absolute bottom-full left-0 mb-1 z-50 p-2 bg-surface border border-border-subtle rounded-lg shadow-md w-64">
 					<ul className="space-y-1">
 						{helpCommands.map((item) => (
 							<li key={item.command}>
 								<Button
 									buttonstyle="w-full text-left px-3 py-2"
-									bgcolor="hover:bg-gray-100"
+									bgcolor="hover:bg-surface-subtle"
 									textstyle=""
 									border="outline-hidden"
 									handleClick={() => {
@@ -52,8 +52,8 @@ export default function SidebarHelpLink() {
 										setShowMenu(false);
 									}}
 								>
-									<span className="block text-sm font-semibold text-gray-700">{item.label}</span>
-									<span className="block text-xs text-gray-500">{item.description}</span>
+									<span className="block text-sm font-semibold text-content">{item.label}</span>
+									<span className="block text-xs text-content-secondary">{item.description}</span>
 								</Button>
 							</li>
 						))}

--- a/tauri/src/components/dialog/SettingDialog.tsx
+++ b/tauri/src/components/dialog/SettingDialog.tsx
@@ -44,10 +44,7 @@ export function SettingDialog<T>(props: SettingDialogProps<T>) {
 		<dialog
 			ref={dialogRef}
 			onClose={props.handleDialogClose}
-			className="overflow-y-auto fixed
-                    top-0 right-0 left-0 z-50
-                    bg-white
-                    border border-gray-200"
+			className="overflow-y-auto fixed top-0 right-0 left-0 z-50 bg-surface border border-border-subtle"
 		>
 			<div
 				className={
@@ -98,9 +95,9 @@ export function SettingDialog<T>(props: SettingDialogProps<T>) {
 
 export function Fieldset(props: { children: ReactNode; legend?: string }) {
 	return (
-		<fieldset className="border border-gray-200 p-2.5 m-2">
+		<fieldset className="border border-border-subtle p-2.5 m-2">
 			{props.legend && (
-				<legend className="text-xs font-semibold text-gray-500 px-1">
+				<legend className="text-xs font-semibold text-content-secondary px-1">
 					{props.legend}
 				</legend>
 			)}
@@ -262,7 +259,7 @@ export function ArraysText(props: {
 		<>
 			{showLabel && (
 				<div className="grid grid-cols-5 pb-1">
-					<span className="col-start-2 text-xs text-gray-500">column</span>
+					<span className="col-start-2 text-xs text-content-secondary">column</span>
 				</div>
 			)}
 			<div className="grid grid-cols-5 pb-2">
@@ -364,8 +361,8 @@ export function KeyValueText(props: {
 		<>
 			{props.index === 0 && (
 				<div className="grid grid-cols-5 pb-1">
-					<span className="col-start-2 text-xs text-gray-500">name</span>
-					<span className="col-start-3 col-span-2 ml-1 text-xs text-gray-500">
+					<span className="col-start-2 text-xs text-content-secondary">name</span>
+					<span className="col-start-3 col-span-2 ml-1 text-xs text-content-secondary">
 						expression
 					</span>
 				</div>

--- a/tauri/src/components/dialog/SettingTable.tsx
+++ b/tauri/src/components/dialog/SettingTable.tsx
@@ -57,10 +57,10 @@ export default function SettingTable<T>({
 				/>
 			)}
 			<table className="table-fixed w-full">
-				<caption className="caption-top text-sm font-semibold text-gray-700 text-left px-2 py-1">
+				<caption className="caption-top text-sm font-semibold text-content text-left px-2 py-1">
 					{caption}
 				</caption>
-				<thead className="text-xs text-gray-700 uppercase bg-gray-50">
+				<thead className="text-xs text-content uppercase bg-surface-subtle">
 					<tr>
 						<th scope="col" className="px-6 py-3 border">
 							Target
@@ -75,7 +75,7 @@ export default function SettingTable<T>({
 						<tr key={getKey(setting)}>
 							<th
 								scope="row"
-								className="px-6 min-w-80 max-w-80 text-left text-sm text-gray-900 border"
+								className="px-6 min-w-80 max-w-80 text-left text-sm text-content border"
 							>
 								{renderSetting(setting)}
 							</th>


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use a consistent design system color palette instead of hardcoded Tailwind color values. This improves maintainability and enables easier theme switching across the application.

## Key Changes
- Replaced hardcoded gray color values with semantic design tokens:
  - `bg-white` → `bg-surface`
  - `bg-gray-50` → `bg-surface-subtle`
  - `bg-gray-100` → `bg-surface-subtle`
  - `hover:bg-gray-100` → `hover:bg-surface-subtle`
  - `border-gray-200` → `border-border-subtle`
  - `border-gray-100` → `border-border-subtle`
  - `text-gray-900` → `text-content`
  - `text-gray-700` → `text-content`
  - `text-gray-500` → `text-content-secondary`

- Updated components across multiple files:
  - Dialog components (SettingDialog, TemplateCommandDialog, ResultDialog)
  - Form components (CompareForm, ConvertForm, GenerateForm, ParameterizeForm, RunForm)
  - Sidebar components (SidebarHelpLink, NameEditMenu)
  - Table component (SettingTable)
  - Fieldset and text input components

- Removed dark mode specific class (`dark:bg-gray-700`) from ResultDialog as it's now handled by the design token system

## Implementation Details
- All changes are purely cosmetic and maintain the same visual hierarchy and spacing
- The refactoring uses semantic color tokens that can be easily customized in a centralized theme configuration
- No functional changes to component behavior or props

https://claude.ai/code/session_01HnULmo3R9K2BPkrkaTGorx