### PR TITLE
Replace isMounted pattern with AbortController

### DIFF
--- a/tauri/.claude/rules/hooks-design.md
+++ b/tauri/.claude/rules/hooks-design.md
@@ -6,14 +6,14 @@
 
 イベントハンドラとして使うだけの関数（deps に含めない）はクロージャのままでよい。
 
-## isMounted ガード
+## アンマウントガード（AbortController）
 
-非同期処理がアンマウント後に完了しうる場合は必ず付ける。
+非同期処理がアンマウント後に完了しうる場合は `AbortController` で必ずガードする。
 
 | 起点 | パターン |
 |---|---|
-| `useEffect` 内 | `let isMounted = true` ローカル変数 + `return () => { isMounted = false }` |
-| イベントハンドラ | `const isMountedRef = useRef(true)` + `useEffect(() => () => { isMountedRef.current = false }, [])` |
+| `useEffect` 内 | `const controller = new AbortController()` + `return () => controller.abort()`、コールバックで `if (!controller.signal.aborted)` |
+| イベントハンドラ | `const abortControllerRef = useRef<AbortController \| null>(null)` + `useEffect` でマウント時に生成・アンマウント時に `controller.abort()`、コールバックで `if (!abortControllerRef.current?.signal.aborted)` |
 
-`useEffect` 外から Promise を開始する場合はクロージャをまたぐため `useRef` が必要。
+`useEffect` 外から Promise を開始する場合はクロージャをまたぐため `useRef` が必要。cleanup で ref を `null` にしないこと（`signal.aborted` 判定が無効化されるため）。
 

