### PR TITLE
Add column datalist loader dialog for dataset settings

### DIFF
--- a/tauri/src/app/form/section/dialog/ColumnDatalistDialog.tsx
+++ b/tauri/src/app/form/section/dialog/ColumnDatalistDialog.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react";
+import {
+	DialogActions,
+	DialogTitle,
+	ModalOverlay,
+} from "../../../../components/dialog";
+import { BlueButton, WhiteButton } from "../../../../components/element/Button";
+import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
+import { useColumnNamesFetcher } from "../../../../hooks/useDatasetSettings";
+import type { DatasetSetting } from "../../../../model/DatasetSettings";
+
+export default function ColumnDatalistDialog({
+	tableNames,
+	target,
+	onLoad,
+	onClose,
+}: {
+	tableNames: string[];
+	target: DatasetSetting;
+	onLoad: (columns: string[]) => void;
+	onClose: () => void;
+}) {
+	const filteredTables = filterTablesByTarget(tableNames, target);
+	const [loadingTable, setLoadingTable] = useState<string | null>(null);
+	const srcInfo = useDatasetSrcInfo();
+	const fetchColumnNames = useColumnNamesFetcher();
+	const abortControllerRef = useRef<AbortController | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+		abortControllerRef.current = controller;
+		return () => {
+			controller.abort();
+		};
+	}, []);
+
+	const handleLoadColumns = (tableName: string) => {
+		if (loadingTable !== null) {
+			return;
+		}
+		if (!abortControllerRef.current) {
+			return;
+		}
+		setLoadingTable(tableName);
+		const { signal } = abortControllerRef.current;
+		fetchColumnNames(srcInfo, tableName, signal).then((columns) => {
+			if (!abortControllerRef.current?.signal.aborted) {
+				onLoad(columns);
+				onClose();
+			}
+		});
+	};
+
+	function renderRow(name: string) {
+		return (
+			<tr key={name} className="border-t border-border-faint">
+				<td className="px-3 py-1.5 text-sm text-content-muted">{name}</td>
+				<td className="px-3 py-1.5 text-right">
+					<BlueButton
+						title={loadingTable === name ? "Loading..." : "Load Columns"}
+						disabled={loadingTable !== null}
+						handleClick={() => handleLoadColumns(name)}
+					/>
+				</td>
+			</tr>
+		);
+	}
+
+	function renderBody() {
+		if (filteredTables.length === 0) {
+			return (
+				<p className="text-sm text-content-disabled py-2">
+					No matching tables.
+				</p>
+			);
+		}
+		return (
+			<div className="overflow-y-auto max-h-72 border border-border-subtle rounded mb-4">
+				<table className="w-full text-sm text-left">
+					<tbody>{filteredTables.map(renderRow)}</tbody>
+				</table>
+			</div>
+		);
+	}
+
+	return (
+		<ModalOverlay width="w-[32rem]" zClass="z-modal-nested">
+			<DialogTitle>Load Column Datalist</DialogTitle>
+			{renderBody()}
+			<DialogActions>
+				<WhiteButton title="Close" handleClick={onClose} />
+			</DialogActions>
+		</ModalOverlay>
+	);
+}
+
+function filterTablesByTarget(
+	tableNames: string[],
+	target: DatasetSetting,
+): string[] {
+	if (target.handler() === "name" && target.name && target.name.length > 0) {
+		const nameSet = new Set(target.name.map((n) => n.toLowerCase()));
+		return tableNames.filter((t) => nameSet.has(t.toLowerCase()));
+	}
+	if (target.handler() === "pattern" && target.pattern?.string) {
+		try {
+			const regex = new RegExp(target.pattern.string, "i");
+			return tableNames.filter((t) => regex.test(t));
+		} catch {
+			return tableNames;
+		}
+	}
+	return tableNames;
+}

--- a/tauri/src/app/form/section/dialog/DatasetSettingDialog.tsx
+++ b/tauri/src/app/form/section/dialog/DatasetSettingDialog.tsx
@@ -10,10 +10,11 @@ import {
 	Text,
 } from "../../../../components/dialog";
 import {
+	BlueButtonIcon,
 	ButtonIcon,
 	ExpandButton,
 } from "../../../../components/element/ButtonIcon";
-import { HelpIcon } from "../../../../components/element/Icon";
+import { HelpIcon, PreviewIcon } from "../../../../components/element/Icon";
 import { ResourceDatalist } from "../../../../components/element/Input";
 import { useDatasetSrcInfo } from "../../../../context/DatasetSrcInfoProvider";
 import { useDatasetTableNames } from "../../../../hooks/useDatasetSettings";
