### PR TITLE
Fix isMountedRef initialization in dialog components

### DIFF
--- a/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
+++ b/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
@@ -102,6 +102,7 @@ function TablesContent({
 	} | null>(null);
 	const isMountedRef = useRef(true);
 	useEffect(() => {
+		isMountedRef.current = true;
 		return () => {
 			isMountedRef.current = false;
 		};

--- a/tauri/src/app/form/section/dialog/TableList.tsx
+++ b/tauri/src/app/form/section/dialog/TableList.tsx
@@ -34,6 +34,7 @@ export default function TableList({
 	);
 	const isMountedRef = useRef(true);
 	useEffect(() => {
+		isMountedRef.current = true;
 		return () => {
 			isMountedRef.current = false;
 		};


### PR DESCRIPTION
## Summary
Initialize `isMountedRef.current` to `true` at the start of the `useEffect` hook in dialog components to ensure the ref is properly set when the component mounts.

## Changes
- **SqlTableInsertDialog.tsx**: Added `isMountedRef.current = true;` at the beginning of the useEffect hook
- **TableList.tsx**: Added `isMountedRef.current = true;` at the beginning of the useEffect hook

## Details
The `isMountedRef` is used to track component mount state and prevent state updates on unmounted components. By explicitly setting it to `true` when the effect runs (on mount), we ensure the ref is properly initialized before any async operations that might check this flag. This prevents potential race conditions where the ref might be checked before the cleanup function has a chance to set it to `false`.

https://claude.ai/code/session_01MASd6Kggs2XhKJFovx8v4H