--- a/tauri/src/app/footer/Footer.tsx
+++ b/tauri/src/app/footer/Footer.tsx
@@ -53,13 +53,12 @@ export default function Footer(prop: {
 			return;
 		}
 		executingRef.current = true;
-		let active = true;
 		setIsLoading(true);
 		const controller = new AbortController();
 		abortControllerRef.current = controller;
 
 		const handleResult = (result: Running) => {
-			if (active) {
+			if (!controller.signal.aborted) {
 				executingRef.current = false;
 				abortControllerRef.current = null;
 				setRunning(result);
@@ -88,7 +87,6 @@ export default function Footer(prop: {
 		}
 
 		return () => {
-			active = false;
 			abortControllerRef.current?.abort();
 			abortControllerRef.current = null;
 		};

--- a/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
+++ b/tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx
@@ -100,11 +100,12 @@ function TablesContent({
 		table: string;
 		data: string[] | "loading";
 	} | null>(null);
-	const isMountedRef = useRef(true);
+	const abortControllerRef = useRef<AbortController | null>(null);
 	useEffect(() => {
-		isMountedRef.current = true;
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
 		return () => {
-			isMountedRef.current = false;
+			controller.abort();
 		};
 	}, []);
 
@@ -120,14 +121,14 @@ function TablesContent({
 		setColumnDialog({ table, data: "loading" });
 		onQueryColumns?.(table).then(
 			(columns) => {
-				if (isMountedRef.current) {
+				if (!abortControllerRef.current?.signal.aborted) {
 					setColumnDialog((prev) =>
 						prev?.table === table ? { table, data: columns } : prev,
 					);
 				}
 			},
 			() => {
-				if (isMountedRef.current) {
+				if (!abortControllerRef.current?.signal.aborted) {
 					setColumnDialog(null);
 				}
 			},

--- a/tauri/src/app/form/section/dialog/TableList.tsx
+++ b/tauri/src/app/form/section/dialog/TableList.tsx
@@ -32,11 +32,12 @@ export default function TableList({
 	const [columnMap, setColumnMap] = useState<Map<string, string[] | "loading">>(
 		new Map(),
 	);
-	const isMountedRef = useRef(true);
+	const abortControllerRef = useRef<AbortController | null>(null);
 	useEffect(() => {
-		isMountedRef.current = true;
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
 		return () => {
-			isMountedRef.current = false;
+			controller.abort();
 		};
 	}, []);
 
@@ -65,12 +66,12 @@ export default function TableList({
 		setColumnMap((prev) => new Map(prev).set(table, "loading"));
 		onQueryColumns(table).then(
 			(columns) => {
-				if (isMountedRef.current) {
+				if (!abortControllerRef.current?.signal.aborted) {
 					setColumnMap((prev) => new Map(prev).set(table, columns));
 				}
 			},
 			() => {
-				if (isMountedRef.current) {
+				if (!abortControllerRef.current?.signal.aborted) {
 					setColumnMap((prev) => {
 						const next = new Map(prev);
 						next.delete(table);

--- a/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
+++ b/tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx
@@ -56,23 +56,23 @@ function ParameterizeTemplateDialog({
 			setLoadState({ status: "error", message: "No template selected" });
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		async function load() {
 			const content = await loadParameterizeTemplateContent(
 				environment.apiUrl,
 				name,
 			);
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setLoadState({ status: "loaded", content });
 			}
 		}
 		load().catch((ex) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setLoadState({ status: "error", message: getErrorMessage(ex) });
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [name, environment.apiUrl]);
 

--- a/tauri/src/app/form/section/element/Chooser.tsx
+++ b/tauri/src/app/form/section/element/Chooser.tsx
@@ -1,6 +1,7 @@
 import { core } from "@tauri-apps/api";
 import { sep } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useEffect, useRef } from "react";
 import {
 	DirectoryButton,
 	FileButton,
@@ -13,12 +14,20 @@ import type { FileProp } from "./FormElementProp";
 function useChooserHandler(prop: FileProp, directory?: boolean) {
 	const context = useWorkspaceContext();
 	const resolveAbsolutePath = useResolveAbsolutePath();
+	const abortControllerRef = useRef<AbortController | null>(null);
+	useEffect(() => {
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
+		return () => {
+			controller.abort();
+		};
+	}, []);
 	return () => {
 		const basePath = context.getPath(prop.element.attribute.defaultPath);
 		const workspacePath = context.workspace;
 		resolveAbsolutePath(prop.path, prop.element.attribute).then((defaultPath) =>
 			open({ defaultPath, directory }).then((files) => {
-				if (files) {
+				if (files && !abortControllerRef.current?.signal.aborted) {
 					const fullPath = files as string;
 					const primaryPrefix = basePath + sep();
 					const secondaryPrefix = workspacePath + sep();

--- a/tauri/src/app/startup/StartupForm.tsx
+++ b/tauri/src/app/startup/StartupForm.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import {
 	type Dispatch,
 	type SetStateAction,
+	useEffect,
 	useRef,
 	useState,
 } from "react";
@@ -139,10 +140,20 @@ function DirectoryChooser(prop: {
 	text: string;
 	setPath: Dispatch<SetStateAction<string>>;
 }) {
+	const abortControllerRef = useRef<AbortController | null>(null);
+	useEffect(() => {
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
+		return () => {
+			controller.abort();
+		};
+	}, []);
 	const handleDirectoryChooserClick = () => {
-		open({ defaultPath: prop.text, directory: true }).then(
-			(files) => files && prop.setPath(files as string),
-		);
+		open({ defaultPath: prop.text, directory: true }).then((files) => {
+			if (files && !abortControllerRef.current?.signal.aborted) {
+				prop.setPath(files as string);
+			}
+		});
 	};
 	return (
 		<ButtonWithIcon

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -91,16 +91,16 @@ export const useDatasetTableNames = (
 			setLoading(false);
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		setLoading(true);
 		fetchTableNames(apiUrl, srcInfo, jdbcValues, paramInputs).then((names) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setTableNames(names);
 				setLoading(false);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, paramInputs]);
 
@@ -161,16 +161,16 @@ export const useDatasetTablePreview = (
 			setLoading(false);
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		setLoading(true);
 		fetchTablePreview(apiUrl, srcInfo, tableName, jdbcValues, paramInputs).then((result) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setPreview(result);
 				setLoading(false);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, tableName, paramInputs]);
 
@@ -233,16 +233,16 @@ export const useDatasetSettingsData = (
 			setLoading(false);
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		setLoading(true);
 		loadDatasetSettings(apiUrl, fileName).then((result) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setSettings(result);
 				setLoading(false);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [fileName, apiUrl]);
 

--- a/tauri/src/hooks/useTemplate.ts
+++ b/tauri/src/hooks/useTemplate.ts
@@ -20,16 +20,16 @@ export const useTemplateData = (name: string): { content: string; loading: boole
 			setLoading(false);
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		setLoading(true);
 		loadTemplateContent(apiUrl, name).then((result) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setContent(result);
 				setLoading(false);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [name, apiUrl]);
 

--- a/tauri/src/hooks/useXlsxSchema.ts
+++ b/tauri/src/hooks/useXlsxSchema.ts
@@ -64,16 +64,16 @@ export const useXlsxSchemaData = (
 			setLoading(false);
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		setLoading(true);
 		loadXlsxSchema(apiUrl, fileName).then((result) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setSchema(result);
 				setLoading(false);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [fileName, apiUrl]);
 
@@ -147,7 +147,7 @@ export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 		if (!srcPath) {
 			return;
 		}
-		let isMounted = true;
+		const controller = new AbortController();
 		fetchSheets(apiUrl, {
 			srcPath,
 			regTableInclude,
@@ -157,12 +157,12 @@ export const useSrcInfoSheets = (srcInfo: SrcInfo): string[] => {
 			regExclude,
 			extension,
 		}).then((names) => {
-			if (isMounted) {
+			if (!controller.signal.aborted) {
 				setSheetNames(names);
 			}
 		});
 		return () => {
-			isMounted = false;
+			controller.abort();
 		};
 	}, [
 		apiUrl,


### PR DESCRIPTION
## Summary
Refactored async operation cleanup patterns across the codebase to use `AbortController` instead of the deprecated `isMounted` flag pattern. This improves code reliability and aligns with modern React best practices.

## Key Changes
- **useEffect-based async operations**: Replaced `let isMounted = true` with `const controller = new AbortController()`, checking `!controller.signal.aborted` in callbacks and calling `controller.abort()` in cleanup
- **Event handler async operations**: Replaced `useRef(true)` with `useRef<AbortController | null>(null)`, initializing the controller in a dedicated `useEffect`, and checking `!abortControllerRef.current?.signal.aborted` in callbacks
- **Files updated**:
  - `tauri/src/hooks/useDatasetSettings.ts` - 3 hooks (`useDatasetTableNames`, `useDatasetTablePreview`, `useDatasetSettingsData`)
  - `tauri/src/hooks/useXlsxSchema.ts` - 2 hooks (`useXlsxSchemaData`, `useSrcInfoSheets`)
  - `tauri/src/hooks/useTemplate.ts` - 1 hook (`useTemplateData`)
  - `tauri/src/app/startup/StartupForm.tsx` - `DirectoryChooser` component
  - `tauri/src/app/form/section/element/Chooser.tsx` - `useChooserHandler` hook
  - `tauri/src/app/form/section/dialog/SqlTableInsertDialog.tsx` - `TablesContent` component
  - `tauri/src/app/form/section/dialog/TableList.tsx` - `TableList` component
  - `tauri/src/app/form/section/dialog/TemplateCommandDialog.tsx` - `ParameterizeTemplateDialog` component
  - `tauri/src/app/footer/Footer.tsx` - `Footer` component (also removed redundant `active` flag)
- **Documentation**: Updated `tauri/.claude/rules/hooks-design.md` to reflect the new AbortController pattern with clear examples for both `useEffect` and event handler contexts

## Implementation Details
- `AbortController` provides a standard, cancellable promise pattern that integrates well with async/await
- The `signal.aborted` property is checked before state updates to prevent memory leaks from unmounted components
- For event handlers, the controller is created once during mount and reused across multiple async operations
- Cleanup functions properly abort pending operations to prevent race conditions

https://claude.ai/code/session_01NPL8qdVYR5scGacKWSi3Lw