### PR TITLE
Defer directory creation to runtime initialization

### DIFF
--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/Application.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/Application.java
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.runtime.Micronaut;
 import io.micronaut.serde.annotation.SerdeImport;
+import yo.dbunitcli.Strings;
 import yo.dbunitcli.application.command.Parameterize;
 import yo.dbunitcli.application.Option;
 import yo.dbunitcli.resource.FileResources;
@@ -31,14 +32,13 @@ public class Application {
         final String workspace = context.getEnvironment()
                 .get(FileResources.PROPERTY_WORKSPACE, String.class)
                 .orElse(".");
-        System.setProperty(FileResources.PROPERTY_WORKSPACE, workspace);
         context.getEnvironment()
                 .get(FileResources.PROPERTY_DATASET_BASE, String.class)
-                .filter(yo.dbunitcli.Strings::isNotEmpty)
+                .filter(Strings::isNotEmpty)
                 .ifPresent(v -> System.setProperty(FileResources.PROPERTY_DATASET_BASE, v));
         context.getEnvironment()
                 .get(FileResources.PROPERTY_RESULT_BASE, String.class)
-                .filter(yo.dbunitcli.Strings::isNotEmpty)
+                .filter(Strings::isNotEmpty)
                 .ifPresent(v -> System.setProperty(FileResources.PROPERTY_RESULT_BASE, v));
         return Workspace.builder().setPath(workspace).build();
     }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/Application.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/Application.java