@@ -23,6 +24,7 @@ import type {
 } from "../../../../model/DatasetSettings";
 import { newDatasetSetting } from "../../../../model/DatasetSettings";
 import { openHelpWindow } from "../../../../utils/helpWindow";
+import ColumnDatalistDialog from "./ColumnDatalistDialog";
 
 export default function DatasetSettingDialog(props: {
 	setting: DatasetSetting;
@@ -34,6 +36,10 @@ export default function DatasetSettingDialog(props: {
 		setTarget((current) => current.replace(select));
 	const [showOptional, setShowOptional] = useState(false);
 	const toggleOptional = () => setShowOptional(!showOptional);
+	const [columnDatalist, setColumnDatalist] = useState<string[]>([]);
+	const [showColumnDialog, setShowColumnDialog] = useState(false);
+	const columnList =
+		columnDatalist.length > 0 ? "column_datalist_list" : undefined;
 	const datasetSrcInfo = useDatasetSrcInfo();
 	const { tableNames } = useDatasetTableNames(datasetSrcInfo);
 	const tableList = tableNames.length > 0 ? "tableName_list" : undefined;
@@ -83,7 +89,7 @@ export default function DatasetSettingDialog(props: {
 					<option value="split">split</option>
 					<option value="separate">separate</option>
 				</Select>
-				{renderModeContent(target, setTarget)}
+				{renderModeContent(target, setTarget, columnList)}
 			</Fieldset>
 			<Fieldset legend="Additional Columns">
 				<ExpandButton
@@ -137,9 +143,18 @@ export default function DatasetSettingDialog(props: {
 				)}
 			</Fieldset>
 			<Fieldset legend="Filter / Order">
+				<div className="flex justify-end pb-1">
+					<BlueButtonIcon
+						title="Load column datalist"
+						handleClick={() => setShowColumnDialog(true)}
+					>
+						<PreviewIcon title="Load column datalist" fill="white" />
+					</BlueButtonIcon>
+				</div>
 				<Arrays
 					name="exclude"
 					values={target.exclude}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceExclude(text, index))
 					}
@@ -148,6 +163,7 @@ export default function DatasetSettingDialog(props: {
 				<Arrays
 					name="include"
 					values={target.include}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceInclude(text, index))
 					}
@@ -156,6 +172,7 @@ export default function DatasetSettingDialog(props: {
 				<Arrays
 					name="keys"
 					values={target.keys}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceKeys(text, index))
 					}
@@ -164,6 +181,7 @@ export default function DatasetSettingDialog(props: {
 				<Arrays
 					name="filter"
 					values={target.filter}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceFilter(text, index))
 					}
@@ -172,12 +190,24 @@ export default function DatasetSettingDialog(props: {
 				<Arrays
 					name="order"
 					values={target.order}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceOrder(text, index))
 					}
 					handleRemove={(index) => setTarget((cur) => cur.removeOrder(index))}
 				/>
+				{columnDatalist.length > 0 && (
+					<ResourceDatalist id="column_datalist" resources={columnDatalist} />
+				)}
 			</Fieldset>
+			{showColumnDialog && (
+				<ColumnDatalistDialog
+					tableNames={tableNames}
+					target={target}
+					onLoad={(columns) => setColumnDatalist(columns)}
+					onClose={() => setShowColumnDialog(false)}
+				/>
+			)}
 		</SettingDialog>
 	);
 }
@@ -185,6 +215,7 @@ export default function DatasetSettingDialog(props: {
 function renderModeContent(
 	target: DatasetSetting,
 	setTarget: React.Dispatch<React.SetStateAction<DatasetSetting>>,
+	columnList: string | undefined,
 ): React.ReactElement {
 	const mode = target.mode();
 	if (mode === "split") {
@@ -221,14 +252,13 @@ function renderModeContent(
 					name="limit"
 					value={target.split?.limit ?? ""}
 					handleChange={(newVal) =>
-						setTarget((cur) =>
-							cur.replaceSplit({ limit: newVal.target.value }),
-						)
+						setTarget((cur) => cur.replaceSplit({ limit: newVal.target.value }))
 					}
 				/>
 				<Arrays
 					name="breakKey"
 					values={target.split?.breakKey ?? []}
+					list={columnList}
 					handleChange={(text, index) =>
 						setTarget((cur) => cur.replaceSplitBreakKey(text, index))
 					}

--- a/tauri/src/hooks/useDatasetSettings.ts
+++ b/tauri/src/hooks/useDatasetSettings.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { useParamInputs } from "../context/ParameterInputProvider";
 import { useEnvironment } from "../context/EnvironmentProvider";
 import { useJdbcConnectionState } from "../context/JdbcConnectionProvider";
+import { useParamInputs } from "../context/ParameterInputProvider";
 import { useSetResourcesSettings } from "../context/WorkspaceResourcesProvider";
 import type { DatasetSrcInfo } from "../model/CommandOption";
 import {
@@ -64,7 +64,9 @@ async function fetchTableNames(
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, { parameters: paramInputs }),
+			body: buildDatasetRequestBody(info, jdbcValues, {
+				parameters: paramInputs,
+			}),
 		},
 	};
 	return fetchData(fetchParams)
@@ -127,7 +129,10 @@ async function fetchTablePreview(
 		options: {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: buildDatasetRequestBody(info, jdbcValues, { tableName, parameters: paramInputs }),
+			body: buildDatasetRequestBody(info, jdbcValues, {
+				tableName,
+				parameters: paramInputs,
+			}),
 		},
 	};
 	return fetchData(fetchParams)
@@ -163,16 +168,27 @@ export const useDatasetTablePreview = (
 		}
 		const controller = new AbortController();
 		setLoading(true);
-		fetchTablePreview(apiUrl, srcInfo, tableName, jdbcValues, paramInputs).then((result) => {
-			if (!controller.signal.aborted) {
-				setPreview(result);
-				setLoading(false);
-			}
-		});
+		fetchTablePreview(apiUrl, srcInfo, tableName, jdbcValues, paramInputs).then(
+			(result) => {
+				if (!controller.signal.aborted) {
+					setPreview(result);
+					setLoading(false);
+				}
+			},
+		);
 		return () => {
 			controller.abort();
 		};
-	}, [apiUrl, srcPath, srcType, srcInfo, sqlNotReady, jdbcValues, tableName, paramInputs]);
+	}, [
+		apiUrl,
+		srcPath,
+		srcType,
+		srcInfo,
+		sqlNotReady,
+		jdbcValues,
+		tableName,
+		paramInputs,
+	]);
 
 	return { preview, loading };
 };
@@ -247,6 +263,29 @@ export const useDatasetSettingsData = (
 	}, [fileName, apiUrl]);
 
 	return { settings, loading };