@@ -28,17 +28,18 @@ public class Application {
 
     @Context
     public Workspace load(final ApplicationContext context) {
-        final Workspace workspace = Workspace.builder().build();
-        workspace.contextReload(
-                context.getEnvironment()
-                        .get(FileResources.PROPERTY_WORKSPACE, String.class)
-                        .orElse(workspace.path().toString()),
-                context.getEnvironment()
-                        .get(FileResources.PROPERTY_DATASET_BASE, String.class)
-                        .orElse(null),
-                context.getEnvironment()
-                        .get(FileResources.PROPERTY_RESULT_BASE, String.class)
-                        .orElse(null));
-        return workspace;
+        final String workspace = context.getEnvironment()
+                .get(FileResources.PROPERTY_WORKSPACE, String.class)
+                .orElse(".");
+        System.setProperty(FileResources.PROPERTY_WORKSPACE, workspace);
+        context.getEnvironment()
+                .get(FileResources.PROPERTY_DATASET_BASE, String.class)
+                .filter(yo.dbunitcli.Strings::isNotEmpty)
+                .ifPresent(v -> System.setProperty(FileResources.PROPERTY_DATASET_BASE, v));
+        context.getEnvironment()
+                .get(FileResources.PROPERTY_RESULT_BASE, String.class)
+                .filter(yo.dbunitcli.Strings::isNotEmpty)
+                .ifPresent(v -> System.setProperty(FileResources.PROPERTY_RESULT_BASE, v));
+        return Workspace.builder().setPath(workspace).build();
     }
 }

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Options.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Options.java
@@ -97,17 +97,14 @@ public record Options(File baseDir, Map<yo.dbunitcli.application.CommandType, Re
 
         public void workspace(final File workspace) {
             this.baseDir = new File(workspace, "option");
-            if (this.baseDir.exists() || this.baseDir.mkdirs()) {
-                this.addParameterFiles(Type.compare)
-                        .addParameterFiles(Type.convert)
-                        .addParameterFiles(Type.generate)
-                        .addParameterFiles(Type.run)
-                        .addParameterFiles(Type.parameterize)
-                ;
-                this.templates = new ResourceFile(
-                        new File(this.parameters.get(Type.parameterize).baseDir(), "template")
-                        , FileResources::searchTemplate);
-            }
+            this.addParameterFiles(Type.compare)
+                    .addParameterFiles(Type.convert)
+                    .addParameterFiles(Type.generate)
+                    .addParameterFiles(Type.run)
+                    .addParameterFiles(Type.parameterize);
+            this.templates = new ResourceFile(
+                    new File(this.parameters.get(Type.parameterize).baseDir(), "template")
+                    , FileResources::searchTemplate);
         }
 
         private Builder addParameterFiles(final Type command) {

--- a/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
+++ b/sidecar/src/main/java/yo/dbunitcli/sidecar/domain/project/Workspace.java
@@ -94,6 +94,7 @@ public class Workspace {
         if (Strings.isNotEmpty(resultBase)) {
             System.setProperty(FileResources.PROPERTY_RESULT_BASE, resultBase);
         }
+        FileResources.baseDir().mkdirs();
         final var newWorkspace = Workspace.builder().setPath(workspace).build();
         this.options = newWorkspace.options();
         this.resources = newWorkspace.resources();
@@ -254,10 +255,8 @@ public class Workspace {
             final File expandedBaseDir = FileResources.baseDir();
             final Resources.Builder resources = Resources.builder();
             final Options.Builder options = Options.builder();
-            if (expandedBaseDir.exists() || expandedBaseDir.mkdirs()) {
-                options.workspace(expandedBaseDir);
-                resources.workspace(expandedBaseDir);
-            }
+            options.workspace(expandedBaseDir);
+            resources.workspace(expandedBaseDir);
             Workspace.LOGGER.info("current workspace:{}", expandedBaseDir.getAbsolutePath());
             return new Workspace(rawFile.toPath(), options.build(), resources.build());
         }

--- a/sidecar/src/test/java/yo/dbunitcli/sidecar/domain/project/OptionsTest.java
+++ b/sidecar/src/test/java/yo/dbunitcli/sidecar/domain/project/OptionsTest.java
@@ -33,8 +33,7 @@ class OptionsTest {
 
     @Test
     public void builder_workspace_optionディレクトリが作成される() {
-        assertTrue(this.optionDir.exists());
-        assertTrue(this.optionDir.isDirectory());
+        assertFalse(this.optionDir.exists());
     }
 
     @Test
@@ -182,8 +181,6 @@ class OptionsTest {
     @Test
     public void builder_workspace_templatesがparameterizeのtemplateサブディレクトリに設定される() {
         final File expectedTemplateDir = new File(new File(this.optionDir, "parameterize"), "template");
-        // templatesのbaseDirが期待のパスになっていることを確認するため、templateディレクトリが作成できることを確認
-        assertTrue(this.optionDir.exists());
         assertEquals(expectedTemplateDir.getAbsolutePath(), this.options.templates().baseDir().getAbsolutePath());
     }
 


### PR DESCRIPTION
## Summary
Refactor directory creation logic to defer filesystem operations until runtime initialization, rather than during object construction. This improves separation of concerns and makes the code more testable.

## Key Changes
- **Application.java**: Modified `load()` method to set workspace path directly via builder instead of calling `contextReload()`, and use `ifPresent()` with `System.setProperty()` for dataset and result base properties
- **Workspace.java**: 
  - Moved `FileResources.baseDir().mkdirs()` call into `contextReload()` method
  - Removed conditional directory creation check in `Builder.build()`, now unconditionally initializes options and resources
- **Options.java**: Removed directory existence check in `workspace()` method, now unconditionally initializes parameter files and templates
- **OptionsTest.java**: Updated test expectations to reflect that option directory is no longer created during builder initialization

## Implementation Details
- Directory creation is now explicitly called in `Workspace.contextReload()` rather than implicitly during builder construction
- Empty string filtering using `Strings::isNotEmpty` ensures only non-empty properties are set
- Default workspace path changed from `workspace.path().toString()` to `"."` for consistency
- Tests updated to verify that directories are not created during object construction phase

https://claude.ai/code/session_01GzZ3zQXPSbSfbLHGmMETvZ