+};
+
+export const useColumnNamesFetcher = () => {
+	const { apiUrl } = useEnvironment();
+	const { jdbcValues } = useJdbcConnectionState();
+	const paramInputs = useParamInputs();
+	return async (
+		srcInfo: DatasetSrcInfo,
+		tableName: string,
+		signal: AbortSignal,
+	): Promise<string[]> => {
+		if (signal.aborted) {
+			return [];
+		}
+		const preview = await fetchTablePreview(
+			apiUrl,
+			srcInfo,
+			tableName,
+			jdbcValues,
+			paramInputs,
+		);
+		return preview.headers;
+	};
 };
 
 async function loadDatasetSettings(


### PR DESCRIPTION
## Summary
Adds a new dialog component that allows users to load column names from database tables directly into the dataset filter/order configuration fields. This improves the user experience by providing autocomplete suggestions for column names.

## Key Changes
- **New Component**: `ColumnDatalistDialog.tsx` - A modal dialog that displays filtered tables and allows loading their column names
  - Filters tables based on the current dataset setting's name or pattern configuration
  - Fetches column names asynchronously with abort signal support
  - Prevents multiple simultaneous loads with loading state management

- **New Hook**: `useColumnNamesFetcher()` in `useDatasetSettings.ts`
  - Extracts column names from table preview data
  - Integrates with existing dataset preview fetching infrastructure
  - Respects abort signals for cleanup

- **Enhanced DatasetSettingDialog**:
  - Added "Load column datalist" button in the Filter/Order section
  - Integrated column datalist display with HTML datalist element
  - Connected all array input fields (exclude, include, keys, filter, order, breakKey) to the loaded column datalist for autocomplete
  - Manages column datalist state and dialog visibility

## Implementation Details
- Uses `AbortController` for proper cleanup of async operations
- Filters tables intelligently based on dataset setting configuration (name list or regex pattern)
- Provides visual feedback during column loading with disabled state
- Integrates seamlessly with existing dataset settings UI patterns
- Maintains backward compatibility - datalist only appears when columns are loaded

https://claude.ai/code/session_013iQXMqa73PLUXTtWm4MQve